### PR TITLE
fix(barrier): gate inside barrier damage

### DIFF
--- a/Assets/_Project/_Tests/EditMode/Barrier/EnemyBarrierAttackGateTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Barrier/EnemyBarrierAttackGateTests.cs
@@ -1,0 +1,34 @@
+using NUnit.Framework;
+
+public class EnemyBarrierAttackGateTests
+{
+    [Test]
+    public void AllowsBarrierDamage_WhenEnemyOutside()
+    {
+        bool canDamage = EnemyAttack.CanDamageBarrier(
+            enemyInside: false,
+            playerInside: false);
+
+        Assert.IsTrue(canDamage, "Enemy outside should be allowed to damage barriers.");
+    }
+
+    [Test]
+    public void AllowsBarrierDamage_WhenEnemyInside_PlayerOutside()
+    {
+        bool canDamage = EnemyAttack.CanDamageBarrier(
+            enemyInside: true,
+            playerInside: false);
+
+        Assert.IsTrue(canDamage, "Enemy inside should be allowed to damage barriers if player is outside (breaking out).");
+    }
+
+    [Test]
+    public void BlocksBarrierDamage_WhenEnemyInside_PlayerInside()
+    {
+        bool canDamage = EnemyAttack.CanDamageBarrier(
+            enemyInside: true,
+            playerInside: true);
+
+        Assert.IsFalse(canDamage, "Enemy inside should not damage barriers when the player is inside.");
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Barrier/EnemyBarrierAttackGateTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Barrier/EnemyBarrierAttackGateTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5e4e7c1f4a854065a26fe68e31b7d15e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -171,6 +171,23 @@ All EditMode tests pass.
 ### Notes
 - Enemy hold reseat bias increased for normal approach speed.
 - Home assignment now runs after barriers register to avoid partial lists.
+
+## 2025-12-XX - fix/barrier-inside-attack-gate
+
+### Summary
+- Block barrier damage when enemy is inside and player is inside; allow when enemy is inside and player is outside (break out).
+- Barrier attacks gate on CastleRegionTracker state and detect barriers via parent to avoid hitbox bypass.
+
+### New or Updated Tests
+**EditMode**
+- `EnemyBarrierAttackGateTests`
+  - `AllowsBarrierDamage_WhenEnemyOutside`
+  - `AllowsBarrierDamage_WhenEnemyInside_PlayerOutside`
+  - `BlocksBarrierDamage_WhenEnemyInside_PlayerInside`
+
+### Notes
+- EnemyAttack caches region lookup and dedupes barrier damage even with hitbox colliders.
+- Manual check: inside enemies do not damage barriers when the player is inside; allowed when the player is outside.
 ## 2025-12-10 - feat/enemy-spawner-basic
 
 ### Summary


### PR DESCRIPTION
## Why
- Prevent enemies inside (with player inside) from damaging barriers.

## What changed
- Added `CanDamageBarrier` gate and applied it in EnemyAttack using CastleRegionTracker and barrier parent detection.
- Added EditMode tests for inside/outside barrier damage rules; updated TEST_LOG.
- Targeting unchanged.

## How to test
1. Unity steps: manual check that enemies inside do not damage barriers when player is inside; outside enemies still can.
2. Run tests: EditMode (EnemyBarrierAttackGateTests and suite).

## Checklist
- [x] Unit tests (EditMode) added/updated
- [x] PlayMode test or manual steps included (manual)
- [x] Demo scene updated (if player-visible) N/A
- [x] Prefab links/layers validated N/A
- [x] README/Docs touched (if new feature) (TEST_LOG)