### PR TITLE
ci(self-hosted): enable stable self-hosted EditMode CI pipeline on Windows

### DIFF
--- a/.github/workflows/editmode.yml
+++ b/.github/workflows/editmode.yml
@@ -21,70 +21,43 @@ jobs:
         run: |
           Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force
 
-      # Read the Unity version from ProjectSettings/ProjectVersion.txt
+      # Read Unity version from ProjectVersion.txt (via PowerShell 7, invoked from cmd)
       - name: Read Unity version from ProjectVersion.txt
-        id: unityver
-        shell: powershell
+        shell: cmd
         run: |
-          $pv = Get-Content "ProjectSettings/ProjectVersion.txt" -ErrorAction Stop |
-                Where-Object { $_ -match 'm_EditorVersion:\s*(.+)$' } |
-                ForEach-Object { $Matches[1].Trim() }
-          if (-not $pv) { Write-Error "Could not read Unity version from ProjectVersion.txt"; exit 1 }
-          "UNITY_VERSION=$pv" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-          Write-Host "Unity version: $pv"
+          "%ProgramFiles%\PowerShell\7\pwsh.exe" -NoProfile -ExecutionPolicy Bypass -Command ^
+            "$p = Get-Content 'ProjectSettings/ProjectVersion.txt' | Select-String -Pattern 'm_EditorVersion:\s*(.+)';" ^
+            "if (-not $p) { Write-Error 'ProjectVersion.txt not found or malformed'; exit 1 }" ^
+            "$v = $p.Matches[0].Groups[1].Value.Trim();" ^
+            "\"UNITY_VERSION=$v\" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append;"
 
-      # Locate Unity.exe for the detected version.
-      # Fast path: check Hub's standard locations on every fixed drive (C:, D:, ...).
-      # Fallback: one-time search, then cache the result to avoid future scans.
+      # Locate Unity.exe for UNITY_VERSION and export UNITY_EXE (PowerShell 7, invoked from cmd)
       - name: Locate Unity.exe
-        shell: powershell
+        shell: cmd
         run: |
-          $version = "${{ env.UNITY_VERSION }}"
-          $cacheFile = Join-Path $Env:RUNNER_TEMP "unity_exe_path.txt"
-
-          # If we have a cached path for this version and it still exists, reuse it
-          if (Test-Path $cacheFile) {
-            $cached = Get-Content $cacheFile | Select-Object -First 1
-            if ($cached -and (Test-Path $cached) -and ($cached -match [regex]::Escape($version))) {
-              "UNITY_EXE=$cached" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-              Write-Host "Using cached Unity path: $cached"
-              exit 0
-            }
-          }
-
-          $unityExe = $null
-
-          # All fixed drives (C:, D:, …)
-          $drives = Get-PSDrive -PSProvider FileSystem | Where-Object { $_.Free -ne $null } | Select-Object -ExpandProperty Root
-
-          # Check common Hub locations first (very fast)
-          foreach ($root in $drives) {
-            foreach ($pf in @("Program Files","Program Files (x86)")) {
-              $candidate = Join-Path $root "$pf/Unity/Hub/Editor/$version/Editor/Unity.exe"
-              if (Test-Path $candidate) { $unityExe = $candidate; break }
-            }
-            if ($unityExe) { break }
-          }
-
-          # Fallback: targeted search for Unity.exe that contains the version in its path (runs once, then cached)
-          if (-not $unityExe) {
-            foreach ($root in $drives) {
-              $hit = Get-ChildItem -Path $root -Filter Unity.exe -File -Recurse -ErrorAction SilentlyContinue |
-                     Where-Object { $_.FullName -match [regex]::Escape($version) } |
-                     Select-Object -First 1
-              if ($hit) { $unityExe = $hit.FullName; break }
-            }
-          }
-
-          if (-not $unityExe) {
-            Write-Error "Unity $version not found on this runner. Install it via Unity Hub."
-            exit 1
-          }
-
-          # Cache and export
-          Set-Content -Path $cacheFile -Value $unityExe -Encoding UTF8
-          "UNITY_EXE=$unityExe" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-          Write-Host "Found Unity: $unityExe"
+          "%ProgramFiles%\PowerShell\7\pwsh.exe" -NoProfile -ExecutionPolicy Bypass -Command ^
+            "$version = $env:UNITY_VERSION;" ^
+            "$roots = @(" ^
+            "  'C:\Program Files\Unity\Hub\Editor'," ^
+            "  'D:\Program Files\Unity\Hub\Editor'," ^
+            "  'C:\Program Files\Unity'," ^
+            "  'D:\Program Files\Unity'" ^
+            ");" ^
+            "$roots = $roots | Select-Object -Unique;" ^
+            "$unityExe = $null;" ^
+            "foreach ($r in $roots) {" ^
+            "  $cand = Join-Path (Join-Path $r $version) 'Editor/Unity.exe';" ^
+            "  if (Test-Path $cand) { $unityExe = $cand; break }" ^
+            "}" ^
+            "if (-not $unityExe) {" ^
+            "  $drives = @('C:\','D:\');" ^
+            "  $unityExe = foreach ($d in $drives) {" ^
+            "    Get-ChildItem -LiteralPath $d -Filter Unity.exe -ErrorAction SilentlyContinue -Recurse |" ^
+            "      Where-Object { $_.FullName -match [regex]::Escape($version) } | Select-Object -First 1 -ExpandProperty FullName" ^
+            "  } | Select-Object -First 1" ^
+            "}" ^
+            "if (-not $unityExe) { Write-Error \"Unity $version not found on this runner.\"; exit 1 }" ^
+            "\"UNITY_EXE=$unityExe\" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append;"
 
       # Make a clean results folder
       - name: Prepare workspace (cmd)

