### PR TITLE
Chore/repo guardrails

### DIFF
--- a/Assets/github/.github/pull_request_template.md
+++ b/Assets/github/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+# Title
+feat(scope): short summary
+
+## Why
+One or two sentences on the problem or goal.
+
+## What changed
+- Bullet points of key changes
+
+## How to test
+1. Open `Scenes/_Demos/BarrierDemo.unity`
+2. Press Play → verify ...
+3. Run tests: EditMode, PlayMode
+
+## Checklist
+- [ ] Unit tests (EditMode) added/updated
+- [ ] PlayMode test or manual steps included
+- [ ] Demo scene updated (if player-visible)
+- [ ] Prefab links/layers validated
+- [ ] README/Docs touched (if new feature)

--- a/Assets/github/PULL_REQUEST_TEMPLATE.md
+++ b/Assets/github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+# Title
+feat(scope): short summary
+
+## Why
+One or two sentences on the problem or goal.
+
+## What changed
+- Bullet points of key changes
+
+## How to test
+1. Open `Scenes/_Demos/BarrierDemo.unity`
+2. Press Play → verify ...
+3. Run tests: EditMode, PlayMode
+
+## Checklist
+- [ ] Unit tests (EditMode) added/updated
+- [ ] PlayMode test or manual steps included
+- [ ] Demo scene updated (if player-visible)
+- [ ] Prefab links/layers validated
+- [ ] README/Docs touched (if new feature)


### PR DESCRIPTION
# Title
chore(repo): add PR template and enforce squash-only merges

## Why
- Keep main history linear and tidy 
- Make self-review consistent with a repeatable checklist

## What changed
- Add .github/pull_request_template.md
- Set branch protection rule requiring PRs for main
- Restrict merge method to Squash only

## How to test
1. Open a small throwaway PR and confirm merge button = Squash and merge only
2. Attempt to push directly to main → push is rejected
3. Open a new PR and verify the template auto-fills
4. Apply labels (tags) in the right sidebar
- For this PR: tech-debt, docs (and optionally workflow)
- Don’t use feature/bug here—this isn’t gameplay code
5. Mark the checklist


## Checklist
- [x] Unit tests (EditMode) added/updated N/A
- [x] PlayMode test or manual steps included
- [x] Demo scene updated (if player-visible) N/A
- [x] Prefab links/layers validated N/A
- [x] README/Docs touched (if new feature) N/A
