### PR TITLE
test(editmode): add prefab & scene smoke tests with PrefabTestUtil

### DIFF
--- a/Assets/_Project/_Tests/EditMode/PrefabSmokeTests.cs
+++ b/Assets/_Project/_Tests/EditMode/PrefabSmokeTests.cs
@@ -1,0 +1,95 @@
+using NUnit.Framework;
+using UnityEngine;
+
+[Category("Smoke/Prefab")]
+public class PrefabSmokeTests
+{
+    const string PlayerPath = "Assets/_Project/Prefabs/Player.prefab";
+    const string EnemyPath  = "Assets/_Project/Prefabs/Enemy.prefab";
+
+    // --- Player ---
+    [Test] public void PlayerPrefab_Loads() {
+        var go = PrefabTestUtil.Load(PlayerPath); PrefabTestUtil.Unload(go);
+    }
+
+    [Test] public void Player_Has_Rigidbody2D() {
+        var go = PrefabTestUtil.Load(PlayerPath);
+        Assert.NotNull(go.GetComponent<Rigidbody2D>());
+        PrefabTestUtil.Unload(go);
+    }
+
+    [Test] public void Player_Has_Collider2D() {
+        var go = PrefabTestUtil.Load(PlayerPath);
+        Assert.NotNull(go.GetComponent<Collider2D>());
+        PrefabTestUtil.Unload(go);
+    }
+
+    [Test] public void Player_Has_Animator() {
+        var go = PrefabTestUtil.Load(PlayerPath);
+        Assert.NotNull(go.GetComponent<Animator>());
+        PrefabTestUtil.Unload(go);
+    }
+
+    [Test] public void Player_Has_PlayerController() {
+        var go = PrefabTestUtil.Load(PlayerPath);
+        Assert.NotNull(go.GetComponent<PlayerController>());
+        PrefabTestUtil.Unload(go);
+    }
+
+    [Test] public void Player_Has_Health() {
+        var go = PrefabTestUtil.Load(PlayerPath);
+        Assert.NotNull(go.GetComponent<Health>());
+        PrefabTestUtil.Unload(go);
+    }
+
+    [Test] public void Player_Has_HitboxChild() {
+        var go = PrefabTestUtil.Load(PlayerPath);
+        Assert.NotNull(go.GetComponentInChildren<Hitbox>(true), "Player must contain a Hitbox child.");
+        PrefabTestUtil.Unload(go);
+    }
+
+    [Test] public void Player_Hitbox_IsTrigger() {
+        var go = PrefabTestUtil.Load(PlayerPath);
+        var hb = go.GetComponentInChildren<Hitbox>(true);
+        Assert.NotNull(hb, "No Hitbox child found.");
+        var col = hb.GetComponent<Collider2D>();
+        Assert.NotNull(col, "Hitbox needs a Collider2D.");
+        Assert.IsTrue(col.isTrigger, "Hitbox collider must be set to IsTrigger.");
+        PrefabTestUtil.Unload(go);
+    }
+
+    // --- Enemy ---
+    [Test] public void EnemyPrefab_Loads() {
+        var go = PrefabTestUtil.Load(EnemyPath); PrefabTestUtil.Unload(go);
+    }
+
+    [Test] public void Enemy_Has_Rigidbody2D() {
+        var go = PrefabTestUtil.Load(EnemyPath);
+        Assert.NotNull(go.GetComponent<Rigidbody2D>());
+        PrefabTestUtil.Unload(go);
+    }
+
+    [Test] public void Enemy_Has_Collider2D() {
+        var go = PrefabTestUtil.Load(EnemyPath);
+        Assert.NotNull(go.GetComponent<Collider2D>());
+        PrefabTestUtil.Unload(go);
+    }
+
+    [Test] public void Enemy_Has_Controller() {
+        var go = PrefabTestUtil.Load(EnemyPath);
+        Assert.NotNull(go.GetComponent<EnemyController2D>());
+        PrefabTestUtil.Unload(go);
+    }
+
+    [Test] public void Enemy_Has_Attack() {
+        var go = PrefabTestUtil.Load(EnemyPath);
+        Assert.NotNull(go.GetComponent<EnemyAttack>());
+        PrefabTestUtil.Unload(go);
+    }
+
+    [Test] public void Enemy_Has_Health() {
+        var go = PrefabTestUtil.Load(EnemyPath);
+        Assert.NotNull(go.GetComponent<Health>());
+        PrefabTestUtil.Unload(go);
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/PrefabSmokeTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/PrefabSmokeTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 238cb076022e58745a7aa7573568447d

--- a/Assets/_Project/_Tests/EditMode/SceneSmokeTests.cs
+++ b/Assets/_Project/_Tests/EditMode/SceneSmokeTests.cs
@@ -1,0 +1,25 @@
+using NUnit.Framework;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+
+[Category("Smoke/Scene")]
+public class SceneSmokeTests
+{
+    [Test]
+    public void SampleScene_Loads()
+    {
+        var scene = EditorSceneManager.OpenScene("Assets/_Project/Scenes/SampleScene.unity", OpenSceneMode.Single);
+        Assert.IsTrue(scene.isLoaded, "Scene failed to load.");
+    }
+
+    [Test]
+    public void SampleScene_Has_No_MissingScripts_OnRoots()
+    {
+        var scene = EditorSceneManager.OpenScene("Assets/_Project/Scenes/SampleScene.unity", OpenSceneMode.Single);
+        foreach (var root in scene.GetRootGameObjects())
+        {
+            foreach (var c in root.GetComponentsInChildren<Component>(true))
+                Assert.IsFalse(c == null, $"Missing script under root: {root.name}");
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/SceneSmokeTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/SceneSmokeTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ca756d903a19bdd439767a9824074b6b

--- a/Assets/_Project/_Tests/EditMode/TestUtils.meta
+++ b/Assets/_Project/_Tests/EditMode/TestUtils.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 11ac28ebfd59f35418c03933f05e6e7e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/EditMode/TestUtils/PrefabTestUtil.cs
+++ b/Assets/_Project/_Tests/EditMode/TestUtils/PrefabTestUtil.cs
@@ -1,0 +1,17 @@
+using UnityEditor;
+using UnityEngine;
+
+public static class PrefabTestUtil
+{
+    public static GameObject Load(string assetPath)
+    {
+        var go = PrefabUtility.LoadPrefabContents(assetPath);
+        if (!go) throw new System.Exception($"Failed to load prefab at: {assetPath}");
+        return go;
+    }
+
+    public static void Unload(GameObject go)
+    {
+        if (go) PrefabUtility.UnloadPrefabContents(go);
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/TestUtils/PrefabTestUtil.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/TestUtils/PrefabTestUtil.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e2d4cdc0101299c439f2f3c5f68b5f31

--- a/Assets/_Project/_Tests/EditMode/_Project.Tests.EditMode.asmdef
+++ b/Assets/_Project/_Tests/EditMode/_Project.Tests.EditMode.asmdef
@@ -1,17 +1,21 @@
 {
-"name": "_Project.Tests.EditMode",
-"references": [
-"_Project.Core",
-"_Project.Gameplay"
-],
-"optionalUnityReferences": [ "TestAssemblies" ],
-"includePlatforms": [ "Editor" ],
-"excludePlatforms": [],
-"allowUnsafeCode": false,
-"overrideReferences": false,
-"precompiledReferences": [],
-"autoReferenced": true,
-"defineConstraints": [],
-"versionDefines": [],
-"noEngineReferences": false
+  "name": "_Project.Tests.EditMode",
+  "references": [
+    "_Project.Core",
+    "_Project.Gameplay"
+  ],
+  "optionalUnityReferences": [
+    "TestAssemblies"
+  ],
+  "includePlatforms": [
+    "Editor"
+  ],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": false,
+  "precompiledReferences": [],
+  "autoReferenced": true,
+  "defineConstraints": [],
+  "versionDefines": [],
+  "noEngineReferences": false
 }


### PR DESCRIPTION
## Why
Prefab and scene references often break when scripts move or prefabs change. We need guardrails to ensure critical components and references are always present. Adding smoke tests improves durability and confidence in refactors.

## What changed

- Added PrefabSmokeTests:
  - Player prefab: must have Rigidbody2D, Collider2D, Animator, PlayerController, Health, Hitbox child with trigger collider
  - Enemy prefab: must have Rigidbody2D, Collider2D, EnemyController2D, EnemyAttack, Health
- Added SceneSmokeTests:
  -  SampleScene loads without errors
  -  No Missing (Mono Script) under root objects
- Added PrefabTestUtil helper to DRY up prefab load/unload
- 
## How to test

1. Open Test Runner ▸ EditMode ▸ Run All → should pass
2. Break something intentionally (remove Health from Enemy, disable Hitbox trigger) → correct test fails
3. Revert changes → all tests green

## Checklist
- [x] Unit tests (EditMode) added/updated
- [x] PlayMode test or manual steps included N/A
- [x] Demo scene updated (if player-visible) N/A
- [x] Prefab links/layers validated
- [x] README/Docs touched (if new feature) N/A