--- a/.github/workflows/editmode.yml
+++ b/.github/workflows/editmode.yml
@@ -18,11 +18,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Resolve the full path to Unity.exe for the requested version
       - name: Locate Unity.exe for ${{ env.UNITY_VERSION }}
-        shell: pwsh
+        shell: powershell -ExecutionPolicy Bypass
         run: |
-          $version = "${env:UNITY_VERSION}"
+          $version = $env:UNITY_VERSION
           $roots = @(
             "C:\Program Files\Unity\Hub\Editor",
             "D:\Program Files\Unity\Hub\Editor",
@@ -37,7 +36,6 @@ jobs:
           }
 
           if (-not $unityExe) {
-            # Fallback: quick search (may take a few seconds on first run)
             $match = Get-ChildItem -Path C:\,D:\ -ErrorAction SilentlyContinue -Filter Unity.exe -Recurse |
               Where-Object { $_.FullName -match "\\Editor\\Unity.exe$" -and $_.FullName -match [regex]::Escape($version) } |
               Select-Object -First 1

--- a/.github/workflows/editmode.yml
+++ b/.github/workflows/editmode.yml
@@ -12,21 +12,28 @@ jobs:
     runs-on: [self-hosted, Windows]
 
     env:
-      UNITY_VERSION: 6000.1.14f1   # update when you upgrade Unity on the runner
+      UNITY_VERSION: 6000.1.14f1  # update when you upgrade Unity on the runner
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Locate Unity.exe for ${{ env.UNITY_VERSION }}
-        shell: powershell -ExecutionPolicy Bypass
+      # Allow pwsh script execution for THIS JOB ONLY (no machine change)
+      - name: Allow pwsh in this job
+        shell: pwsh
         run: |
-          $version = $env:UNITY_VERSION
+          Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force
+
+      # Locate Unity.exe for the given UNITY_VERSION and export to GITHUB_ENV
+      - name: Locate Unity.exe
+        shell: pwsh
+        run: |
+          $version = "${{ env.UNITY_VERSION }}"
           $roots = @(
             "C:\Program Files\Unity\Hub\Editor",
-            "D:\Program Files\Unity\Hub\Editor",
-            "$env:ProgramFiles\Unity\Hub\Editor",
-            "$env:ProgramFiles(x86)\Unity\Hub\Editor"
+            "C:\Program Files\Unity\Hub",
+            "C:\Program Files\Unity",
+            "$Env:ProgramFiles\Unity\Hub\Editor"
           ) | Select-Object -Unique
 
           $unityExe = $null
@@ -36,18 +43,18 @@ jobs:
           }
 
           if (-not $unityExe) {
-            $match = Get-ChildItem -Path C:\,D:\ -ErrorAction SilentlyContinue -Filter Unity.exe -Recurse |
-              Where-Object { $_.FullName -match "\\Editor\\Unity.exe$" -and $_.FullName -match [regex]::Escape($version) } |
-              Select-Object -First 1
-            if ($match) { $unityExe = $match.FullName }
+            # Fallback: narrow search to versioned paths first to avoid false hits
+            $unityExe = Get-ChildItem -Path 'C:\' -Filter Unity.exe -ErrorAction SilentlyContinue -Recurse |
+              Where-Object { $_.FullName -match [regex]::Escape($version) } |
+              Select-Object -First 1 -ExpandProperty FullName
           }
 
           if (-not $unityExe) {
-            Write-Error "Unity $version not found. Check UNITY_VERSION or install path."
+            Write-Error "Unity $version not found on this runner. Install via Unity Hub."
             exit 1
           }
 
-          "UNITY_EXE=$unityExe" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "UNITY_EXE=$unityExe" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Prepare workspace (cmd)
         shell: cmd

--- a/.github/workflows/editmode.yml
+++ b/.github/workflows/editmode.yml
@@ -11,19 +11,18 @@ jobs:
     name: Unity EditMode Tests (Self-Hosted)
     runs-on: [self-hosted, Windows]
     env:
