### PR TITLE
chore(unity): add missing .asmdef meta files

### DIFF
--- a/Assets/Scripts/_Project.Core/_Project.Core.asmdef.meta
+++ b/Assets/Scripts/_Project.Core/_Project.Core.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 26c31025cbb4d9d43939e96e0b66f59a
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/_Project.Editor/_Project.Editor.asmdef.meta
+++ b/Assets/Scripts/_Project.Editor/_Project.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 81704b1bb6efba44c9df9b9dea4d07a0
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/_Project.Gameplay/_Project.Gameplay.asmdef.meta
+++ b/Assets/Scripts/_Project.Gameplay/_Project.Gameplay.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 182c032bd5c6f344db9b143e1ea69938
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Tests.meta
+++ b/Assets/_Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d5659215b7235424690973d9eee35c71
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Tests/EditMode.meta
+++ b/Assets/_Tests/EditMode.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5dfc4e666501eb04b9a1d307844189e6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Tests/EditMode/_Project.Tests.EditMode.asmdef.meta
+++ b/Assets/_Tests/EditMode/_Project.Tests.EditMode.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 473e3eae624dacd43ba4a534764a0a48
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Tests/PlayMode.meta
+++ b/Assets/_Tests/PlayMode.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a33e15ba872359747b674f349641fcf4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Tests/PlayMode/_Project.Tests.PlayMode.asmdef.meta
+++ b/Assets/_Tests/PlayMode/_Project.Tests.PlayMode.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 77553b3aec7421a4a906aad08514ece6
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Why

- Ensure assembly definition GUIDs are tracked so Editor/Test assemblies resolve consistently across machines and branches.

## What changed
- Added .meta files for _Project.Core, _Project.Gameplay, _Project.Editor, _Project.Tests.EditMode, _Project.Tests.PlayMode

- Added .meta for Assets/_Tests folders**

## How to test

1. Open Unity → let it recompile; no “Missing assembly” errors.
2. Window ▸ Test Runner → EditMode and PlayMode assemblies appear.
3. Close & re-open the project (sanity) → still clean.

## Checklist
- [x] Unit tests (EditMode) added/updated N/A
- [x] PlayMode test or manual steps included N/A
- [x] Demo scene updated (if player-visible) N/A
- [x] Prefab links/layers validated N/A
- [x] README/Docs touched (if new feature) N/A
