### PR TITLE
chore(asmdef): split runtime (Core, Gameplay), Editor-only, and test assemblies (EditMode, PlayMode)

### DIFF
--- a/Assets/Scripts/_Project.Core/_Project.Core.asmdef
+++ b/Assets/Scripts/_Project.Core/_Project.Core.asmdef
@@ -1,0 +1,15 @@
+{
+"name": "_Project.Core",
+"rootNamespace": "Castlebound",
+"references": [],
+"optionalUnityReferences": [],
+"includePlatforms": [],
+"excludePlatforms": [],
+"allowUnsafeCode": false,
+"overrideReferences": false,
+"precompiledReferences": [],
+"autoReferenced": true,
+"defineConstraints": [],
+"versionDefines": [],
+"noEngineReferences": false
+}

--- a/Assets/Scripts/_Project.Editor/_Project.Editor.asmdef
+++ b/Assets/Scripts/_Project.Editor/_Project.Editor.asmdef
@@ -1,0 +1,18 @@
+{
+"name": "_Project.Editor",
+"rootNamespace": "Castlebound.Editor",
+"references": [
+"_Project.Core",
+"_Project.Gameplay"
+],
+"optionalUnityReferences": [],
+"includePlatforms": [ "Editor" ],
+"excludePlatforms": [],
+"allowUnsafeCode": false,
+"overrideReferences": false,
+"precompiledReferences": [],
+"autoReferenced": true,
+"defineConstraints": [],
+"versionDefines": [],
+"noEngineReferences": false
+}

--- a/Assets/Scripts/_Project.Gameplay/_Project.Gameplay.asmdef
+++ b/Assets/Scripts/_Project.Gameplay/_Project.Gameplay.asmdef
@@ -1,0 +1,17 @@
+{
+"name": "_Project.Gameplay",
+"rootNamespace": "Castlebound.Gameplay",
+"references": [
+"_Project.Core"
+],
+"optionalUnityReferences": [],
+"includePlatforms": [],
+"excludePlatforms": [],
+"allowUnsafeCode": false,
+"overrideReferences": false,
+"precompiledReferences": [],
+"autoReferenced": true,
+"defineConstraints": [],
+"versionDefines": [],
+"noEngineReferences": false
+}

--- a/Assets/_Tests/EditMode/_Project.Tests.EditMode.asmdef
+++ b/Assets/_Tests/EditMode/_Project.Tests.EditMode.asmdef
@@ -1,0 +1,17 @@
+{
+"name": "_Project.Tests.EditMode",
+"references": [
+"_Project.Core",
+"_Project.Gameplay"
+],
+"optionalUnityReferences": [ "TestAssemblies" ],
+"includePlatforms": [ "Editor" ],
+"excludePlatforms": [],
+"allowUnsafeCode": false,
+"overrideReferences": false,
+"precompiledReferences": [],
+"autoReferenced": true,
+"defineConstraints": [],
+"versionDefines": [],
+"noEngineReferences": false
+}

--- a/Assets/_Tests/PlayMode/_Project.Tests.PlayMode.asmdef
+++ b/Assets/_Tests/PlayMode/_Project.Tests.PlayMode.asmdef
@@ -1,0 +1,17 @@
+{
+"name": "_Project.Tests.PlayMode",
+"references": [
+"_Project.Core",
+"_Project.Gameplay"
+],
+"optionalUnityReferences": [ "TestAssemblies" ],
+"includePlatforms": [],
+"excludePlatforms": [],
+"allowUnsafeCode": false,
+"overrideReferences": false,
+"precompiledReferences": [],
+"autoReferenced": true,
+"defineConstraints": [],
+"versionDefines": [],
+"noEngineReferences": false
+}


### PR DESCRIPTION
## Why
To improve compile times and enforce clear code boundaries by splitting the project into assemblies for core systems, gameplay, editor tools, and tests.

## What changed
- Added `_Project.Core`, `_Project.Gameplay`, and `_Project.Editor` asmdefs under `Assets/Scripts/`
- Added `_Project.Tests.EditMode` and `_Project.Tests.PlayMode` asmdefs under `Assets/_Tests/`
- Gameplay assembly now depends on Core
- Test assemblies reference Core + Gameplay

## How to test
1. Open Unity → let scripts recompile
2. Open **Window ▸ Test Runner**
   - Confirm EditMode and PlayMode assemblies appear

## Checklist
- [x] Unit tests (EditMode) added/updated → **N/A** 
- [x] PlayMode test or manual steps included → **N/A**
- [x] Demo scene updated (if player-visible) → **N/A**
- [x] Prefab links/layers validated → **N/A**
- [x] README/Docs touched (if new feature) → **N/A**