-      UNITY_VERSION: 6000.1.14f1   # change if you update your local Unity
+      UNITY_VERSION: 6000.1.14f1   # change if you update Unity on the runner
+
+    # <- Key fix: every PowerShell step runs with Bypass
+    defaults:
+      run:
+        shell: 'powershell -NoProfile -ExecutionPolicy Bypass'
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Allow inline PowerShell scripts in this job (no admin needed)
-      - name: Allow PowerShell scripts (process scope)
-        shell: powershell
-        run: Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force
-
       - name: Prepare workspace
-        shell: powershell
         run: |
           $ErrorActionPreference = 'Stop'
           $Results = Join-Path "${{ github.workspace }}" "TestResults"
@@ -31,7 +30,6 @@ jobs:
           New-Item -ItemType Directory -Force -Path $Results | Out-Null
 
       - name: Run Unity EditMode Tests
-        shell: powershell
         run: |
           $ErrorActionPreference = 'Stop'
           $UnityExe   = "C:\Program Files\Unity\Hub\Editor\$env:UNITY_VERSION\Editor\Unity.exe"

--- a/.github/workflows/editmode.yml
+++ b/.github/workflows/editmode.yml
@@ -12,38 +12,31 @@ jobs:
     runs-on: [self-hosted, Windows]
 
     env:
-      UNITY_VERSION: 6000.1.14f1   # update if you change your local Unity install
+      UNITY_VERSION: 6000.1.14f1   # update when you upgrade Unity on the runner
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Allow PowerShell scripts in THIS job only (no machine-wide change)
-      - name: Allow PowerShell scripts (process scope)
-        shell: powershell
+      - name: Prepare workspace (cmd)
+        shell: cmd
         run: |
-          Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process -Force
-          $PSVersionTable.PSVersion
+          if exist "%CD%\TestResults" rmdir /s /q "%CD%\TestResults"
+          mkdir "%CD%\TestResults"
 
-      - name: Prepare workspace
-        shell: powershell
+      - name: Run Unity EditMode Tests (cmd)
+        shell: cmd
         run: |
-          $results = Join-Path "${{ github.workspace }}" "TestResults"
-          if (Test-Path $results) { Remove-Item $results -Recurse -Force }
-          New-Item -ItemType Directory -Force -Path $results | Out-Null
-
-      - name: Run Unity EditMode Tests
-        shell: powershell
-        run: |
-          $unityExe = "C:\Program Files\Unity\Hub\Editor\${{ env.UNITY_VERSION }}\Editor\Unity.exe"
-          if (!(Test-Path $unityExe)) {
-            Write-Error "Unity not found at $unityExe. Check version or install path."
-          }
-          & "$unityExe" -batchmode -nographics -quit `
-            -projectPath "${{ github.workspace }}" `
-            -logfile "${{ github.workspace }}\TestResults\EditModeLog.txt" `
-            -runTests -testPlatform EditMode `
-            -testResults "${{ github.workspace }}\TestResults\EditModeResults.xml"
+          set "UNITY_EXE=C:\Program Files\Unity\Hub\Editor\%UNITY_VERSION%\Editor\Unity.exe"
+          if not exist "%UNITY_EXE%" (
+            echo Unity not found at "%UNITY_EXE%"
+            exit /b 1
+          )
+          "%UNITY_EXE%" -batchmode -nographics -quit ^
+            -projectPath "%CD%" ^
+            -logfile "%CD%\TestResults\EditModeLog.txt" ^
+            -runTests -testPlatform EditMode ^
+            -testResults "%CD%\TestResults\EditModeResults.xml"
 
       - name: Upload Test Results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/editmode.yml
+++ b/.github/workflows/editmode.yml
@@ -8,16 +8,18 @@ on:
 
 jobs:
   editmode-tests:
-    name: EditMode Tests (Unity)
-    runs-on: [self-hosted, Windows]   # your PC's runner
+    runs-on: [self-hosted, Windows]
+    env:
+      UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Unity EditMode Tests
         uses: game-ci/unity-test-runner@v4
         with:
           projectPath: .
-          unityVersion: 6000.1.14f1     # <-- set to your exact Unity 6 version on PC
+          unityVersion: 6000.1.14f1
           testMode: EditMode
           customParameters: -nographics -batchmode
+
+

--- a/.github/workflows/editmode.yml
+++ b/.github/workflows/editmode.yml
@@ -1,0 +1,23 @@
+name: EditMode CI (Self-Hosted)
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+jobs:
+  editmode-tests:
+    name: EditMode Tests (Unity)
+    runs-on: [self-hosted, Windows]   # your PC's runner
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Unity EditMode Tests
+        uses: game-ci/unity-test-runner@v4
+        with:
+          projectPath: .
+          unityVersion: 6000.1.14f1     # <-- set to your exact Unity 6 version on PC
+          testMode: EditMode
+          customParameters: -nographics -batchmode

