### PR TITLE
fix(ui): set potion cooldown overlay fill amount

### DIFF
--- a/Assets/_Project/Scenes/MainPrototype.unity
+++ b/Assets/_Project/Scenes/MainPrototype.unity
@@ -3921,7 +3921,7 @@ MonoBehaviour:
   m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 1
-  m_FillAmount: 1
+  m_FillAmount: 0
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0


### PR DESCRIPTION
Why  
Fix cooldown overlay starting filled.

What changed  
- Set cooldown overlay fill amount to 0 in MainPrototype scene.

How to test  
Unity steps  
- Open MainPrototype  
- Trigger potion cooldown; overlay starts empty and fills correctly

Run tests  
- N/A

Checklist  
- [x] Unit tests (EditMode) added/updated (N/A)  
- [x] PlayMode test or manual steps included  
- [x] Demo scene updated (if player-visible)  
- [x] Prefab links/layers validated (N/A)  
- [x] README/Docs touched (if new feature) (N/A)