### PR TITLE
feat(hygiene): establish Unity runtime hygiene baseline

### DIFF
--- a/Docs/GitCleanup.txt
+++ b/Docs/GitCleanup.txt
@@ -5,3 +5,23 @@ Run local EditMode CI test:
   pwsh .\ci\run-editmode.ps1
 Artifacts are written to TestResults/.
 
+Git Maintenance Audit — November 2025
+
+- Cleaned obsolete local CI/test branches:
+  chore/asmdef-file-placement, chore/ci-add-summary, ci/editmode,
+  docs/workflow-baseline, feat/ci-playmode, test/editmode-smoke
+
+- Archived historical branches:
+  archive/maintenance-unity6-stable
+  archive/migration-2022lts
+
+- Removed outdated remote branches fully merged into main:
+  feat/enemy-movement-improvements, feat/enemy-wall-damage, fix/enemy-attack-damage
+
+- Renamed tag:
+  v0.1.0-ci-stable → milestone/ci-editmode-only
+
+- Current milestone tags:
+  milestone/ci-editmode-only
+  milestone/infra-baseline
+  ci/2022.3-lts-migration-ok

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -6,6 +6,6 @@ EditorBuildSettings:
   serializedVersion: 2
   m_Scenes:
   - enabled: 1
-    path: Assets/Scenes/SampleScene.unity
-    guid: 2cda990e2423bbf4892e6590ba056729
+    path: Assets/_Project/Scenes/SampleScene.unity
+    guid: 8c9cfa26abfee488c85f1582747f6a02
   m_configObjects: {}


### PR DESCRIPTION
## Why
Lock in a clean Unity and repo environment before starting prototype iteration. This ensures Play-in-Editor runs without errors, tags/layers are standardized, and repo hygiene work is documented.

## What changed
- Set the current working sample scene as the primary startup scene (Build Settings index 0).
- Confirmed core gameplay Tags (Player, Enemy, Wall, Projectile) and Layers (Player, Enemies, Walls, Environment) in ProjectSettings/TagManager.
- Verified Play-in-Editor and a Windows build run with zero errors and no warnings.
- Updated Docs/GitCleanup.txt with November 2025 branch/tag cleanup audit log.

## How to test
1. Open the project in Unity.
2. Open the current working scene (the one used for manual tests).
3. File ▸ Build Settings… and confirm this scene is listed at index 0.
4. Open Window ▸ General ▸ Console, clear it, and press Play:
   - Verify no red errors and no warnings appear.
5. Optionally build to Windows again:
   - Confirm the build launches straight into the working scene and runs without errors.

## Checklist
- [x] Unit tests (EditMode) added/updated N/A
- [x] PlayMode test or manual steps included
- [x] Demo scene updated (if player-visible) N/A
- [x] Prefab links/layers validated
- [x] README/Docs touched (if new feature)