--- a/.github/workflows/editmode.yml
+++ b/.github/workflows/editmode.yml
@@ -8,18 +8,39 @@ on:
 
 jobs:
   editmode-tests:
+    name: Unity EditMode Tests (Self-Hosted)
     runs-on: [self-hosted, Windows]
-    env:
-      UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Unity EditMode Tests
-        uses: game-ci/unity-test-runner@v4
+
+      # Optional: clean test results from previous runs
+      - name: Prepare workspace
+        shell: pwsh
+        run: |
+          if (Test-Path "$PWD\TestResults") {
+            Remove-Item "$PWD\TestResults" -Recurse -Force
+          }
+          New-Item -ItemType Directory -Force -Path "$PWD\TestResults" | Out-Null
+
+      # Run Unity EditMode tests directly (no Docker)
+      - name: Run Unity EditMode Tests
+        shell: pwsh
+        run: |
+          $unityExe = "C:\Program Files\Unity\Hub\Editor\6000.1.14f1\Editor\Unity.exe"
+          if (!(Test-Path $unityExe)) {
+            Write-Error "❌ Unity not found at $unityExe. Check version or install path."
+          }
+          & "$unityExe" -batchmode -nographics -quit `
+            -projectPath "$PWD" `
+            -logfile "$PWD\TestResults\EditModeLog.txt" `
+            -runTests -testPlatform EditMode `
+            -testResults "$PWD\TestResults\EditModeResults.xml"
+
+      # Upload test results for review
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v4
         with:
-          projectPath: .
-          unityVersion: 6000.1.14f1
-          testMode: EditMode
-          customParameters: -nographics -batchmode
-
-
+          name: EditModeResults
+          path: TestResults/

--- a/.github/workflows/editmode.yml
+++ b/.github/workflows/editmode.yml
@@ -15,72 +15,79 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Allow PowerShell scripts only for THIS job (no machine-wide change)
-      - name: Allow PowerShell in this job
-        shell: powershell
-        run: |
-          Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force
-
-      # Read Unity version from ProjectVersion.txt (via PowerShell 7, invoked from cmd)
-      - name: Read Unity version from ProjectVersion.txt
+      # Pure CMD: detect Unity version and locate Unity.exe (no PowerShell)
+      - name: Detect Unity and export path (cmd only)
         shell: cmd
         run: |
-          "%ProgramFiles%\PowerShell\7\pwsh.exe" -NoProfile -ExecutionPolicy Bypass -Command ^
-            "$p = Get-Content 'ProjectSettings/ProjectVersion.txt' | Select-String -Pattern 'm_EditorVersion:\s*(.+)';" ^
-            "if (-not $p) { Write-Error 'ProjectVersion.txt not found or malformed'; exit 1 }" ^
-            "$v = $p.Matches[0].Groups[1].Value.Trim();" ^
-            "\"UNITY_VERSION=$v\" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append;"
+          setlocal enableextensions enabledelayedexpansion
 
-      # Locate Unity.exe for UNITY_VERSION and export UNITY_EXE (PowerShell 7, invoked from cmd)
-      - name: Locate Unity.exe
-        shell: cmd
-        run: |
-          "%ProgramFiles%\PowerShell\7\pwsh.exe" -NoProfile -ExecutionPolicy Bypass -Command ^
-            "$version = $env:UNITY_VERSION;" ^
-            "$roots = @(" ^
-            "  'C:\Program Files\Unity\Hub\Editor'," ^
-            "  'D:\Program Files\Unity\Hub\Editor'," ^
-            "  'C:\Program Files\Unity'," ^
-            "  'D:\Program Files\Unity'" ^
-            ");" ^
-            "$roots = $roots | Select-Object -Unique;" ^
-            "$unityExe = $null;" ^
-            "foreach ($r in $roots) {" ^
-            "  $cand = Join-Path (Join-Path $r $version) 'Editor/Unity.exe';" ^
-            "  if (Test-Path $cand) { $unityExe = $cand; break }" ^
-            "}" ^
-            "if (-not $unityExe) {" ^
-            "  $drives = @('C:\','D:\');" ^
-            "  $unityExe = foreach ($d in $drives) {" ^
-            "    Get-ChildItem -LiteralPath $d -Filter Unity.exe -ErrorAction SilentlyContinue -Recurse |" ^
-            "      Where-Object { $_.FullName -match [regex]::Escape($version) } | Select-Object -First 1 -ExpandProperty FullName" ^
-            "  } | Select-Object -First 1" ^
-            "}" ^
-            "if (-not $unityExe) { Write-Error \"Unity $version not found on this runner.\"; exit 1 }" ^
-            "\"UNITY_EXE=$unityExe\" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append;"
+          REM ---- Read version from ProjectSettings/ProjectVersion.txt
+          if not exist "ProjectSettings\ProjectVersion.txt" (
+            echo ERROR: ProjectSettings\ProjectVersion.txt not found.
+            exit /b 1
+          )
+          set "VERLINE="
+          for /f "usebackq tokens=* delims=" %%L in ("ProjectSettings\ProjectVersion.txt") do (
+            echo %%L | findstr /b /c:"m_EditorVersion:" >nul && set "VERLINE=%%L"
+          )
+          if not defined VERLINE (
+            echo ERROR: m_EditorVersion not found in ProjectVersion.txt
+            exit /b 1
+          )
+          for /f "tokens=2 delims= " %%V in ("!VERLINE!") do set "UNITY_VERSION=%%V"
+          echo Detected UNITY_VERSION=!UNITY_VERSION!
 
