### PR TITLE
feat(docs): add README and CONTRIBUTING baseline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,119 @@
+© 2025 Harrison Bruhl. All rights reserved.
+Personal and educational use permitted. Commercial use by permission only.
+
+---
+
+# Contributing to Castlebound: Siege Eternal
+
+These guidelines describe how to develop and maintain **Castlebound: Siege Eternal**.  
+They apply both to the solo-dev workflow and any future collaborators.
+
+---
+
+## 🧭 Branching Rules
+
+- Work only on **feature branches** (never commit directly to `main`).  
+- Branch naming:
+  - `feat/<feature-name>` → new gameplay or systems
+  - `fix/<bug-name>` → bug fixes
+  - `chore/<meta-change>` → CI / cleanup / non-game logic
+  - `docs/<topic>` → documentation
+
+Example:
+
+```bash
+git checkout -b feat/enemy-chase-ai
+```
+
+---
+
+## 💬 Commit Message Rules (Conventional Commits)
+
+Format:
+
+```
+type(scope): short description
+```
+
+Examples:
+
+```
+feat(player): add movement input
+fix(ci): correct PlayMode workflow path
+docs(readme): add setup instructions
+```
+
+Types include: `feat`, `fix`, `chore`, `docs`, `test`, `refactor`, `style`, `perf`.
+
+---
+
+## 🔀 Pull Requests
+
+- All changes merge via Pull Request into `main`.
+- Use the PR template and fill it out completely:
+  - Summary: what and why
+  - How to Test: Unity Test Runner + manual steps
+  - Checklist: tests / CI / docs / cleanup
+- CI must be green before merge.
+- Merge style → Squash & Merge only.
+
+Example PR title:
+
+```
+feat(wall): add repair interaction system
+```
+
+---
+
+## 🧪 Testing Expectations
+
+Before pushing:
+
+- Run all EditMode and PlayMode tests locally via Test Runner.
+- Fix any failures before commit.
+- Add tests for new logic where possible.
+
+CI:
+
+- GitHub Actions runs both test types on each PR and blocks merges on failure.
+
+---
+
+## 🏷 Labels
+
+| Label      | Usage                              |
+| ---------- | ---------------------------------- |
+| `feature`  | Gameplay or system additions       |
+| `fix`      | Bug fixes                          |
+| `docs`     | Documentation updates              |
+| `workflow` | CI / automation changes            |
+| `testing`  | New or updated tests               |
+| `tech-debt`| Refactor or cleanup                |
+| `question` | Discussion or clarification        |
+
+---
+
+## 🧱 Code Style & Folder Conventions
+
+C# Style:
+
+- PascalCase for classes
+- camelCase for variables
+- `[SerializeField]` for private Inspector fields
+
+Folders:
+
+- `_Project/Scripts/`
+- `_Project/Prefabs/`
+- `_Project/Art/`
+- `_Project/Animations/`
+- `_Tests/`
+- `Scenes/`
+
+---
+
+## 🤝 Solo Dev vs Future Contributors
+
+Currently maintained by a solo developer, but structured for future growth.  
+All contributors follow the same workflow to keep merges consistent and testable.
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,88 @@
+# 🏰 Castlebound: Siege Eternal
+
+**Castlebound: Siege Eternal** is a top-down 2D medieval siege survival game built in Unity.  
+Defend your castle from waves of enemies, repair walls, and survive as long as you can.  
+Designed for **mobile (Android first)** and developed as a **solo-dev project**.
+
+---
+
+## ⚙️ Project Status
+
+> **Current Phase:** Prototype foundations complete (CI + Tests + Docs)  
+> Building toward: first playable loop — movement, attack, enemies, wall repair.
+
+✅ EditMode + PlayMode tests passing locally and in GitHub Actions  
+✅ Branch protection and squash-only merges active  
+✅ CI automation and self-hosted runners configured
+
+---
+
+## 🧩 Tech Stack
+
+- **Engine:** Unity 2023 LTS (2D)
+- **Language:** C#
+- **IDE:** Visual Studio Code
+- **Platform:** Android (primary), Windows Editor testing
+- **Version Control:** Git + GitHub
+- **CI:** GitHub Actions (EditMode + PlayMode)
+
+---
+
+## ▶️ How to Run the Game
+
+1. Clone the repository  
+   ```bash
+   git clone https://github.com/f1cklepickle/Castlebound.git
+   ```
+2. Open the project in Unity 2023 LTS.
+3. Load the MainPrototype scene (`Scenes/MainPrototype.unity`).
+4. Press Play in the Unity Editor.
+
+---
+
+## 🧪 How to Run Tests
+
+### In Unity
+
+- Window ▸ General ▸ Test Runner
+- Choose:
+  - EditMode (logic/unit)
+  - PlayMode (scene/behavior)
+- Click Run All — all tests should pass.
+
+### In GitHub Actions
+
+- Every Pull Request automatically runs both test categories.
+- Merge is blocked if any tests fail.
+
+---
+
+## 🧱 CI / Workflow Overview
+
+- All work happens on feature branches (`feat/...`, `fix/...`, `docs/...`, etc.).
+- Commits follow Conventional Commits.
+- Pull Requests use a fixed template with “How to Test” and checklist.
+- Merges to `main` must:
+  - Pass CI
+  - Use Squash & Merge
+- See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
+
+---
+
+## 📊 CI Status
+
+Workflow  | Status
+--------- | ------
+EditMode Tests | 
+PlayMode Tests | 
+
+---
+
+## 🛠 Future Roadmap (Preview)
+
+- Expand castle construction & upgrades
+- Add new enemy types and attack patterns
+- Introduce traps, towers, and keep upgrades
+- Implement wave scaling and progression
+- Optimize for full Android builds
+


### PR DESCRIPTION
## Why
To finalize Phase G – Docs in the Solo Dev Workflow by adding clear baseline documentation for project onboarding and workflow consistency.
This ensures the project’s setup, testing, and contribution process are fully documented before beginning prototype iteration.

## What changed

- Added README.md with overview, setup, testing instructions, and CI badges.
- Added CONTRIBUTING.md defining branch, commit, PR, and testing rules.
- Linked CONTRIBUTING.md from the README.
- No gameplay or code changes introduced.
- Verified CI badges and Markdown rendering locally.

## How to test
### Open repository in GitHub or VS Code and confirm presence of both files.
### Open README.md and verify:
-   Clone + run instructions are clear.
-   CI badges render for EditMode / PlayMode workflows.
-   Link to CONTRIBUTING.md works.
### Open CONTRIBUTING.md and verify:
-   Branch / commit / PR rules match actual workflow.
-   Testing expectations align with current CI setup.
### Push branch → confirm both EditMode and PlayMode CI checks pass.

## Checklist
- [x] Unit tests (EditMode) added/updated
- [x] PlayMode test or manual steps included
- [x] Demo scene updated (if player-visible) N/A
- [x] Prefab links/layers validated N/A
- [x] README/Docs touched (if new feature)
