### PR TITLE
feat(input): movement-first facing with conditional aim override

### DIFF
--- a/Assets/_Project/Prefabs/Player.prefab
+++ b/Assets/_Project/Prefabs/Player.prefab
@@ -118,6 +118,7 @@ GameObject:
   - component: {fileID: 9150000000000000100}
   - component: {fileID: 9150000000000000201}
   - component: {fileID: 9150000000000000202}
+  - component: {fileID: 9150000000000000203}
   m_Layer: 3
   m_Name: Player
   m_TagString: Player
@@ -244,43 +245,17 @@ MonoBehaviour:
   inventorySource: {fileID: 0}
   weaponSlotSwapHandler:
     weaponSlotSwapCooldown: 0.5
-  playerWeaponController: {fileID: 9150000000000000006}
+  playerWeaponController: {fileID: 0}
   mobileInputDriver: {fileID: 0}
   fireInputController: {fileID: 9150000000000000201}
   aimInputResolver: {fileID: 9150000000000000202}
+  facingPolicyResolver: {fileID: 9150000000000000203}
   baseAttackRate: 1.5
   movementOrchestrator:
-    deadZone: 0.1
+    deadZone: 0.3
     rotationSpeed: 720
     facingDirectionOffset: 90
     flipDirection: 0
---- !u!114 &9150000000000000201
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8325390509751579795}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e6430bca95d64ded995de7a9d4e90b03, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  useReleaseFallbackPolling: 1
---- !u!114 &9150000000000000202
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8325390509751579795}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7a123fed8f4f4317b4ff8507cb6db48a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  stickDeadZone: 0.0001
-  stickMagnitudeMax: 1.1
 --- !u!114 &6061923462103248084
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -542,6 +517,50 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   menuController: {fileID: 0}
+--- !u!114 &9150000000000000201
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8325390509751579795}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6430bca95d64ded995de7a9d4e90b03, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  useReleaseFallbackPolling: 1
+--- !u!114 &9150000000000000202
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8325390509751579795}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7a123fed8f4f4317b4ff8507cb6db48a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  stickDeadZone: 0.0001
+  stickMagnitudeMax: 1.1
+--- !u!114 &9150000000000000203
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8325390509751579795}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8a463690c6d665a40a814e84d0b9208c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  aimEnterThreshold: 0.25
+  aimExitThreshold: 0.2
+  movementMeaningfulThreshold: 0.1
+  returnToMovementFacingSpeed: 720
+  stickMagnitudeMax: 1.1
 --- !u!1 &9150000000000000001
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/_Project/Prefabs/Player.prefab
+++ b/Assets/_Project/Prefabs/Player.prefab
@@ -245,14 +245,14 @@ MonoBehaviour:
   inventorySource: {fileID: 0}
   weaponSlotSwapHandler:
     weaponSlotSwapCooldown: 0.5
-  playerWeaponController: {fileID: 0}
+  playerWeaponController: {fileID: 9150000000000000006}
   mobileInputDriver: {fileID: 0}
   fireInputController: {fileID: 9150000000000000201}
   aimInputResolver: {fileID: 9150000000000000202}
   facingPolicyResolver: {fileID: 9150000000000000203}
   baseAttackRate: 1.5
   movementOrchestrator:
-    deadZone: 0.3
+    deadZone: 0.1
     rotationSpeed: 720
     facingDirectionOffset: 90
     flipDirection: 0

--- a/Assets/_Project/Scenes/MainPrototype.unity
+++ b/Assets/_Project/Scenes/MainPrototype.unity
@@ -4713,6 +4713,8 @@ MonoBehaviour:
   repairButton: {fileID: 3003000004}
   playerInput: {fileID: 0}
   baseAttackRate: 1.5
