### PR TITLE
feat(weapon): add equip and attack stat integration

### DIFF
--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/Weapons.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/Weapons.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8b70a0c1c1e24e6a9c1e4bfa6c2d2d65
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/Weapons/IWeaponDefinitionResolver.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/Weapons/IWeaponDefinitionResolver.cs
@@ -1,0 +1,9 @@
+using Castlebound.Gameplay.Inventory;
+
+namespace Castlebound.Gameplay.Combat
+{
+    public interface IWeaponDefinitionResolver
+    {
+        WeaponDefinition Resolve(string weaponId);
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/Weapons/IWeaponDefinitionResolver.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/Weapons/IWeaponDefinitionResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5f2b9b3c1a1c4d7d9a6f8b2e6f3a4d1c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/Weapons/PlayerWeaponController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/Weapons/PlayerWeaponController.cs
@@ -1,0 +1,47 @@
+using UnityEngine;
+using Castlebound.Gameplay.Inventory;
+
+namespace Castlebound.Gameplay.Combat
+{
+    public class PlayerWeaponController : MonoBehaviour
+    {
+        private IWeaponDefinitionResolver resolver;
+        private WeaponDefinition equippedDefinition;
+
+        public string CurrentWeaponId => equippedDefinition != null ? equippedDefinition.ItemId : null;
+
+        public WeaponStats CurrentWeaponStats
+        {
+            get
+            {
+                if (equippedDefinition == null)
+                {
+                    return new WeaponStats(0, 0f, Vector2.zero, 0f);
+                }
+
+                return new WeaponStats(
+                    equippedDefinition.Damage,
+                    equippedDefinition.AttackSpeed,
+                    equippedDefinition.HitboxSize,
+                    equippedDefinition.Knockback);
+            }
+        }
+
+        public void SetWeaponDefinitionResolver(IWeaponDefinitionResolver definitionResolver)
+        {
+            resolver = definitionResolver;
+        }
+
+        public void RefreshEquippedWeapon(InventoryState inventory)
+        {
+            if (inventory == null || resolver == null)
+            {
+                equippedDefinition = null;
+                return;
+            }
+
+            string weaponId = inventory.GetWeaponId(inventory.ActiveWeaponSlotIndex);
+            equippedDefinition = resolver.Resolve(weaponId);
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/Weapons/PlayerWeaponController.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/Weapons/PlayerWeaponController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1e6c2b7a4d2f4c6a9e3b1f7a2d6c9e5b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/Weapons/WeaponStats.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/Weapons/WeaponStats.cs
@@ -1,0 +1,20 @@
+using UnityEngine;
+
+namespace Castlebound.Gameplay.Combat
+{
+    public struct WeaponStats
+    {
+        public int Damage { get; }
+        public float AttackSpeed { get; }
+        public Vector2 HitboxSize { get; }
+        public float Knockback { get; }
+
+        public WeaponStats(int damage, float attackSpeed, Vector2 hitboxSize, float knockback)
+        {
+            Damage = damage;
+            AttackSpeed = attackSpeed;
+            HitboxSize = hitboxSize;
+            Knockback = knockback;
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/Weapons/WeaponStats.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/Weapons/WeaponStats.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6a8f2c9e4d1a4b7f9c3e2b5d1f7a9e0c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/EditMode/Combat/PlayerWeaponControllerTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Combat/PlayerWeaponControllerTests.cs
@@ -1,0 +1,82 @@
+using NUnit.Framework;
+using UnityEngine;
+using Castlebound.Gameplay.Inventory;
+using Castlebound.Gameplay.Combat;
+
+namespace Castlebound.Tests.Combat
+{
+    public class PlayerWeaponControllerTests
+    {
+        [Test]
+        public void EquipWeapon_SetsActiveDefinition_FromInventory()
+        {
+            var playerGo = new GameObject("Player");
+            var inventoryComponent = playerGo.AddComponent<InventoryStateComponent>();
+
+            var weapon = ScriptableObject.CreateInstance<WeaponDefinition>();
+            weapon.ItemId = "weapon_basic";
+            weapon.Damage = 5;
+            weapon.AttackSpeed = 1.2f;
+            weapon.HitboxSize = new Vector2(1.2f, 0.6f);
+            weapon.Knockback = 3f;
+
+            var controller = playerGo.AddComponent<PlayerWeaponController>();
+            controller.SetWeaponDefinitionResolver(new TestWeaponResolver(weapon));
+
+            inventoryComponent.State.AddWeapon("weapon_basic");
+
+            controller.RefreshEquippedWeapon(inventoryComponent.State);
+
+            Assert.AreEqual("weapon_basic", controller.CurrentWeaponId);
+
+            Object.DestroyImmediate(playerGo);
+            Object.DestroyImmediate(weapon);
+        }
+
+        [Test]
+        public void Attack_UsesWeaponStats()
+        {
+            var playerGo = new GameObject("Player");
+            var inventoryComponent = playerGo.AddComponent<InventoryStateComponent>();
+
+            var weapon = ScriptableObject.CreateInstance<WeaponDefinition>();
+            weapon.ItemId = "weapon_basic";
+            weapon.Damage = 7;
+            weapon.AttackSpeed = 2.5f;
+            weapon.HitboxSize = new Vector2(2f, 1f);
+            weapon.Knockback = 4f;
+
+            var controller = playerGo.AddComponent<PlayerWeaponController>();
+            controller.SetWeaponDefinitionResolver(new TestWeaponResolver(weapon));
+
+            inventoryComponent.State.AddWeapon("weapon_basic");
+            controller.RefreshEquippedWeapon(inventoryComponent.State);
+
+            var stats = controller.CurrentWeaponStats;
+
+            Assert.AreEqual(7, stats.Damage);
+            Assert.AreEqual(2.5f, stats.AttackSpeed);
+            Assert.AreEqual(2f, stats.HitboxSize.x);
+            Assert.AreEqual(1f, stats.HitboxSize.y);
+            Assert.AreEqual(4f, stats.Knockback);
+
+            Object.DestroyImmediate(playerGo);
+            Object.DestroyImmediate(weapon);
+        }
+
+        private sealed class TestWeaponResolver : IWeaponDefinitionResolver
+        {
+            private readonly WeaponDefinition definition;
+
+            public TestWeaponResolver(WeaponDefinition definition)
+            {
+                this.definition = definition;
+            }
+
+            public WeaponDefinition Resolve(string weaponId)
+            {
+                return definition != null && definition.ItemId == weaponId ? definition : null;
+            }
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Combat/PlayerWeaponControllerTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Combat/PlayerWeaponControllerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8e6f3f5c2c4b4c8a9f2b0a4e2c9f5d7a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,18 @@
 
 ---
 
+## 2026-01-05 - feat/weapon-equip-attack
+
+### Summary
+- Added PlayerWeaponController and weapon stat mapping from inventory definitions.
+
+### New or Updated Tests
+**EditMode**
+- `PlayerWeaponControllerTests`
+
+### Notes
+- Weapon stats are exposed as a data object for attack integration.
+
 ## 2026-01-04 - feat/item-pickups
 
 ### Summary


### PR DESCRIPTION
## Why
Weapon stats need to drive player attack behavior using inventory definitions.

## What changed
- Added PlayerWeaponController and weapon stats mapping from inventory items
- Added EditMode tests for equip and stat usage
- Updated TEST_LOG with new tests

## How to test
1. Unity: Run EditMode tests for Combat
2. CLI: Run `EditMode` test suite

## Checklist
- [x] Unit tests (EditMode) added/updated
- [x] PlayMode test or manual steps included (N/A)
- [x] Demo scene updated (N/A)
- [x] Prefab links/layers validated (N/A)
- [x] README/Docs touched