-      # Make a clean results folder
+          REM ---- Probe common Hub roots first (fast-path)
+          set "UNITY_EXE="
+          for %%R in (
+            "C:\Program Files\Unity\Hub\Editor"
+            "D:\Program Files\Unity\Hub\Editor"
+            "E:\Program Files\Unity\Hub\Editor"
+            "C:\Program Files\Unity"
+            "D:\Program Files\Unity"
+            "E:\Program Files\Unity"
+          ) do (
+            if exist "%%~R\!UNITY_VERSION!\Editor\Unity.exe" (
+              set "UNITY_EXE=%%~R\!UNITY_VERSION!\Editor\Unity.exe"
+            )
+          )
+
+          REM ---- Slow-path: scan fixed drives if not found yet
+          if not defined UNITY_EXE (
+            for /f %%D in ('wmic logicaldisk where "drivetype=3" get deviceid ^| find ":"') do (
+              if not defined UNITY_EXE (
+                for /f "delims=" %%P in ('dir /b /s "%%D\*\!UNITY_VERSION!\Editor\Unity.exe" 2^>nul') do (
+                  set "UNITY_EXE=%%P"
+                  goto :found
+                )
+              )
+            )
+          )
+          :found
+
+          if not defined UNITY_EXE (
+            echo ERROR: Unity !UNITY_VERSION! not found on this runner. Install via Unity Hub.
+            exit /b 1
+          )
+
+          echo Found UNITY_EXE=!UNITY_EXE!
+          echo UNITY_EXE=!UNITY_EXE!>>"%GITHUB_ENV%"
+
       - name: Prepare workspace (cmd)
         shell: cmd
         run: |
           if exist "%CD%\TestResults" rmdir /s /q "%CD%\TestResults"
           mkdir "%CD%\TestResults"
 
-      # Run EditMode tests
       - name: Run Unity EditMode Tests (cmd)
         shell: cmd
         run: |
-          if not exist "%UNITY_EXE%" (
-            echo Unity not found at "%UNITY_EXE%"
-            exit /b 1
-          )
           "%UNITY_EXE%" -batchmode -nographics -quit ^
             -projectPath "%CD%" ^
             -logfile "%CD%\TestResults\EditModeLog.txt" ^
             -runTests -testPlatform EditMode ^
             -testResults "%CD%\TestResults\EditModeResults.xml"
 
-      # Upload results
       - name: Upload Test Results
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/editmode.yml
+++ b/.github/workflows/editmode.yml
@@ -11,12 +11,11 @@ jobs:
     name: Unity EditMode Tests (Self-Hosted)
     runs-on: [self-hosted, Windows]
     env:
-      UNITY_VERSION: 6000.1.14f1   # change if you update Unity on the runner
+      UNITY_VERSION: 6000.1.14f1   # update if you upgrade Unity on the runner
 
-    # <- Key fix: every PowerShell step runs with Bypass
     defaults:
       run:
-        shell: 'powershell -NoProfile -ExecutionPolicy Bypass'
+        shell: 'pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "{0}"'
 
     steps:
       - name: Checkout

--- a/.github/workflows/editmode.yml
+++ b/.github/workflows/editmode.yml
@@ -10,36 +10,44 @@ jobs:
   editmode-tests:
     name: Unity EditMode Tests (Self-Hosted)
     runs-on: [self-hosted, Windows]
+    env:
+      UNITY_VERSION: 6000.1.14f1   # change here when you upgrade Unity on the runner
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Optional: clean test results from previous runs
       - name: Prepare workspace
-        shell: pwsh
+        shell: powershell
         run: |
-          if (Test-Path "$PWD\TestResults") {
-            Remove-Item "$PWD\TestResults" -Recurse -Force
-          }
-          New-Item -ItemType Directory -Force -Path "$PWD\TestResults" | Out-Null
+          $Results = Join-Path "${{ github.workspace }}" "TestResults"
+          if (Test-Path $Results) { Remove-Item $Results -Recurse -Force }
+          New-Item -ItemType Directory -Force -Path $Results | Out-Null
 
-      # Run Unity EditMode tests directly (no Docker)
       - name: Run Unity EditMode Tests