+  rightStickAttackDeadzone: 160
+  enableInEditor: 0
 --- !u!114 &3000000003
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerFacingPolicyResolver.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerFacingPolicyResolver.cs
@@ -1,0 +1,55 @@
+using UnityEngine;
+
+public class PlayerFacingPolicyResolver : MonoBehaviour
+{
+    [SerializeField] private float aimEnterThreshold = 0.25f;
+    [SerializeField] private float aimExitThreshold = 0.20f;
+    [SerializeField] private float movementMeaningfulThreshold = 0.10f;
+    [SerializeField] private float returnToMovementFacingSpeed = 720f;
+    [SerializeField] private float stickMagnitudeMax = 1.1f;
+
+    private bool rightStickAimActive;
+
+    public Vector2 ResolveFacing(
+        Vector2 currentFacing,
+        Vector2 movementInput,
+        Vector2 resolvedAimInput,
+        Vector2 rawLookInput,
+        bool aimIntentActive,
+        float deltaTime)
+    {
+        bool stickAimIntentActive = UpdateRightStickAimIntent(rawLookInput);
+        bool shouldUseAim = aimIntentActive || stickAimIntentActive;
+
+        if (shouldUseAim && resolvedAimInput.sqrMagnitude > 0.0001f)
+            return resolvedAimInput.normalized;
+
+        float movementThresholdSquared = movementMeaningfulThreshold * movementMeaningfulThreshold;
+        if (movementInput.sqrMagnitude >= movementThresholdSquared)
+            return movementInput.normalized;
+
+        return currentFacing;
+    }
+
+    private bool UpdateRightStickAimIntent(Vector2 rawLookInput)
+    {
+        float lookMagnitude = rawLookInput.magnitude;
+        if (lookMagnitude > stickMagnitudeMax)
+        {
+            rightStickAimActive = false;
+            return false;
+        }
+
+        if (rightStickAimActive)
+        {
+            if (lookMagnitude <= aimExitThreshold)
+                rightStickAimActive = false;
+        }
+        else if (lookMagnitude >= aimEnterThreshold)
+        {
+            rightStickAimActive = true;
+        }
+
+        return rightStickAimActive;
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerFacingPolicyResolver.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerFacingPolicyResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8a463690c6d665a40a814e84d0b9208c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Input/MobileInputDriver.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Input/MobileInputDriver.cs
@@ -31,6 +31,9 @@ namespace Castlebound.Gameplay.Input
                  "past the deadzone. Weapon attackSpeed will scale this once the combat " +
                  "stat pipeline is wired (see PlayerController refactor issue).")]
         [SerializeField] private float baseAttackRate = 1.5f;
+        [Tooltip("Minimum right-zone drag distance before attack pulses begin. " +
+                 "Higher values make look-only thumb movement less likely to trigger swings.")]
+        [SerializeField] private float rightStickAttackDeadzone = 65f;
 
         [Tooltip("Editor override. If enabled, virtual touch controls run in Editor regardless of detected devices.")]
         [SerializeField] private bool enableInEditor;
@@ -67,6 +70,8 @@ namespace Castlebound.Gameplay.Input
 
             if (repairButton != null)
                 repairButton.OnRepairRequested += HandleRepairRequested;
+
+            ApplyRightStickAttackDeadzone();
         }
 
         private bool ShouldEnableVirtualGamepad()
@@ -97,6 +102,8 @@ namespace Castlebound.Gameplay.Input
 
         private void Update()
         {
+            ApplyRightStickAttackDeadzone();
+
             if (_virtualGamepad == null)
                 return;
 
@@ -151,6 +158,18 @@ namespace Castlebound.Gameplay.Input
         public void SetAttackRate(float attacksPerSecond)
         {
             baseAttackRate = Mathf.Max(attacksPerSecond, 0.1f);
+        }
+
+        public void SetRightStickAttackDeadzone(float deadzone)
+        {
+            rightStickAttackDeadzone = Mathf.Max(deadzone, 0f);
+            ApplyRightStickAttackDeadzone();
+        }
+
+        private void ApplyRightStickAttackDeadzone()
+        {
+            if (aimAttackZone != null)
+                aimAttackZone.AttackDeadzone = Mathf.Max(rightStickAttackDeadzone, 0f);
         }
     }
 }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/PlayerController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/PlayerController.cs
