### PR TITLE
Ci/editmode

### DIFF
--- a/.github/workflows/editmode.yml
+++ b/.github/workflows/editmode.yml
@@ -1,0 +1,34 @@
+name: EditMode CI
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+jobs:
+  editmode-tests:
+    name: EditMode Tests (Unity)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Cache Unity Library
+        uses: actions/cache@v4
+        with:
+          path: Library
+          key: Library-${{ runner.os }}-${{ hashFiles('**/Packages/packages-lock.json') }}
+          restore-keys: |
+            Library-${{ runner.os }}-
+
+      - name: Test (EditMode)
+        uses: game-ci/unity-test-runner@v4
+        with:
+          projectPath: .
+          unityVersion: 2022.3.XXf1   # <- set to your exact Unity LTS (e.g., 2022.3.40f1)
+          testMode: EditMode
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          customParameters: -nographics -batchmode
+      # Artifacts are uploaded automatically by the action (logs/results)

--- a/.github/workflows/editmode.yml
+++ b/.github/workflows/editmode.yml
@@ -27,7 +27,7 @@ jobs:
         uses: game-ci/unity-test-runner@v4
         with:
           projectPath: .
-          unityVersion: 2022.3.XXf1   # <- set to your exact Unity LTS (e.g., 2022.3.40f1)
+          unityVersion: 6000.1.14f1  # <- set to your exact Unity LTS (e.g., 2022.3.40f1)
           testMode: EditMode
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           customParameters: -nographics -batchmode


### PR DESCRIPTION
## Why
Add continuous integration so every commit and pull request runs Unity EditMode tests in a clean environment. This prevents regressions and keeps main stable.

## What changed
- Added .github/workflows/editmode.yml
- Configured job EditMode CI to install Unity 6000.1.14f1 and run all EditMode tests
- Cached Unity Library for faster builds

## How to test
1. Open this PR; confirm EditMode CI runs under the Checks tab.
2. Verify job succeeds (green ✔).
3. (Optional) Temporarily break a test locally and push — confirm CI goes red and blocks merge.

## Checklist
- [x] Unit tests (EditMode) added/updated
- [x] PlayMode test or manual steps included N/A
- [x] Demo scene updated (if player-visible) N/A
- [x] Prefab links/layers validated N/A
- [x] README/Docs touched (if new feature) N/A 