-        shell: pwsh
+        shell: powershell
         run: |
-          $unityExe = "C:\Program Files\Unity\Hub\Editor\6000.1.14f1\Editor\Unity.exe"
-          if (!(Test-Path $unityExe)) {
-            Write-Error "❌ Unity not found at $unityExe. Check version or install path."
+          $UnityExe   = "C:\Program Files\Unity\Hub\Editor\$env:UNITY_VERSION\Editor\Unity.exe"
+          if (!(Test-Path $UnityExe)) {
+            Write-Error "❌ Unity not found at $UnityExe. Check version or install path."
+            exit 1
           }
-          & "$unityExe" -batchmode -nographics -quit `
-            -projectPath "$PWD" `
-            -logfile "$PWD\TestResults\EditModeLog.txt" `
-            -runTests -testPlatform EditMode `
-            -testResults "$PWD\TestResults\EditModeResults.xml"
 
-      # Upload test results for review
+          $ProjectPath = "${{ github.workspace }}"
+          $ResultsDir  = Join-Path $ProjectPath "TestResults"
+          $LogFile     = Join-Path $ResultsDir  "EditModeLog.txt"
+          $XmlFile     = Join-Path $ResultsDir  "EditModeResults.xml"
+
+          & "$UnityExe" -batchmode -nographics -quit `
+            -projectPath "$ProjectPath" `
+            -runTests -testPlatform EditMode `
+            -logfile "$LogFile" `
+            -testResults "$XmlFile"
+
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
       - name: Upload Test Results
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: EditModeResults

--- a/.github/workflows/editmode.yml
+++ b/.github/workflows/editmode.yml
@@ -18,6 +18,39 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Resolve the full path to Unity.exe for the requested version
+      - name: Locate Unity.exe for ${{ env.UNITY_VERSION }}
+        shell: pwsh
+        run: |
+          $version = "${env:UNITY_VERSION}"
+          $roots = @(
+            "C:\Program Files\Unity\Hub\Editor",
+            "D:\Program Files\Unity\Hub\Editor",
+            "$env:ProgramFiles\Unity\Hub\Editor",
+            "$env:ProgramFiles(x86)\Unity\Hub\Editor"
+          ) | Select-Object -Unique
+
+          $unityExe = $null
+          foreach ($r in $roots) {
+            $candidate = Join-Path $r $version | Join-Path -ChildPath "Editor\Unity.exe"
+            if (Test-Path $candidate) { $unityExe = $candidate; break }
+          }
+
+          if (-not $unityExe) {
+            # Fallback: quick search (may take a few seconds on first run)
+            $match = Get-ChildItem -Path C:\,D:\ -ErrorAction SilentlyContinue -Filter Unity.exe -Recurse |
+              Where-Object { $_.FullName -match "\\Editor\\Unity.exe$" -and $_.FullName -match [regex]::Escape($version) } |
+              Select-Object -First 1
+            if ($match) { $unityExe = $match.FullName }
+          }
+
+          if (-not $unityExe) {
+            Write-Error "Unity $version not found. Check UNITY_VERSION or install path."
+            exit 1
+          }
+
+          "UNITY_EXE=$unityExe" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
       - name: Prepare workspace (cmd)
         shell: cmd
         run: |
@@ -27,7 +60,6 @@ jobs:
       - name: Run Unity EditMode Tests (cmd)
         shell: cmd
         run: |
-          set "UNITY_EXE=C:\Program Files\Unity\Hub\Editor\%UNITY_VERSION%\Editor\Unity.exe"
           if not exist "%UNITY_EXE%" (
             echo Unity not found at "%UNITY_EXE%"
             exit /b 1

--- a/.github/workflows/editmode.yml
+++ b/.github/workflows/editmode.yml
@@ -11,15 +11,21 @@ jobs:
     name: Unity EditMode Tests (Self-Hosted)
     runs-on: [self-hosted, Windows]
     env:
-      UNITY_VERSION: 6000.1.14f1   # change here when you upgrade Unity on the runner
+      UNITY_VERSION: 6000.1.14f1   # change if you update your local Unity
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Allow inline PowerShell scripts in this job (no admin needed)
+      - name: Allow PowerShell scripts (process scope)
+        shell: powershell
+        run: Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force
+
       - name: Prepare workspace
         shell: powershell
         run: |
+          $ErrorActionPreference = 'Stop'
           $Results = Join-Path "${{ github.workspace }}" "TestResults"
           if (Test-Path $Results) { Remove-Item $Results -Recurse -Force }
           New-Item -ItemType Directory -Force -Path $Results | Out-Null
@@ -27,6 +33,7 @@ jobs:
       - name: Run Unity EditMode Tests
         shell: powershell
         run: |
+          $ErrorActionPreference = 'Stop'
           $UnityExe   = "C:\Program Files\Unity\Hub\Editor\$env:UNITY_VERSION\Editor\Unity.exe"
           if (!(Test-Path $UnityExe)) {
             Write-Error "❌ Unity not found at $UnityExe. Check version or install path."

--- a/.github/workflows/editmode.yml
+++ b/.github/workflows/editmode.yml
@@ -11,57 +11,89 @@ jobs:
     name: Unity EditMode Tests (Self-Hosted)
     runs-on: [self-hosted, Windows]
 
-    env:
-      UNITY_VERSION: 6000.1.14f1  # update when you upgrade Unity on the runner
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Allow pwsh script execution for THIS JOB ONLY (no machine change)
-      - name: Allow pwsh in this job
-        shell: pwsh
+      # Allow PowerShell scripts only for THIS job (no machine-wide change)
+      - name: Allow PowerShell in this job
+        shell: powershell
         run: |
           Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force
 
-      # Locate Unity.exe for the given UNITY_VERSION and export to GITHUB_ENV
+      # Read the Unity version from ProjectSettings/ProjectVersion.txt
+      - name: Read Unity version from ProjectVersion.txt
+        id: unityver
+        shell: powershell
+        run: |
+          $pv = Get-Content "ProjectSettings/ProjectVersion.txt" -ErrorAction Stop |
+                Where-Object { $_ -match 'm_EditorVersion:\s*(.+)$' } |
+                ForEach-Object { $Matches[1].Trim() }
+          if (-not $pv) { Write-Error "Could not read Unity version from ProjectVersion.txt"; exit 1 }
+          "UNITY_VERSION=$pv" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+          Write-Host "Unity version: $pv"
+
+      # Locate Unity.exe for the detected version.
+      # Fast path: check Hub's standard locations on every fixed drive (C:, D:, ...).
+      # Fallback: one-time search, then cache the result to avoid future scans.
       - name: Locate Unity.exe
-        shell: pwsh
+        shell: powershell
         run: |
           $version = "${{ env.UNITY_VERSION }}"
-          $roots = @(
-            "C:\Program Files\Unity\Hub\Editor",
-            "C:\Program Files\Unity\Hub",
-            "C:\Program Files\Unity",
-            "$Env:ProgramFiles\Unity\Hub\Editor"
-          ) | Select-Object -Unique
+          $cacheFile = Join-Path $Env:RUNNER_TEMP "unity_exe_path.txt"
+
+          # If we have a cached path for this version and it still exists, reuse it
+          if (Test-Path $cacheFile) {
+            $cached = Get-Content $cacheFile | Select-Object -First 1
+            if ($cached -and (Test-Path $cached) -and ($cached -match [regex]::Escape($version))) {
+              "UNITY_EXE=$cached" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+              Write-Host "Using cached Unity path: $cached"
+              exit 0
+            }
+          }
 
           $unityExe = $null
-          foreach ($r in $roots) {
-            $candidate = Join-Path $r $version | Join-Path -ChildPath "Editor\Unity.exe"
-            if (Test-Path $candidate) { $unityExe = $candidate; break }
+
+          # All fixed drives (C:, D:, …)
+          $drives = Get-PSDrive -PSProvider FileSystem | Where-Object { $_.Free -ne $null } | Select-Object -ExpandProperty Root
+
+          # Check common Hub locations first (very fast)
+          foreach ($root in $drives) {
+            foreach ($pf in @("Program Files","Program Files (x86)")) {
+              $candidate = Join-Path $root "$pf/Unity/Hub/Editor/$version/Editor/Unity.exe"
+              if (Test-Path $candidate) { $unityExe = $candidate; break }
+            }
+            if ($unityExe) { break }
+          }
+
+          # Fallback: targeted search for Unity.exe that contains the version in its path (runs once, then cached)
+          if (-not $unityExe) {
+            foreach ($root in $drives) {
+              $hit = Get-ChildItem -Path $root -Filter Unity.exe -File -Recurse -ErrorAction SilentlyContinue |
+                     Where-Object { $_.FullName -match [regex]::Escape($version) } |
+                     Select-Object -First 1
+              if ($hit) { $unityExe = $hit.FullName; break }
+            }
           }
 
           if (-not $unityExe) {
-            # Fallback: narrow search to versioned paths first to avoid false hits
-            $unityExe = Get-ChildItem -Path 'C:\' -Filter Unity.exe -ErrorAction SilentlyContinue -Recurse |
-              Where-Object { $_.FullName -match [regex]::Escape($version) } |
-              Select-Object -First 1 -ExpandProperty FullName
-          }
-
-          if (-not $unityExe) {
-            Write-Error "Unity $version not found on this runner. Install via Unity Hub."
+            Write-Error "Unity $version not found on this runner. Install it via Unity Hub."
             exit 1
           }
 
+          # Cache and export
+          Set-Content -Path $cacheFile -Value $unityExe -Encoding UTF8
           "UNITY_EXE=$unityExe" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+          Write-Host "Found Unity: $unityExe"
 
+      # Make a clean results folder
       - name: Prepare workspace (cmd)
         shell: cmd
         run: |
           if exist "%CD%\TestResults" rmdir /s /q "%CD%\TestResults"
           mkdir "%CD%\TestResults"
 
+      # Run EditMode tests
       - name: Run Unity EditMode Tests (cmd)
         shell: cmd
         run: |
@@ -75,6 +107,7 @@ jobs:
             -runTests -testPlatform EditMode ^
             -testResults "%CD%\TestResults\EditModeResults.xml"
 
+      # Upload results
       - name: Upload Test Results
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/editmode.yml
+++ b/.github/workflows/editmode.yml
@@ -10,48 +10,42 @@ jobs:
   editmode-tests:
     name: Unity EditMode Tests (Self-Hosted)
     runs-on: [self-hosted, Windows]
-    env:
-      UNITY_VERSION: 6000.1.14f1   # update if you upgrade Unity on the runner
 
-    defaults:
-      run:
-        shell: 'pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "{0}"'
+    env:
+      UNITY_VERSION: 6000.1.14f1   # update if you change your local Unity install
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Prepare workspace
+      # Allow PowerShell scripts in THIS job only (no machine-wide change)
+      - name: Allow PowerShell scripts (process scope)
+        shell: powershell
         run: |
-          $ErrorActionPreference = 'Stop'
-          $Results = Join-Path "${{ github.workspace }}" "TestResults"
-          if (Test-Path $Results) { Remove-Item $Results -Recurse -Force }
-          New-Item -ItemType Directory -Force -Path $Results | Out-Null
+          Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process -Force
+          $PSVersionTable.PSVersion
+
+      - name: Prepare workspace
+        shell: powershell
+        run: |
+          $results = Join-Path "${{ github.workspace }}" "TestResults"
+          if (Test-Path $results) { Remove-Item $results -Recurse -Force }
+          New-Item -ItemType Directory -Force -Path $results | Out-Null
 
       - name: Run Unity EditMode Tests
+        shell: powershell
         run: |
-          $ErrorActionPreference = 'Stop'
-          $UnityExe   = "C:\Program Files\Unity\Hub\Editor\$env:UNITY_VERSION\Editor\Unity.exe"
-          if (!(Test-Path $UnityExe)) {
-            Write-Error "❌ Unity not found at $UnityExe. Check version or install path."
-            exit 1
+          $unityExe = "C:\Program Files\Unity\Hub\Editor\${{ env.UNITY_VERSION }}\Editor\Unity.exe"
+          if (!(Test-Path $unityExe)) {
+            Write-Error "Unity not found at $unityExe. Check version or install path."
           }
-
-          $ProjectPath = "${{ github.workspace }}"
-          $ResultsDir  = Join-Path $ProjectPath "TestResults"
-          $LogFile     = Join-Path $ResultsDir  "EditModeLog.txt"
-          $XmlFile     = Join-Path $ResultsDir  "EditModeResults.xml"
-
-          & "$UnityExe" -batchmode -nographics -quit `
-            -projectPath "$ProjectPath" `
+          & "$unityExe" -batchmode -nographics -quit `
+            -projectPath "${{ github.workspace }}" `
+            -logfile "${{ github.workspace }}\TestResults\EditModeLog.txt" `
             -runTests -testPlatform EditMode `
-            -logfile "$LogFile" `
-            -testResults "$XmlFile"
-
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+            -testResults "${{ github.workspace }}\TestResults\EditModeResults.xml"
 
       - name: Upload Test Results
-        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: EditModeResults


### PR DESCRIPTION
## Why
To establish a reliable continuous integration setup for Unity EditMode tests on a self-hosted Windows runner using PowerShell 7, ensuring all future commits are automatically verified locally without depending on external Docker or GitHub-hosted runners.

## What changed
- Installed and registered PowerShell 7 (x64) for CI compatibility
- Fully reinstalled and configured Windows self-hosted GitHub Actions runner (D:\actions-runner)
- Implemented EditMode CI workflow (editmode.yml) with auto-detection of Unity 6 installs
- Repaired permissions, environment variables, and execution policies for PowerShell
- Validated service registration and ensured it runs automatically on startup
- Confirmed CI pipeline successfully detects Unity.exe, runs EditMode tests, and uploads results

## How to test
1. Open the Castlebound project in Unity
2. Commit > push to main > open a PR > CI triggers automatically
3. View Actions > Unity EditMode Tests (Self-Hosted) — all steps should complete successfully.

## Checklist
- [x] Unit tests (EditMode) added/updated
- [x] PlayMode test or manual steps included
- [x] Demo scene updated (if player-visible) N/A
- [x] Prefab links/layers validated N/A
- [x] README/Docs touched (if new feature) N/A