@@ -22,6 +22,7 @@ public class PlayerController : MonoBehaviour
     [SerializeField] private MobileInputDriver mobileInputDriver;
     [SerializeField] private PlayerFireInputController fireInputController;
     [SerializeField] private PlayerAimInputResolver aimInputResolver;
+    [SerializeField] private PlayerFacingPolicyResolver facingPolicyResolver;
     [SerializeField] private float baseAttackRate = 1.5f;
     
     [Header("Movement")]
@@ -47,6 +48,7 @@ public class PlayerController : MonoBehaviour
         if (mobileInputDriver == null) mobileInputDriver = FindObjectOfType<MobileInputDriver>();
         if (fireInputController == null) fireInputController = GetComponent<PlayerFireInputController>();
         if (aimInputResolver == null) aimInputResolver = GetComponent<PlayerAimInputResolver>();
+        if (facingPolicyResolver == null) facingPolicyResolver = GetComponent<PlayerFacingPolicyResolver>();
         inventoryState = inventorySource != null ? inventorySource.State : null;
         if (weaponSlotSwapHandler == null) weaponSlotSwapHandler = new WeaponSlotSwapHandler();
         if (movementOrchestrator == null) movementOrchestrator = new PlayerMovementOrchestrator();
@@ -97,7 +99,7 @@ public class PlayerController : MonoBehaviour
 
         fireInputController?.Tick();
 
-        movementOrchestrator.Tick(mover, transform, movementInput, ResolveAimInput(), Time.fixedDeltaTime);
+        movementOrchestrator.Tick(mover, transform, movementInput, ResolveFacingInput(), Time.fixedDeltaTime);
         SyncMobileAttackRate();
     }
 
@@ -237,5 +239,25 @@ public class PlayerController : MonoBehaviour
         return aimInputResolver != null
             ? aimInputResolver.Resolve(transform.position, aimInput)
             : aimInput;
+    }
+
+    private Vector2 ResolveFacingInput()
+    {
+        var resolvedAimInput = ResolveAimInput();
+        if (facingPolicyResolver == null)
+            facingPolicyResolver = GetComponent<PlayerFacingPolicyResolver>();
+
+        if (facingPolicyResolver == null)
+            return resolvedAimInput;
+
+        var aimIntentActive = fireInputController != null && fireInputController.IsFireHeld;
+        var currentFacing = movementOrchestrator != null ? movementOrchestrator.LastMoveDirection : (Vector2)transform.up;
+        return facingPolicyResolver.ResolveFacing(
+            currentFacing,
+            movementInput,
+            resolvedAimInput,
+            aimInput,
+            aimIntentActive,
+            Time.fixedDeltaTime);
     }
 }

--- a/Assets/_Project/_Tests/EditMode/Input/MobileInputDriverTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Input/MobileInputDriverTests.cs
@@ -134,5 +134,46 @@ namespace Castlebound.Tests.Input
             Assert.Greater(storedRate, 0f,
                 "SetAttackRate(0) should clamp to a positive minimum to avoid divide-by-zero.");
         }
+
+        [Test]
+        public void SetRightStickAttackDeadzone_MethodExists_AsPublicApiContract()
+        {
+            var method = typeof(MobileInputDriver).GetMethod(
+                "SetRightStickAttackDeadzone",
+                BindingFlags.Instance | BindingFlags.Public);
+
+            Assert.IsNotNull(method,
+                "MobileInputDriver must expose SetRightStickAttackDeadzone(float) for Android attack deadzone tuning.");
+        }
+
+        [Test]
+        public void SetRightStickAttackDeadzone_ClampsToZero_AndAppliesToAimZone()
+        {
+            _driver = _go.AddComponent<MobileInputDriver>();
+
+            var aimZoneGo = new GameObject("AimZone");
+            var aimZone = aimZoneGo.AddComponent<TouchAimAttackZone>();
+
+            var aimZoneField = typeof(MobileInputDriver).GetField(
+                "aimAttackZone",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.IsNotNull(aimZoneField, "aimAttackZone field was not found.");
+            aimZoneField.SetValue(_driver, aimZone);
+
+            var method = typeof(MobileInputDriver).GetMethod(
+                "SetRightStickAttackDeadzone",
+                BindingFlags.Instance | BindingFlags.Public);
+            Assert.IsNotNull(method, "SetRightStickAttackDeadzone(float) must exist.");
+
+            method.Invoke(_driver, new object[] { -10f });
+            Assert.AreEqual(0f, aimZone.AttackDeadzone, 0.001f,
+                "Negative deadzone values should clamp to zero and propagate to TouchAimAttackZone.");
+
+            method.Invoke(_driver, new object[] { 95f });
+            Assert.AreEqual(95f, aimZone.AttackDeadzone, 0.001f,
+                "Configured deadzone should propagate to TouchAimAttackZone.");
+
+            Object.DestroyImmediate(aimZoneGo);
+        }
     }
 }

--- a/Assets/_Project/_Tests/EditMode/Input/PlayerFacingPolicyContractsTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Input/PlayerFacingPolicyContractsTests.cs
@@ -1,0 +1,74 @@
+using System.IO;
+using NUnit.Framework;
+
+namespace Castlebound.Tests.Input
+{
+    public class PlayerFacingPolicyContractsTests
+    {
+        private const string PlayerControllerPath =
+            "Assets/_Project/Scripts/_Project.Gameplay/Player/PlayerController.cs";
+        private const string FacingPolicyResolverPath =
+            "Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerFacingPolicyResolver.cs";
+
+        [Test]
+        public void PlayerController_DelegatesFacingSourceSelection_ToFacingPolicyResolver()
+        {
+            var source = File.ReadAllText(PlayerControllerPath);
+
+            StringAssert.Contains("PlayerFacingPolicyResolver", source,
+                "PlayerController should delegate facing-source policy to PlayerFacingPolicyResolver.");
+            StringAssert.Contains("facingPolicyResolver.ResolveFacing", source,
+                "PlayerController should request final facing from the policy resolver.");
+        }
+
+        [Test]
+        public void FacingPolicyResolver_Exists_WithThresholdAndSmoothingTunables()
+        {
+            Assert.That(File.Exists(FacingPolicyResolverPath), Is.True,
+                "Facing policy component should exist as a dedicated resolver.");
+
+            var source = File.ReadAllText(FacingPolicyResolverPath);
+
+            StringAssert.Contains("[SerializeField] private float aimEnterThreshold", source,
+                "Aim-enter threshold should be tunable to avoid chatter.");
+            StringAssert.Contains("[SerializeField] private float aimExitThreshold", source,
+                "Aim-exit threshold should be tunable for hysteresis.");
+            StringAssert.Contains("[SerializeField] private float movementMeaningfulThreshold", source,
+                "Movement threshold should gate movement-facing behavior.");
+            StringAssert.Contains("[SerializeField] private float returnToMovementFacingSpeed", source,
+                "Return speed should be tunable for smooth transition back to movement-facing.");
+        }
+
+        [Test]
+        public void FacingPolicyResolver_ExposesExplicitAimIntent_AndSmoothReturnContract()
+        {
+            Assert.That(File.Exists(FacingPolicyResolverPath), Is.True,
+                "Facing policy component should exist before evaluating contract details.");
+
+            var source = File.ReadAllText(FacingPolicyResolverPath);
+
+            StringAssert.Contains("ResolveFacing(", source,
+                "Facing policy resolver should expose a single facing resolution entrypoint.");
+            StringAssert.Contains("aimIntentActive", source,
+                "Facing policy should only apply aim override when explicit aim intent is active.");
+            StringAssert.Contains("return resolvedAimInput.normalized", source,
+                "When aim intent is active, policy should select aim as the facing source.");
+            StringAssert.DoesNotContain("Mathf.MoveTowardsAngle", source,
+                "Facing policy should not own angle interpolation; rotation smoothing belongs to movement orchestration.");
+        }
+
+        [Test]
+        public void FacingPolicyResolver_PreservesFacing_WhenMovementIsNotMeaningful()
+        {
+            Assert.That(File.Exists(FacingPolicyResolverPath), Is.True,
+                "Facing policy component should exist before evaluating fallback contract.");
+
+            var source = File.ReadAllText(FacingPolicyResolverPath);
+
+            StringAssert.Contains("movementMeaningfulThreshold * movementMeaningfulThreshold", source,
+                "Movement-facing should only apply when movement input is meaningful.");
+            StringAssert.Contains("return currentFacing", source,
+                "When movement is not meaningful, facing should be preserved.");
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Input/PlayerFacingPolicyContractsTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Input/PlayerFacingPolicyContractsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 80f857aa785254749bf6151ea5c8727d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/EditMode/Input/PlayerFacingPolicyResolverTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Input/PlayerFacingPolicyResolverTests.cs
@@ -1,0 +1,159 @@
+using System.Reflection;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Castlebound.Tests.Input
+{
+    public class PlayerFacingPolicyResolverTests
+    {
+        private GameObject root;
+        private PlayerFacingPolicyResolver resolver;
+
+        [SetUp]
+        public void SetUp()
+        {
+            root = new GameObject("PlayerFacingPolicyResolver");
+            resolver = root.AddComponent<PlayerFacingPolicyResolver>();
+            SetPrivateFloat("aimEnterThreshold", 0.25f);
+            SetPrivateFloat("aimExitThreshold", 0.20f);
+            SetPrivateFloat("movementMeaningfulThreshold", 0.10f);
+            SetPrivateFloat("stickMagnitudeMax", 1.1f);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(root);
+        }
+
+        [Test]
+        public void ResolveFacing_PcWithoutAimIntent_UsesMovementDirection()
+        {
+            var result = resolver.ResolveFacing(
+                currentFacing: Vector2.up,
+                movementInput: Vector2.right,
+                resolvedAimInput: Vector2.left,
+                rawLookInput: Vector2.zero,
+                aimIntentActive: false,
+                deltaTime: 0.02f);
+
+            Assert.Less(Vector2.Distance(result, Vector2.right), 0.001f);
+        }
+
+        [Test]
+        public void ResolveFacing_PcWithAimIntent_UsesAimDirection()
+        {
+            var result = resolver.ResolveFacing(
+                currentFacing: Vector2.up,
+                movementInput: Vector2.right,
+                resolvedAimInput: Vector2.left,
+                rawLookInput: Vector2.zero,
+                aimIntentActive: true,
+                deltaTime: 0.02f);
+
+            Assert.Less(Vector2.Distance(result, Vector2.left), 0.001f);
+        }
+
+        [Test]
+        public void ResolveFacing_AndroidRightStickAboveEnter_ActivatesAimOverride()
+        {
+            var result = resolver.ResolveFacing(
+                currentFacing: Vector2.up,
+                movementInput: Vector2.right,
+                resolvedAimInput: Vector2.down,
+                rawLookInput: new Vector2(0.30f, 0f),
+                aimIntentActive: false,
+                deltaTime: 0.02f);
+
+            Assert.Less(Vector2.Distance(result, Vector2.down), 0.001f);
+        }
+
+        [Test]
+        public void ResolveFacing_AndroidRightStickBetweenEnterAndExit_KeepsAimOverride()
+        {
+            resolver.ResolveFacing(
+                currentFacing: Vector2.up,
+                movementInput: Vector2.right,
+                resolvedAimInput: Vector2.left,
+                rawLookInput: new Vector2(0.30f, 0f),
+                aimIntentActive: false,
+                deltaTime: 0.02f);
+
+            var result = resolver.ResolveFacing(
+                currentFacing: Vector2.up,
+                movementInput: Vector2.right,
+                resolvedAimInput: Vector2.left,
+                rawLookInput: new Vector2(0.22f, 0f),
+                aimIntentActive: false,
+                deltaTime: 0.02f);
+
+            Assert.Less(Vector2.Distance(result, Vector2.left), 0.001f);
+        }
+
+        [Test]
+        public void ResolveFacing_AndroidRightStickBelowExit_ReturnsToMovementDirection()
+        {
+            resolver.ResolveFacing(
+                currentFacing: Vector2.up,
+                movementInput: Vector2.left,
+                resolvedAimInput: Vector2.down,
+                rawLookInput: new Vector2(0.30f, 0f),
+                aimIntentActive: false,
+                deltaTime: 0.02f);
+
+            var result = resolver.ResolveFacing(
+                currentFacing: Vector2.up,
+                movementInput: Vector2.left,
+                resolvedAimInput: Vector2.down,
+                rawLookInput: new Vector2(0.19f, 0f),
+                aimIntentActive: false,
+                deltaTime: 0.02f);
+
+            Assert.Less(Vector2.Distance(result, Vector2.left), 0.001f);
+        }
+
+        [Test]
+        public void ResolveFacing_AimEndsWithoutMeaningfulMovement_PreservesCurrentFacing()
+        {
+            var currentFacing = new Vector2(0.3f, 0.95f).normalized;
+            var result = resolver.ResolveFacing(
+                currentFacing: currentFacing,
+                movementInput: new Vector2(0.05f, 0f),
+                resolvedAimInput: Vector2.left,
+                rawLookInput: Vector2.zero,
+                aimIntentActive: false,
+                deltaTime: 0.02f);
+
+            Assert.Less(Vector2.Distance(result, currentFacing), 0.001f);
+        }
+
+        [Test]
+        public void ResolveFacing_InvalidLookMagnitudeAboveMax_DisablesStickAimIntent()
+        {
+            resolver.ResolveFacing(
+                currentFacing: Vector2.up,
+                movementInput: Vector2.right,
+                resolvedAimInput: Vector2.left,
+                rawLookInput: new Vector2(0.30f, 0f),
+                aimIntentActive: false,
+                deltaTime: 0.02f);
+
+            var result = resolver.ResolveFacing(
+                currentFacing: Vector2.up,
+                movementInput: Vector2.right,
+                resolvedAimInput: Vector2.left,
+                rawLookInput: new Vector2(1.2f, 0f),
+                aimIntentActive: false,
+                deltaTime: 0.02f);
+
+            Assert.Less(Vector2.Distance(result, Vector2.right), 0.001f);
+        }
+
+        private void SetPrivateFloat(string fieldName, float value)
+        {
+            var field = typeof(PlayerFacingPolicyResolver).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(field, $"Expected private field '{fieldName}' to exist.");
+            field.SetValue(resolver, value);
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Input/PlayerFacingPolicyResolverTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Input/PlayerFacingPolicyResolverTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cab40e5a7d9f48979230161b29c9cfe8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/PlayMode/Input.meta
+++ b/Assets/_Project/_Tests/PlayMode/Input.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 896b578891a54405ac56ae400c94ee73
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/PlayMode/Input/PlayerFacingPolicyPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/Input/PlayerFacingPolicyPlayTests.cs
@@ -1,0 +1,136 @@
+using System.Collections;
+using System.Reflection;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Castlebound.Tests.PlayMode.Input
+{
+    public class PlayerFacingPolicyPlayTests
+    {
+        [UnityTest]
+        public IEnumerator Runtime_Pc_MovementFacingToAimFacingAndBack_SwitchesCorrectly()
+        {
+            var root = new GameObject("PlayerFacingPolicyResolver");
+            var resolver = root.AddComponent<PlayerFacingPolicyResolver>();
+            ConfigureResolver(resolver);
+
+            var movementFacing = resolver.ResolveFacing(
+                currentFacing: Vector2.up,
+                movementInput: Vector2.right,
+                resolvedAimInput: Vector2.left,
+                rawLookInput: Vector2.zero,
+                aimIntentActive: false,
+                deltaTime: 0.02f);
+            yield return null;
+
+            var aimFacing = resolver.ResolveFacing(
+                currentFacing: movementFacing,
+                movementInput: Vector2.right,
+                resolvedAimInput: Vector2.left,
+                rawLookInput: Vector2.zero,
+                aimIntentActive: true,
+                deltaTime: 0.02f);
+            yield return null;
+
+            var releasedFacing = resolver.ResolveFacing(
+                currentFacing: aimFacing,
+                movementInput: Vector2.right,
+                resolvedAimInput: Vector2.left,
+                rawLookInput: Vector2.zero,
+                aimIntentActive: false,
+                deltaTime: 0.02f);
+
+            Assert.Less(Vector2.Distance(movementFacing, Vector2.right), 0.001f);
+            Assert.Less(Vector2.Distance(aimFacing, Vector2.left), 0.001f);
+            Assert.Less(Vector2.Distance(releasedFacing, Vector2.right), 0.001f);
+
+            Object.Destroy(root);
+        }
+
+        [UnityTest]
+        public IEnumerator Runtime_AndroidRightStickHysteresis_ActivatesAndReleasesAimOverride()
+        {
+            var root = new GameObject("PlayerFacingPolicyResolver");
+            var resolver = root.AddComponent<PlayerFacingPolicyResolver>();
+            ConfigureResolver(resolver);
+
+            var entered = resolver.ResolveFacing(
+                currentFacing: Vector2.up,
+                movementInput: Vector2.down,
+                resolvedAimInput: Vector2.left,
+                rawLookInput: new Vector2(0.30f, 0f),
+                aimIntentActive: false,
+                deltaTime: 0.02f);
+            yield return null;
+
+            var between = resolver.ResolveFacing(
+                currentFacing: entered,
+                movementInput: Vector2.down,
+                resolvedAimInput: Vector2.left,
+                rawLookInput: new Vector2(0.22f, 0f),
+                aimIntentActive: false,
+                deltaTime: 0.02f);
+            yield return null;
+
+            var exited = resolver.ResolveFacing(
+                currentFacing: between,
+                movementInput: Vector2.down,
+                resolvedAimInput: Vector2.left,
+                rawLookInput: new Vector2(0.19f, 0f),
+                aimIntentActive: false,
+                deltaTime: 0.02f);
+
+            Assert.Less(Vector2.Distance(entered, Vector2.left), 0.001f);
+            Assert.Less(Vector2.Distance(between, Vector2.left), 0.001f);
+            Assert.Less(Vector2.Distance(exited, Vector2.down), 0.001f);
+
+            Object.Destroy(root);
+        }
+
+        [UnityTest]
+        public IEnumerator Runtime_AimEndsWithoutMovement_PreservesFacing()
+        {
+            var root = new GameObject("PlayerFacingPolicyResolver");
+            var resolver = root.AddComponent<PlayerFacingPolicyResolver>();
+            ConfigureResolver(resolver);
+
+            var aimedFacing = resolver.ResolveFacing(
+                currentFacing: Vector2.up,
+                movementInput: Vector2.zero,
+                resolvedAimInput: Vector2.left,
+                rawLookInput: Vector2.zero,
+                aimIntentActive: true,
+                deltaTime: 0.02f);
+            yield return null;
+
+            var releasedFacing = resolver.ResolveFacing(
+                currentFacing: aimedFacing,
+                movementInput: new Vector2(0.05f, 0f),
+                resolvedAimInput: Vector2.left,
+                rawLookInput: Vector2.zero,
+                aimIntentActive: false,
+                deltaTime: 0.02f);
+
+            Assert.Less(Vector2.Distance(aimedFacing, Vector2.left), 0.001f);
+            Assert.Less(Vector2.Distance(releasedFacing, aimedFacing), 0.001f);
+
+            Object.Destroy(root);
+        }
+
+        private static void ConfigureResolver(PlayerFacingPolicyResolver resolver)
+        {
+            SetPrivateFloat(resolver, "aimEnterThreshold", 0.25f);
+            SetPrivateFloat(resolver, "aimExitThreshold", 0.20f);
+            SetPrivateFloat(resolver, "movementMeaningfulThreshold", 0.10f);
+            SetPrivateFloat(resolver, "stickMagnitudeMax", 1.1f);
+        }
+
+        private static void SetPrivateFloat(PlayerFacingPolicyResolver resolver, string fieldName, float value)
+        {
+            var field = typeof(PlayerFacingPolicyResolver).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(field, $"Expected private field '{fieldName}' to exist.");
+            field.SetValue(resolver, value);
+        }
+    }
+}

--- a/Assets/_Project/_Tests/PlayMode/Input/PlayerFacingPolicyPlayTests.cs.meta
+++ b/Assets/_Project/_Tests/PlayMode/Input/PlayerFacingPolicyPlayTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2f80746ea617418f8aa53b9302c7112c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,24 @@
 
 ---
 
+## 2026-03-06 - feat(input): movement-first facing with conditional aim override (#153)
+
+### Summary
+- Added a dedicated `PlayerFacingPolicyResolver` to enforce movement-first facing with explicit aim override intent.
+- Kept `PlayerController` orchestration thin by delegating facing-source selection through policy resolution.
+- Added EditMode and PlayMode coverage for PC/Android source switching, hysteresis thresholds, and no-movement facing fallback.
+
+### New or Updated Tests
+**EditMode**
+- `PlayerFacingPolicyContractsTests` — verifies delegated facing-policy contract, tunable thresholds, and source-selection boundaries.
+- `PlayerFacingPolicyResolverTests` — verifies PC aim-intent override, Android right-stick hysteresis enter/hold/exit, and no-movement facing preservation.
+
+**PlayMode**
+- `PlayerFacingPolicyPlayTests` — verifies runtime movement-facing <-> aim-facing switching for PC and Android policy paths.
+
+### Notes
+- Hold-fire cadence and editor touch-zone mouse-bleed regression suites remained green during facing-policy validation.
+
 ## 2026-03-06 - feat(input): pc mouse aim + hold-fire cadence (#140/#141)
 
 ### Summary


### PR DESCRIPTION
## Why
Current always-aim-facing behavior felt disconnected from movement. This change makes movement the default facing source and only enables aim-facing during explicit combat-aim intent.

## What changed
- Added `PlayerFacingPolicyResolver` to choose facing source from movement vs aim intent
- Updated `PlayerController` to delegate facing selection and keep controller orchestration thin
- Wired facing policy on `Player.prefab`
- Added EditMode and PlayMode tests for policy contracts, source switching, hysteresis, and fallback behavior
- Added mobile tuning control for right-stick attack deadzone and tests for propagation/clamping
- Updated `Docs/TEST_LOG.md` with #153 validation entry

## How to test
1. Open the relevant scene or demo (if applicable)
2. Press Play → verify expected behavior
3. Run tests:
   - EditMode
   - PlayMode (or note manual validation)

## Checklist

- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated (if player-visible)
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched 

## Related
- Closes #153