### PR TITLE
feat(combat): high-rate cadence contracts

### DIFF
--- a/Assets/_Project/Art/Knight_Assets/Knight_Attack.anim
+++ b/Assets/_Project/Art/Knight_Assets/Knight_Attack.anim
@@ -195,7 +195,7 @@ AnimationClip:
     m_Level: 0
     m_CycleOffset: 0
     m_HasAdditiveReferencePose: 0
-    m_LoopTime: 0
+    m_LoopTime: 1
     m_LoopBlend: 0
     m_LoopBlendOrientation: 0
     m_LoopBlendPositionY: 0
@@ -614,18 +614,4 @@ AnimationClip:
     flags: 0
   m_HasGenericRootTransform: 0
   m_HasMotionFloatCurves: 0
-  m_Events:
-  - time: 0.35
-    functionName: EnableHitbox
-    data: 
-    objectReferenceParameter: {fileID: 0}
-    floatParameter: 0
-    intParameter: 0
-    messageOptions: 0
-  - time: 0.48333332
-    functionName: DisableHitbox
-    data: 
-    objectReferenceParameter: {fileID: 0}
-    floatParameter: 0
-    intParameter: 0
-    messageOptions: 0
+  m_Events: []

--- a/Assets/_Project/Art/Knight_Assets/Player.controller
+++ b/Assets/_Project/Art/Knight_Assets/Player.controller
@@ -69,13 +69,13 @@ AnimatorState:
   m_IKOnFeet: 0
   m_WriteDefaultValues: 1
   m_Mirror: 0
-  m_SpeedParameterActive: 0
+  m_SpeedParameterActive: 1
   m_MirrorParameterActive: 0
   m_CycleOffsetParameterActive: 0
   m_TimeParameterActive: 0
   m_Motion: {fileID: 7400000, guid: e3d1940cf07f3c34c9a4d05627996154, type: 2}
   m_Tag: 
-  m_SpeedParameter: 
+  m_SpeedParameter: AttackSpeedMultiplier
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
@@ -91,6 +91,12 @@ AnimatorController:
   - m_Name: Attack
     m_Type: 9
     m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
+  - m_Name: AttackSpeedMultiplier
+    m_Type: 1
+    m_DefaultFloat: 1
     m_DefaultInt: 0
     m_DefaultBool: 0
     m_Controller: {fileID: 9100000}

--- a/Assets/_Project/Art/Knight_Assets/Player.controller
+++ b/Assets/_Project/Art/Knight_Assets/Player.controller
@@ -94,6 +94,12 @@ AnimatorController:
     m_DefaultInt: 0
     m_DefaultBool: 0
     m_Controller: {fileID: 9100000}
+  - m_Name: AttackLoopActive
+    m_Type: 4
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
   - m_Name: AttackSpeedMultiplier
     m_Type: 1
     m_DefaultFloat: 1
@@ -120,7 +126,10 @@ AnimatorStateTransition:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: 
-  m_Conditions: []
+  m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: AttackLoopActive
+    m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: -2237345301440000089}
   m_Solo: 0
@@ -129,8 +138,8 @@ AnimatorStateTransition:
   serializedVersion: 3
   m_TransitionDuration: 0.05
   m_TransitionOffset: 0
-  m_ExitTime: 1
-  m_HasExitTime: 1
+  m_ExitTime: 0
+  m_HasExitTime: 0
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
@@ -144,7 +153,7 @@ AnimatorStateTransition:
   m_Name: 
   m_Conditions:
   - m_ConditionMode: 1
-    m_ConditionEvent: Attack
+    m_ConditionEvent: AttackLoopActive
     m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: -1932427923381377868}

--- a/Assets/_Project/Prefabs/Player.prefab
+++ b/Assets/_Project/Prefabs/Player.prefab
@@ -119,6 +119,7 @@ GameObject:
   - component: {fileID: 9150000000000000201}
   - component: {fileID: 9150000000000000202}
   - component: {fileID: 9150000000000000203}
+  - component: {fileID: 9150000000000000204}
   m_Layer: 3
   m_Name: Player
   m_TagString: Player
@@ -250,6 +251,7 @@ MonoBehaviour:
   fireInputController: {fileID: 9150000000000000201}
   aimInputResolver: {fileID: 9150000000000000202}
   facingPolicyResolver: {fileID: 9150000000000000203}
+  attackAnimationDriver: {fileID: 9150000000000000204}
   baseAttackRate: 1.5
   movementOrchestrator:
     deadZone: 0.1
@@ -561,6 +563,21 @@ MonoBehaviour:
   movementMeaningfulThreshold: 0.1
   returnToMovementFacingSpeed: 720
   stickMagnitudeMax: 1.1
+--- !u!114 &9150000000000000204
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8325390509751579795}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d39325ab6ac94d30afb94b328d6021cc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  attackSpeedParameter: AttackSpeedMultiplier
+  minAttackSpeedMultiplier: 0.25
+  maxAttackSpeedMultiplier: 3
 --- !u!1 &9150000000000000001
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/_Project/Prefabs/Player.prefab
+++ b/Assets/_Project/Prefabs/Player.prefab
@@ -120,6 +120,7 @@ GameObject:
   - component: {fileID: 9150000000000000202}
   - component: {fileID: 9150000000000000203}
   - component: {fileID: 9150000000000000204}
+  - component: {fileID: 9150000000000000205}
   m_Layer: 3
   m_Name: Player
   m_TagString: Player
@@ -246,12 +247,13 @@ MonoBehaviour:
   inventorySource: {fileID: 0}
   weaponSlotSwapHandler:
     weaponSlotSwapCooldown: 0.5
-  playerWeaponController: {fileID: 9150000000000000006}
+  playerWeaponController: {fileID: 0}
   mobileInputDriver: {fileID: 0}
   fireInputController: {fileID: 9150000000000000201}
   aimInputResolver: {fileID: 9150000000000000202}
   facingPolicyResolver: {fileID: 9150000000000000203}
   attackAnimationDriver: {fileID: 9150000000000000204}
+  attackLoop: {fileID: 9150000000000000205}
   baseAttackRate: 1.5
   movementOrchestrator:
     deadZone: 0.1
@@ -532,6 +534,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   useReleaseFallbackPolling: 1
+  autoChainHoldThresholdSeconds: 0.08
 --- !u!114 &9150000000000000202
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -576,8 +579,26 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   attackSpeedParameter: AttackSpeedMultiplier
+  normalizedProgressParameter: AttackProgress
+  loopActiveParameter: AttackLoopActive
   minAttackSpeedMultiplier: 0.25
-  maxAttackSpeedMultiplier: 3
+  maxAttackSpeedMultiplier: 12
+--- !u!114 &9150000000000000205
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8325390509751579795}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7c94724e17d343a6a1b398fbed4b5146, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  windupDuration: 0.14
+  activeDuration: 0.02
+  recoveryDuration: 0.01
+  minSwingDuration: 0.03
 --- !u!1 &9150000000000000001
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/Hitbox.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/Hitbox.cs
@@ -25,6 +25,11 @@ public class Hitbox : MonoBehaviour
     // Called by Player (via Animation Event at swing start)
     public void Activate()
     {
+        if (activeWindow)
+        {
+            return;
+        }
+
         hitThisSwing.Clear();
         EnsureReferences();
         UpdateColliderSize();

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/Hitbox.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/Hitbox.cs
@@ -22,7 +22,7 @@ public class Hitbox : MonoBehaviour
         activeWindow = false;
     }
 
-    // Called by Player (via Animation Event at swing start)
+    // Called by PlayerController while the current swing's hit window is active.
     public void Activate()
     {
         if (activeWindow)
@@ -40,7 +40,7 @@ public class Hitbox : MonoBehaviour
         activeWindow = true;
     }
 
-    // Called by Player (via Animation Event at swing end)
+    // Called by PlayerController once the current swing's hit window closes.
     public void Deactivate()
     {
         activeWindow = false;

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerAttackAnimationDriver.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerAttackAnimationDriver.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+
+public class PlayerAttackAnimationDriver : MonoBehaviour
+{
+    [SerializeField] private string attackSpeedParameter = "AttackSpeedMultiplier";
+    [SerializeField] private float minAttackSpeedMultiplier = 0.25f;
+    [SerializeField] private float maxAttackSpeedMultiplier = 3f;
+
+    public void ApplyAttackSpeed(Animator animator, float effectiveAttackRate, float baseAttackRate)
+    {
+        if (animator == null || string.IsNullOrWhiteSpace(attackSpeedParameter))
+            return;
+
+        float safeBaseRate = Mathf.Max(baseAttackRate, 0.0001f);
+        float rawMultiplier = effectiveAttackRate / safeBaseRate;
+        float clampedMultiplier = Mathf.Clamp(rawMultiplier, minAttackSpeedMultiplier, maxAttackSpeedMultiplier);
+        animator.SetFloat(attackSpeedParameter, clampedMultiplier);
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerAttackAnimationDriver.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerAttackAnimationDriver.cs
@@ -3,17 +3,58 @@ using UnityEngine;
 public class PlayerAttackAnimationDriver : MonoBehaviour
 {
     [SerializeField] private string attackSpeedParameter = "AttackSpeedMultiplier";
+    [SerializeField] private string normalizedProgressParameter = "AttackProgress";
+    [SerializeField] private string loopActiveParameter = "AttackLoopActive";
     [SerializeField] private float minAttackSpeedMultiplier = 0.25f;
-    [SerializeField] private float maxAttackSpeedMultiplier = 3f;
+    [SerializeField] private float maxAttackSpeedMultiplier = 12f;
 
     public void ApplyAttackSpeed(Animator animator, float effectiveAttackRate, float baseAttackRate)
     {
         if (animator == null || string.IsNullOrWhiteSpace(attackSpeedParameter))
+            return;
+        if (!HasParameter(animator, attackSpeedParameter, AnimatorControllerParameterType.Float))
             return;
 
         float safeBaseRate = Mathf.Max(baseAttackRate, 0.0001f);
         float rawMultiplier = effectiveAttackRate / safeBaseRate;
         float clampedMultiplier = Mathf.Clamp(rawMultiplier, minAttackSpeedMultiplier, maxAttackSpeedMultiplier);
         animator.SetFloat(attackSpeedParameter, clampedMultiplier);
+    }
+
+    public void ApplyLoopPresentation(
+        Animator animator,
+        bool isSwingActive,
+        float normalizedSwingProgress,
+        float effectiveAttackRate,
+        float baseAttackRate)
+    {
+        if (animator == null)
+            return;
+
+        ApplyAttackSpeed(animator, effectiveAttackRate, baseAttackRate);
+
+        if (!string.IsNullOrWhiteSpace(loopActiveParameter) &&
+            HasParameter(animator, loopActiveParameter, AnimatorControllerParameterType.Bool))
+            animator.SetBool(loopActiveParameter, isSwingActive);
+
+        if (!string.IsNullOrWhiteSpace(normalizedProgressParameter) &&
+            HasParameter(animator, normalizedProgressParameter, AnimatorControllerParameterType.Float))
+            animator.SetFloat(normalizedProgressParameter, Mathf.Clamp01(normalizedSwingProgress));
+    }
+
+    private static bool HasParameter(
+        Animator animator,
+        string parameterName,
+        AnimatorControllerParameterType expectedType)
+    {
+        var parameters = animator.parameters;
+        for (int i = 0; i < parameters.Length; i++)
+        {
+            var p = parameters[i];
+            if (p.type == expectedType && p.name == parameterName)
+                return true;
+        }
+
+        return false;
     }
 }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerAttackAnimationDriver.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerAttackAnimationDriver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d39325ab6ac94d30afb94b328d6021cc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerAttackLoop.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerAttackLoop.cs
@@ -1,4 +1,3 @@
-using System;
 using UnityEngine;
 
 public class PlayerAttackLoop : MonoBehaviour
@@ -18,16 +17,20 @@ public class PlayerAttackLoop : MonoBehaviour
     }
 
     private AttackPhase phase = AttackPhase.Idle;
+    private readonly PlayerAttackCooldownGate attackCooldownGate = new PlayerAttackCooldownGate();
     private float phaseRemaining;
     private float swingElapsed;
+    private float elapsedTime;
     private float currentWindupDuration;
     private float currentActiveDuration;
     private float currentRecoveryDuration;
     private int completedSwingCount;
+    private bool hitWindowActiveThisStep;
 
     public bool IsSwingActive => phase != AttackPhase.Idle;
     public bool IsPresentationActive => phase == AttackPhase.Windup || phase == AttackPhase.Active;
     public bool IsHitWindowOpen => phase == AttackPhase.Active;
+    public bool ShouldKeepHitboxActiveThisStep => hitWindowActiveThisStep;
     public int CompletedSwingCount => completedSwingCount;
     public float CurrentWindupDuration => currentWindupDuration;
     public float CurrentActiveDuration => currentActiveDuration;
@@ -39,20 +42,17 @@ public class PlayerAttackLoop : MonoBehaviour
 
     public void Tick(float deltaTime, float effectiveAttackRate, bool isHeld)
     {
-        Tick(deltaTime, effectiveAttackRate, isHeld, null, null);
-    }
+        hitWindowActiveThisStep = IsHitWindowOpen;
 
-    public void Tick(
-        float deltaTime,
-        float effectiveAttackRate,
-        bool isHeld,
-        Func<bool> tryStartSwing,
-        Action<bool> setHitWindowActive)
-    {
         if (phase == AttackPhase.Idle && isHeld)
-            TryStartSwing(effectiveAttackRate, tryStartSwing);
+            TryStartSwing(effectiveAttackRate);
 
-        if (deltaTime <= 0f || phase == AttackPhase.Idle)
+        if (deltaTime <= 0f)
+            return;
+
+        elapsedTime += deltaTime;
+
+        if (phase == AttackPhase.Idle)
             return;
 
         float remainingDelta = deltaTime;
@@ -67,7 +67,7 @@ public class PlayerAttackLoop : MonoBehaviour
                     break;
                 }
 
-                if (!TryStartSwing(effectiveAttackRate, tryStartSwing))
+                if (!TryStartSwing(effectiveAttackRate))
                     break;
 
                 continue;
@@ -81,7 +81,7 @@ public class PlayerAttackLoop : MonoBehaviour
             if (phaseRemaining > 0f)
                 break;
 
-            AdvancePhase(effectiveAttackRate, isHeld, tryStartSwing, setHitWindowActive);
+            AdvancePhase(effectiveAttackRate, isHeld);
         }
     }
 
@@ -94,11 +94,14 @@ public class PlayerAttackLoop : MonoBehaviour
         currentActiveDuration = 0f;
         currentRecoveryDuration = 0f;
         completedSwingCount = 0;
+        elapsedTime = 0f;
+        hitWindowActiveThisStep = false;
+        attackCooldownGate.Reset();
     }
 
-    private bool TryStartSwing(float effectiveAttackRate, Func<bool> tryStartSwing)
+    private bool TryStartSwing(float effectiveAttackRate)
     {
-        if (tryStartSwing != null && !tryStartSwing.Invoke())
+        if (!attackCooldownGate.TryConsume(elapsedTime, effectiveAttackRate))
             return false;
 
         ComputeScaledDurations(effectiveAttackRate);
@@ -110,27 +113,24 @@ public class PlayerAttackLoop : MonoBehaviour
 
     private void AdvancePhase(
         float effectiveAttackRate,
-        bool isHeld,
-        Func<bool> tryStartSwing,
-        Action<bool> setHitWindowActive)
+        bool isHeld)
     {
         switch (phase)
         {
             case AttackPhase.Windup:
                 phase = AttackPhase.Active;
                 phaseRemaining = currentActiveDuration;
-                setHitWindowActive?.Invoke(true);
+                hitWindowActiveThisStep = true;
                 break;
             case AttackPhase.Active:
                 phase = AttackPhase.Recovery;
                 phaseRemaining = currentRecoveryDuration;
-                setHitWindowActive?.Invoke(false);
                 break;
             case AttackPhase.Recovery:
                 completedSwingCount++;
                 if (isHeld)
                 {
-                    if (!TryStartSwing(effectiveAttackRate, tryStartSwing))
+                    if (!TryStartSwing(effectiveAttackRate))
                     {
                         phase = AttackPhase.AwaitingChain;
                         phaseRemaining = 0f;

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerAttackLoop.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerAttackLoop.cs
@@ -1,0 +1,160 @@
+using System;
+using UnityEngine;
+
+public class PlayerAttackLoop : MonoBehaviour
+{
+    [SerializeField] private float windupDuration = 0.05f;
+    [SerializeField] private float activeDuration = 0.06f;
+    [SerializeField] private float recoveryDuration = 0.09f;
+    [SerializeField] private float minSwingDuration = 0.03f;
+
+    private enum AttackPhase
+    {
+        Idle,
+        AwaitingChain,
+        Windup,
+        Active,
+        Recovery
+    }
+
+    private AttackPhase phase = AttackPhase.Idle;
+    private float phaseRemaining;
+    private float swingElapsed;
+    private float currentWindupDuration;
+    private float currentActiveDuration;
+    private float currentRecoveryDuration;
+    private int completedSwingCount;
+
+    public bool IsSwingActive => phase != AttackPhase.Idle;
+    public bool IsPresentationActive => phase == AttackPhase.Windup || phase == AttackPhase.Active;
+    public bool IsHitWindowOpen => phase == AttackPhase.Active;
+    public int CompletedSwingCount => completedSwingCount;
+    public float CurrentWindupDuration => currentWindupDuration;
+    public float CurrentActiveDuration => currentActiveDuration;
+    public float CurrentRecoveryDuration => currentRecoveryDuration;
+    public float CurrentSwingDuration => currentWindupDuration + currentActiveDuration + currentRecoveryDuration;
+    public float MinSwingDuration => minSwingDuration;
+    public float NormalizedSwingProgress =>
+        CurrentSwingDuration > 0f ? Mathf.Clamp01(swingElapsed / CurrentSwingDuration) : 0f;
+
+    public void Tick(float deltaTime, float effectiveAttackRate, bool isHeld)
+    {
+        Tick(deltaTime, effectiveAttackRate, isHeld, null, null);
+    }
+
+    public void Tick(
+        float deltaTime,
+        float effectiveAttackRate,
+        bool isHeld,
+        Func<bool> tryStartSwing,
+        Action<bool> setHitWindowActive)
+    {
+        if (phase == AttackPhase.Idle && isHeld)
+            TryStartSwing(effectiveAttackRate, tryStartSwing);
+
+        if (deltaTime <= 0f || phase == AttackPhase.Idle)
+            return;
+
+        float remainingDelta = deltaTime;
+        while (remainingDelta > 0f && phase != AttackPhase.Idle)
+        {
+            if (phase == AttackPhase.AwaitingChain)
+            {
+                if (!isHeld)
+                {
+                    phase = AttackPhase.Idle;
+                    phaseRemaining = 0f;
+                    break;
+                }
+
+                if (!TryStartSwing(effectiveAttackRate, tryStartSwing))
+                    break;
+
+                continue;
+            }
+
+            float step = Mathf.Min(phaseRemaining, remainingDelta);
+            phaseRemaining -= step;
+            remainingDelta -= step;
+            swingElapsed += step;
+
+            if (phaseRemaining > 0f)
+                break;
+
+            AdvancePhase(effectiveAttackRate, isHeld, tryStartSwing, setHitWindowActive);
+        }
+    }
+
+    public void ResetLoopState()
+    {
+        phase = AttackPhase.Idle;
+        phaseRemaining = 0f;
+        swingElapsed = 0f;
+        currentWindupDuration = 0f;
+        currentActiveDuration = 0f;
+        currentRecoveryDuration = 0f;
+        completedSwingCount = 0;
+    }
+
+    private bool TryStartSwing(float effectiveAttackRate, Func<bool> tryStartSwing)
+    {
+        if (tryStartSwing != null && !tryStartSwing.Invoke())
+            return false;
+
+        ComputeScaledDurations(effectiveAttackRate);
+        phase = AttackPhase.Windup;
+        phaseRemaining = currentWindupDuration;
+        swingElapsed = 0f;
+        return true;
+    }
+
+    private void AdvancePhase(
+        float effectiveAttackRate,
+        bool isHeld,
+        Func<bool> tryStartSwing,
+        Action<bool> setHitWindowActive)
+    {
+        switch (phase)
+        {
+            case AttackPhase.Windup:
+                phase = AttackPhase.Active;
+                phaseRemaining = currentActiveDuration;
+                setHitWindowActive?.Invoke(true);
+                break;
+            case AttackPhase.Active:
+                phase = AttackPhase.Recovery;
+                phaseRemaining = currentRecoveryDuration;
+                setHitWindowActive?.Invoke(false);
+                break;
+            case AttackPhase.Recovery:
+                completedSwingCount++;
+                if (isHeld)
+                {
+                    if (!TryStartSwing(effectiveAttackRate, tryStartSwing))
+                    {
+                        phase = AttackPhase.AwaitingChain;
+                        phaseRemaining = 0f;
+                        swingElapsed = CurrentSwingDuration;
+                    }
+                }
+                else
+                {
+                    phase = AttackPhase.Idle;
+                    phaseRemaining = 0f;
+                }
+                break;
+        }
+    }
+
+    private void ComputeScaledDurations(float effectiveAttackRate)
+    {
+        float safeRate = Mathf.Max(effectiveAttackRate, 0.0001f);
+        float baseTotal = Mathf.Max(0.001f, windupDuration + activeDuration + recoveryDuration);
+        float targetSwingDuration = Mathf.Max(minSwingDuration, 1f / safeRate);
+        float durationScale = targetSwingDuration / baseTotal;
+
+        currentWindupDuration = Mathf.Max(0.0001f, windupDuration * durationScale);
+        currentActiveDuration = Mathf.Max(0.0001f, activeDuration * durationScale);
+        currentRecoveryDuration = Mathf.Max(0.0001f, recoveryDuration * durationScale);
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerAttackLoop.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerAttackLoop.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7c94724e17d343a6a1b398fbed4b5146
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Input/MobileInputDriver.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Input/MobileInputDriver.cs
@@ -40,8 +40,6 @@ namespace Castlebound.Gameplay.Input
 
         private Gamepad _virtualGamepad;
         private bool _pendingRepairPress;
-        private bool _pendingFirePulse;
-        private float _attackTimer;
 
         private void OnEnable()
         {
@@ -114,30 +112,12 @@ namespace Castlebound.Gameplay.Input
                 state.leftStick = movementZone.MoveVector;
 
             // Right stick drives facing direction.
-            // Right trigger pulses at baseAttackRate while the zone is held past the deadzone,
-            // producing a repeated press-release cycle so OnFire fires on each pulse.
-            // Resetting the timer to zero when not firing ensures the first attack in a new
-            // drag is immediate rather than waiting out the previous interval.
+            // Right trigger remains held while the right zone is firing.
+            // Cadence authority lives in PlayerAttackLoop / cooldown gate.
             if (aimAttackZone != null)
             {
                 state.rightStick = aimAttackZone.FacingDirection;
-
-                if (aimAttackZone.IsFiring)
-                {
-                    _attackTimer -= Time.deltaTime;
-                    if (_attackTimer <= 0f)
-                    {
-                        _pendingFirePulse = true;
-                        _attackTimer = 1f / Mathf.Max(baseAttackRate, 0.1f);
-                    }
-                }
-                else
-                {
-                    _attackTimer = 0f;
-                }
-
-                state.rightTrigger = _pendingFirePulse ? 1f : 0f;
-                _pendingFirePulse = false;
+                state.rightTrigger = aimAttackZone.IsFiring ? 1f : 0f;
             }
 
             // One-shot repair press: button is set this frame, absent next frame = released.

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Input/MobileInputDriver.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Input/MobileInputDriver.cs
@@ -27,10 +27,6 @@ namespace Castlebound.Gameplay.Input
                  "Must be assigned so the virtual gamepad is paired to its InputUser.")]
         [SerializeField] private PlayerInput playerInput;
 
-        [Tooltip("How many times per second the player attacks while the right zone is held " +
-                 "past the deadzone. Weapon attackSpeed will scale this once the combat " +
-                 "stat pipeline is wired (see PlayerController refactor issue).")]
-        [SerializeField] private float baseAttackRate = 1.5f;
         [Tooltip("Minimum right-zone drag distance before attack pulses begin. " +
                  "Higher values make look-only thumb movement less likely to trigger swings.")]
         [SerializeField] private float rightStickAttackDeadzone = 65f;
@@ -133,11 +129,6 @@ namespace Castlebound.Gameplay.Input
         private void HandleRepairRequested()
         {
             _pendingRepairPress = true;
-        }
-
-        public void SetAttackRate(float attacksPerSecond)
-        {
-            baseAttackRate = Mathf.Max(attacksPerSecond, 0.1f);
         }
 
         public void SetRightStickAttackDeadzone(float deadzone)

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/PlayerController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/PlayerController.cs
@@ -36,8 +36,6 @@ public class PlayerController : MonoBehaviour
     private PlayerCollisionMove2D mover;
     private InventoryState inventoryState;
     private bool inputLocked;
-    private readonly PlayerAttackCooldownGate attackCooldownGate = new PlayerAttackCooldownGate();
-    private float appliedMobileAttackRate = -1f;
 
     void Awake()
     {
@@ -58,7 +56,6 @@ public class PlayerController : MonoBehaviour
         if (movementOrchestrator == null) movementOrchestrator = new PlayerMovementOrchestrator();
         if (fireInputController != null)
             fireInputController.Configure(null);
-        SyncMobileAttackRate();
     }
 
 
@@ -104,15 +101,11 @@ public class PlayerController : MonoBehaviour
         var effectiveAttackRate = GetEffectiveAttackRate();
         var isFireHeld = fireInputController != null && fireInputController.IsFireHeld;
         if (attackLoop != null)
-            attackLoop.Tick(
-                Time.fixedDeltaTime,
-                effectiveAttackRate,
-                isFireHeld,
-                TryTriggerAttack,
-                SetHitWindowActive);
+            attackLoop.Tick(Time.fixedDeltaTime, effectiveAttackRate, isFireHeld);
+
+        ApplyAttackRuntimeState();
 
         movementOrchestrator.Tick(mover, transform, movementInput, ResolveFacingInput(), Time.fixedDeltaTime);
-        SyncMobileAttackRate();
         SyncAttackAnimationSpeed();
     }
 
@@ -218,8 +211,8 @@ public class PlayerController : MonoBehaviour
         if (locked)
         {
             fireInputController?.ClearHeldFire();
-            SetHitWindowActive(false);
             attackLoop?.ResetLoopState();
+            ApplyAttackRuntimeState();
         }
     }
 
@@ -230,19 +223,6 @@ public class PlayerController : MonoBehaviour
             : 1f;
 
         return PlayerAttackRateCalculator.ComputeEffectiveRate(baseAttackRate, weaponAttackSpeed);
-    }
-
-    private void SyncMobileAttackRate()
-    {
-        if (mobileInputDriver == null)
-            return;
-
-        var rate = GetEffectiveAttackRate();
-        if (Mathf.Approximately(rate, appliedMobileAttackRate))
-            return;
-
-        mobileInputDriver.SetAttackRate(rate);
-        appliedMobileAttackRate = rate;
     }
 
     private void SyncAttackAnimationSpeed()
@@ -264,17 +244,10 @@ public class PlayerController : MonoBehaviour
             baseAttackRate);
     }
 
-    private bool TryTriggerAttack()
+    private void ApplyAttackRuntimeState()
     {
-        if (!attackCooldownGate.TryConsume(Time.fixedTime, GetEffectiveAttackRate()))
-            return false;
-
-        return true;
-    }
-
-    private void SetHitWindowActive(bool active)
-    {
-        if (active)
+        var shouldKeepHitboxActive = attackLoop != null && attackLoop.ShouldKeepHitboxActiveThisStep;
+        if (shouldKeepHitboxActive)
             EnableHitbox();
         else
             DisableHitbox();

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/PlayerController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/PlayerController.cs
@@ -24,6 +24,7 @@ public class PlayerController : MonoBehaviour
     [SerializeField] private PlayerAimInputResolver aimInputResolver;
     [SerializeField] private PlayerFacingPolicyResolver facingPolicyResolver;
     [SerializeField] private PlayerAttackAnimationDriver attackAnimationDriver;
+    [SerializeField] private PlayerAttackLoop attackLoop;
     [SerializeField] private float baseAttackRate = 1.5f;
     
     [Header("Movement")]
@@ -51,11 +52,12 @@ public class PlayerController : MonoBehaviour
         if (aimInputResolver == null) aimInputResolver = GetComponent<PlayerAimInputResolver>();
         if (facingPolicyResolver == null) facingPolicyResolver = GetComponent<PlayerFacingPolicyResolver>();
         if (attackAnimationDriver == null) attackAnimationDriver = GetComponent<PlayerAttackAnimationDriver>();
+        if (attackLoop == null) attackLoop = GetComponent<PlayerAttackLoop>();
         inventoryState = inventorySource != null ? inventorySource.State : null;
         if (weaponSlotSwapHandler == null) weaponSlotSwapHandler = new WeaponSlotSwapHandler();
         if (movementOrchestrator == null) movementOrchestrator = new PlayerMovementOrchestrator();
         if (fireInputController != null)
-            fireInputController.Configure(TryTriggerAttack);
+            fireInputController.Configure(null);
         SyncMobileAttackRate();
     }
 
@@ -87,11 +89,6 @@ public class PlayerController : MonoBehaviour
         }
 
         fireInputController?.OnFirePressedStateChanged(value.isPressed);
-
-        if (!value.isPressed)
-            return;
-
-        TryTriggerAttack();
     }
 
     void FixedUpdate()
@@ -101,6 +98,19 @@ public class PlayerController : MonoBehaviour
 
         fireInputController?.Tick();
 
+        if (attackLoop == null)
+            attackLoop = GetComponent<PlayerAttackLoop>();
+
+        var effectiveAttackRate = GetEffectiveAttackRate();
+        var isFireHeld = fireInputController != null && fireInputController.IsFireHeld;
+        if (attackLoop != null)
+            attackLoop.Tick(
+                Time.fixedDeltaTime,
+                effectiveAttackRate,
+                isFireHeld,
+                TryTriggerAttack,
+                SetHitWindowActive);
+
         movementOrchestrator.Tick(mover, transform, movementInput, ResolveFacingInput(), Time.fixedDeltaTime);
         SyncMobileAttackRate();
         SyncAttackAnimationSpeed();
@@ -109,11 +119,17 @@ public class PlayerController : MonoBehaviour
 
     public void EnableHitbox()
     {
+        if (hitboxObject == null)
+            return;
+
         hitboxObject.GetComponent<Hitbox>()?.Activate();
     }
 
     public void DisableHitbox()
     {
+        if (hitboxObject == null)
+            return;
+
         hitboxObject.GetComponent<Hitbox>()?.Deactivate();
     }
 
@@ -200,7 +216,11 @@ public class PlayerController : MonoBehaviour
     {
         inputLocked = locked;
         if (locked)
+        {
             fireInputController?.ClearHeldFire();
+            SetHitWindowActive(false);
+            attackLoop?.ResetLoopState();
+        }
     }
 
     private float GetEffectiveAttackRate()
@@ -233,16 +253,31 @@ public class PlayerController : MonoBehaviour
         if (attackAnimationDriver == null)
             return;
 
-        attackAnimationDriver.ApplyAttackSpeed(animator, GetEffectiveAttackRate(), baseAttackRate);
+        var rate = GetEffectiveAttackRate();
+        var isSwingActive = attackLoop != null && attackLoop.IsPresentationActive;
+        var normalizedSwingProgress = attackLoop != null ? attackLoop.NormalizedSwingProgress : 0f;
+        attackAnimationDriver.ApplyLoopPresentation(
+            animator,
+            isSwingActive,
+            normalizedSwingProgress,
+            rate,
+            baseAttackRate);
     }
 
     private bool TryTriggerAttack()
     {
-        if (!attackCooldownGate.TryConsume(Time.time, GetEffectiveAttackRate()))
+        if (!attackCooldownGate.TryConsume(Time.fixedTime, GetEffectiveAttackRate()))
             return false;
 
-        animator.SetTrigger("Attack");
         return true;
+    }
+
+    private void SetHitWindowActive(bool active)
+    {
+        if (active)
+            EnableHitbox();
+        else
+            DisableHitbox();
     }
 
     private Vector2 ResolveAimInput()

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/PlayerController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/PlayerController.cs
@@ -23,6 +23,7 @@ public class PlayerController : MonoBehaviour
     [SerializeField] private PlayerFireInputController fireInputController;
     [SerializeField] private PlayerAimInputResolver aimInputResolver;
     [SerializeField] private PlayerFacingPolicyResolver facingPolicyResolver;
+    [SerializeField] private PlayerAttackAnimationDriver attackAnimationDriver;
     [SerializeField] private float baseAttackRate = 1.5f;
     
     [Header("Movement")]
@@ -49,6 +50,7 @@ public class PlayerController : MonoBehaviour
         if (fireInputController == null) fireInputController = GetComponent<PlayerFireInputController>();
         if (aimInputResolver == null) aimInputResolver = GetComponent<PlayerAimInputResolver>();
         if (facingPolicyResolver == null) facingPolicyResolver = GetComponent<PlayerFacingPolicyResolver>();
+        if (attackAnimationDriver == null) attackAnimationDriver = GetComponent<PlayerAttackAnimationDriver>();
         inventoryState = inventorySource != null ? inventorySource.State : null;
         if (weaponSlotSwapHandler == null) weaponSlotSwapHandler = new WeaponSlotSwapHandler();
         if (movementOrchestrator == null) movementOrchestrator = new PlayerMovementOrchestrator();
@@ -101,6 +103,7 @@ public class PlayerController : MonoBehaviour
 
         movementOrchestrator.Tick(mover, transform, movementInput, ResolveFacingInput(), Time.fixedDeltaTime);
         SyncMobileAttackRate();
+        SyncAttackAnimationSpeed();
     }
 
 
@@ -220,6 +223,17 @@ public class PlayerController : MonoBehaviour
 
         mobileInputDriver.SetAttackRate(rate);
         appliedMobileAttackRate = rate;
+    }
+
+    private void SyncAttackAnimationSpeed()
+    {
+        if (attackAnimationDriver == null)
+            attackAnimationDriver = GetComponent<PlayerAttackAnimationDriver>();
+
+        if (attackAnimationDriver == null)
+            return;
+
+        attackAnimationDriver.ApplyAttackSpeed(animator, GetEffectiveAttackRate(), baseAttackRate);
     }
 
     private bool TryTriggerAttack()

--- a/Assets/_Project/_Tests/EditMode/Input/MobileInputDriverHoldFireContractsTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Input/MobileInputDriverHoldFireContractsTests.cs
@@ -1,0 +1,24 @@
+using System.IO;
+using NUnit.Framework;
+
+namespace Castlebound.Tests.Input
+{
+    public class MobileInputDriverHoldFireContractsTests
+    {
+        private const string MobileInputDriverPath =
+            "Assets/_Project/Scripts/_Project.Gameplay/Player/Input/MobileInputDriver.cs";
+
+        [Test]
+        public void MobileInputDriver_DoesNotUsePulseTimer_ForRightTriggerWhileFiring()
+        {
+            var source = File.ReadAllText(MobileInputDriverPath);
+
+            StringAssert.DoesNotContain("_pendingFirePulse", source,
+                "Android right-trigger hold should not depend on one-frame fire pulses.");
+            StringAssert.DoesNotContain("_attackTimer", source,
+                "Android right-trigger hold should not be cadence-gated by MobileInputDriver timers.");
+            StringAssert.Contains("state.rightTrigger = aimAttackZone.IsFiring ? 1f : 0f;", source,
+                "Android right-trigger should remain pressed while aim zone is firing.");
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Input/MobileInputDriverHoldFireContractsTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Input/MobileInputDriverHoldFireContractsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d21fb39440534bed8bce7f4e87ac72bf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/EditMode/Input/MobileInputDriverOwnershipContractsTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Input/MobileInputDriverOwnershipContractsTests.cs
@@ -1,0 +1,35 @@
+using System.IO;
+using NUnit.Framework;
+
+namespace Castlebound.Tests.Input
+{
+    public class MobileInputDriverOwnershipContractsTests
+    {
+        private const string MobileInputDriverPath =
+            "Assets/_Project/Scripts/_Project.Gameplay/Player/Input/MobileInputDriver.cs";
+        private const string PlayerControllerPath =
+            "Assets/_Project/Scripts/_Project.Gameplay/Player/PlayerController.cs";
+
+        [Test]
+        public void MobileInputDriver_DoesNotExposeAttackRateApi()
+        {
+            var source = File.ReadAllText(MobileInputDriverPath);
+
+            StringAssert.DoesNotContain("SetAttackRate(", source,
+                "Mobile input should not expose an attack-rate API once cadence authority lives in the attack runtime.");
+            StringAssert.DoesNotContain("baseAttackRate", source,
+                "Mobile input should not retain a stale attack-rate field once it only forwards held intent.");
+        }
+
+        [Test]
+        public void PlayerController_DoesNotSyncAttackRate_IntoMobileInput()
+        {
+            var source = File.ReadAllText(PlayerControllerPath);
+
+            StringAssert.DoesNotContain("SyncMobileAttackRate(", source,
+                "PlayerController should not push attack cadence into MobileInputDriver once mobile input is intent-only.");
+            StringAssert.DoesNotContain("mobileInputDriver.SetAttackRate", source,
+                "PlayerController should not call a removed mobile attack-rate API.");
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Input/MobileInputDriverOwnershipContractsTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Input/MobileInputDriverOwnershipContractsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b422d51c604a9cb4398232e5cb91928e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/EditMode/Input/MobileInputDriverTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Input/MobileInputDriverTests.cs
@@ -19,16 +19,15 @@ namespace Castlebound.Tests.Input
     ///     the PlayerInput user (needs a real PlayerInput component in a live scene).
     ///   - Per-frame QueueStateEvent writing left/right stick values from the touch zones
     ///     and those values reaching PlayerController.OnMove / OnLook / OnFire.
-    ///   - Attack pulse timer: that rightTrigger pulses at baseAttackRate while IsFiring,
-    ///     that the first pulse is immediate (timer reset to 0 on pointer-up), and that
-    ///     Mathf.Max clamps baseAttackRate so zero/negative values do not divide by zero.
+    ///   - Held-fire routing: that rightTrigger remains held while IsFiring and releases
+    ///     when the touch aim zone exits its firing threshold.
     ///
     /// For full pipeline coverage create a PlayMode integration test that:
     ///   1. Loads the gameplay scene (or a minimal stand-in).
     ///   2. Confirms InputSystem.devices contains a Gamepad named "MobileGamepad".
     ///   3. Simulates a drag on TouchMovementZone and asserts PlayerController moved.
-    ///   4. Simulates a right-zone drag past the deadzone and asserts the Attack animator
-    ///      trigger fires repeatedly at approximately baseAttackRate.
+    ///   4. Simulates a right-zone drag past the deadzone and asserts held-fire intent
+    ///      reaches PlayerController through the virtual gamepad path.
     /// </summary>
     public class MobileInputDriverTests
     {
@@ -100,39 +99,6 @@ namespace Castlebound.Tests.Input
                 _go.SetActive(true);
                 _go.SetActive(false);
             }, "Repeated enable/disable cycles should not throw.");
-        }
-
-        [Test]
-        public void SetAttackRate_MethodExists_AsPublicApiContract()
-        {
-            var method = typeof(MobileInputDriver).GetMethod(
-                "SetAttackRate",
-                BindingFlags.Instance | BindingFlags.Public);
-
-            Assert.IsNotNull(method,
-                "MobileInputDriver must expose public SetAttackRate(float) so attack cadence can be wired from weapon stats.");
-        }
-
-        [Test]
-        public void SetAttackRate_ClampsToPositiveMinimum()
-        {
-            _driver = _go.AddComponent<MobileInputDriver>();
-
-            var method = typeof(MobileInputDriver).GetMethod(
-                "SetAttackRate",
-                BindingFlags.Instance | BindingFlags.Public);
-            Assert.IsNotNull(method, "SetAttackRate(float) must exist.");
-
-            method.Invoke(_driver, new object[] { 0f });
-
-            var baseRateField = typeof(MobileInputDriver).GetField(
-                "baseAttackRate",
-                BindingFlags.Instance | BindingFlags.NonPublic);
-            Assert.IsNotNull(baseRateField, "baseAttackRate field was not found.");
-
-            var storedRate = (float)baseRateField.GetValue(_driver);
-            Assert.Greater(storedRate, 0f,
-                "SetAttackRate(0) should clamp to a positive minimum to avoid divide-by-zero.");
         }
 
         [Test]

--- a/Assets/_Project/_Tests/EditMode/Input/PlayerHoldFireContractsTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Input/PlayerHoldFireContractsTests.cs
@@ -48,12 +48,14 @@ namespace Castlebound.Tests.Input
         }
 
         [Test]
-        public void PlayerController_KeepsCooldownGateAsAttackAuthority()
+        public void PlayerController_KeepsAttackAuthorityDelegated_ToAttackLoop()
         {
             var source = File.ReadAllText(PlayerControllerPath);
 
-            StringAssert.Contains("attackCooldownGate.TryConsume", source,
-                "Attack cadence should remain authoritative through PlayerAttackCooldownGate.");
+            StringAssert.Contains("attackLoop.Tick(", source,
+                "PlayerController should continue delegating held-fire cadence progression to PlayerAttackLoop.");
+            StringAssert.DoesNotContain("attackCooldownGate.TryConsume", source,
+                "PlayerController should no longer own direct cooldown consumption.");
         }
     }
 }

--- a/Assets/_Project/_Tests/EditMode/Input/PlayerHoldFireContractsTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Input/PlayerHoldFireContractsTests.cs
@@ -20,7 +20,7 @@ namespace Castlebound.Tests.Input
         }
 
         [Test]
-        public void PlayerController_DelegatesPressedState_AndTick_ToFireInputController()
+        public void PlayerController_DelegatesPressedState_ToFireInputController_AndTicksAttackLoop()
         {
             var source = File.ReadAllText(PlayerControllerPath);
 
@@ -30,11 +30,9 @@ namespace Castlebound.Tests.Input
             Assert.IsTrue(forwardsPressedState,
                 "PlayerController should forward pressed state updates to PlayerFireInputController.");
 
-            var ticksFireInput =
-                source.Contains("fireInputController.Tick()") ||
-                source.Contains("fireInputController?.Tick()");
-            Assert.IsTrue(ticksFireInput,
-                "PlayerController should tick PlayerFireInputController from FixedUpdate.");
+            var ticksAttackLoop = source.Contains("attackLoop.Tick(");
+            Assert.IsTrue(ticksAttackLoop,
+                "PlayerController should tick PlayerAttackLoop from FixedUpdate.");
         }
 
         [Test]

--- a/Assets/_Project/_Tests/EditMode/Player/AnimatorAttackTransitionContractTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Player/AnimatorAttackTransitionContractTests.cs
@@ -9,7 +9,7 @@ namespace Castlebound.Tests.Player
     public class AnimatorAttackTransitionContractTests
     {
         [Test]
-        public void PlayerAttackTransition_UsesExitTimeWithShortBlend()
+        public void PlayerAttackTransition_UsesLoopActiveConditionWithShortBlend()
         {
             var controller = AssetDatabase.LoadAssetAtPath<AnimatorController>(
                 "Assets/_Project/Art/Knight_Assets/Player.controller");
@@ -34,22 +34,14 @@ namespace Castlebound.Tests.Player
 
             var attackToIdle = attackState.transitions[0];
 
-            Assert.IsTrue(attackToIdle.hasExitTime,
-                "Attack->Idle should keep exit-time flow for this animator graph to avoid one-and-done attack states.");
+            Assert.IsFalse(attackToIdle.hasExitTime,
+                "Loop-era attack should not rely on exit-time gate for Attack->Idle transitions.");
             Assert.LessOrEqual(attackToIdle.duration, 0.1f,
                 "Attack->Idle transition duration should be short to avoid hard-capping repeat attacks.");
 
-            var clip = attackState.motion as AnimationClip;
-            Assert.IsNotNull(clip, "Knight_Attack state must use an AnimationClip motion.");
-
-            var disableEvent = AnimationUtility.GetAnimationEvents(clip)
-                .FirstOrDefault(e => e.functionName == "DisableHitbox");
-            Assert.IsNotNull(disableEvent,
-                "Knight_Attack clip must include DisableHitbox event to close the hit window.");
-
-            var disableNormalizedTime = disableEvent.time / clip.length;
-            Assert.GreaterOrEqual(attackToIdle.exitTime, disableNormalizedTime,
-                "Attack->Idle exitTime must not start before DisableHitbox event; otherwise hitbox damage can be skipped.");
+            Assert.IsTrue(
+                attackToIdle.conditions.Any(c => c.parameter == "AttackLoopActive" && c.mode == AnimatorConditionMode.IfNot),
+                "Attack->Idle should be driven by AttackLoopActive=false in loop-era presentation.");
         }
     }
 }

--- a/Assets/_Project/_Tests/EditMode/Player/PlayerAttackAnimationSpeedContractsTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Player/PlayerAttackAnimationSpeedContractsTests.cs
@@ -17,8 +17,8 @@ namespace Castlebound.Tests.Player
 
             StringAssert.Contains("PlayerAttackAnimationDriver", source,
                 "PlayerController should delegate animator attack-speed updates to a dedicated component.");
-            StringAssert.Contains("attackAnimationDriver.ApplyAttackSpeed", source,
-                "PlayerController should invoke attackAnimationDriver.ApplyAttackSpeed(...) each frame/tick path.");
+            StringAssert.Contains("attackAnimationDriver.ApplyLoopPresentation", source,
+                "PlayerController should invoke attackAnimationDriver.ApplyLoopPresentation(...) each frame/tick path.");
         }
 
         [Test]

--- a/Assets/_Project/_Tests/EditMode/Player/PlayerAttackAnimationSpeedContractsTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Player/PlayerAttackAnimationSpeedContractsTests.cs
@@ -1,0 +1,54 @@
+using System.IO;
+using NUnit.Framework;
+
+namespace Castlebound.Tests.Player
+{
+    public class PlayerAttackAnimationSpeedContractsTests
+    {
+        private const string PlayerControllerPath =
+            "Assets/_Project/Scripts/_Project.Gameplay/Player/PlayerController.cs";
+        private const string AttackAnimationDriverPath =
+            "Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerAttackAnimationDriver.cs";
+
+        [Test]
+        public void PlayerController_DelegatesAttackAnimationSpeed_ToDedicatedDriver()
+        {
+            var source = File.ReadAllText(PlayerControllerPath);
+
+            StringAssert.Contains("PlayerAttackAnimationDriver", source,
+                "PlayerController should delegate animator attack-speed updates to a dedicated component.");
+            StringAssert.Contains("attackAnimationDriver.ApplyAttackSpeed", source,
+                "PlayerController should invoke attackAnimationDriver.ApplyAttackSpeed(...) each frame/tick path.");
+        }
+
+        [Test]
+        public void AttackAnimationDriver_Exists_WithAnimatorParameterContract()
+        {
+            Assert.That(File.Exists(AttackAnimationDriverPath), Is.True,
+                "A dedicated PlayerAttackAnimationDriver component should exist.");
+
+            var source = File.ReadAllText(AttackAnimationDriverPath);
+
+            StringAssert.Contains("[SerializeField] private string attackSpeedParameter", source,
+                "Driver should expose an animator float parameter name for attack speed.");
+            StringAssert.Contains("animator.SetFloat", source,
+                "Driver should apply attack speed through Animator.SetFloat.");
+        }
+
+        [Test]
+        public void AttackAnimationDriver_ClampsAnimationSpeedMultiplier()
+        {
+            Assert.That(File.Exists(AttackAnimationDriverPath), Is.True,
+                "Driver must exist before validating multiplier clamp contract.");
+
+            var source = File.ReadAllText(AttackAnimationDriverPath);
+
+            StringAssert.Contains("[SerializeField] private float minAttackSpeedMultiplier", source,
+                "Driver should define a minimum multiplier clamp.");
+            StringAssert.Contains("[SerializeField] private float maxAttackSpeedMultiplier", source,
+                "Driver should define a maximum multiplier clamp.");
+            StringAssert.Contains("Mathf.Clamp", source,
+                "Driver should clamp computed animation speed to a safe range.");
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Player/PlayerAttackAnimationSpeedContractsTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Player/PlayerAttackAnimationSpeedContractsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b6037f4722a34dad8d20a526624f78e7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/EditMode/Player/PlayerAttackAnimatorLoopContractsTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Player/PlayerAttackAnimatorLoopContractsTests.cs
@@ -1,0 +1,52 @@
+using System.IO;
+using NUnit.Framework;
+
+namespace Castlebound.Tests.Player
+{
+    public class PlayerAttackAnimatorLoopContractsTests
+    {
+        private const string PlayerAnimatorControllerPath =
+            "Assets/_Project/Art/Knight_Assets/Player.controller";
+
+        [Test]
+        public void PlayerAnimator_DefinesAttackLoopActiveBoolParameter()
+        {
+            var source = File.ReadAllText(PlayerAnimatorControllerPath);
+
+            StringAssert.Contains("- m_Name: AttackLoopActive", source,
+                "Player animator should define AttackLoopActive bool for loop-era attack presentation.");
+        }
+
+        [Test]
+        public void PlayerAnimator_DoesNotRequireAttackTriggerTransition()
+        {
+            var source = File.ReadAllText(PlayerAnimatorControllerPath);
+
+            var containsAttackTriggerCondition =
+                source.Contains("m_ConditionEvent: Attack\n") ||
+                source.Contains("m_ConditionEvent: Attack\r\n");
+            Assert.IsFalse(containsAttackTriggerCondition,
+                "Loop-era attack presentation should not depend on trigger-driven Idle->Attack transitions.");
+        }
+
+        [Test]
+        public void PlayerAnimator_ExitsAttackWithoutExitTimeGate()
+        {
+            var source = File.ReadAllText(PlayerAnimatorControllerPath);
+
+            StringAssert.DoesNotContain("m_HasExitTime: 1", source,
+                "Loop-era attack transitions should not be constrained by exit-time gates.");
+        }
+
+        [Test]
+        public void AttackClip_DoesNotOwnHitboxEvents()
+        {
+            var source = File.ReadAllText("Assets/_Project/Art/Knight_Assets/Knight_Attack.anim");
+
+            StringAssert.DoesNotContain("functionName: EnableHitbox", source,
+                "Hitbox window should be owned by PlayerAttackLoop, not animation events.");
+            StringAssert.DoesNotContain("functionName: DisableHitbox", source,
+                "Hitbox window should be owned by PlayerAttackLoop, not animation events.");
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Player/PlayerAttackAnimatorLoopContractsTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Player/PlayerAttackAnimatorLoopContractsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bc38422784344f2eafce2f58a9548380
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/EditMode/Player/PlayerAttackAuthorityOwnershipContractsTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Player/PlayerAttackAuthorityOwnershipContractsTests.cs
@@ -1,0 +1,57 @@
+using System.IO;
+using NUnit.Framework;
+
+namespace Castlebound.Tests.Player
+{
+    public class PlayerAttackAuthorityOwnershipContractsTests
+    {
+        private const string PlayerControllerPath =
+            "Assets/_Project/Scripts/_Project.Gameplay/Player/PlayerController.cs";
+        private const string AttackLoopPath =
+            "Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerAttackLoop.cs";
+
+        [Test]
+        public void PlayerController_DoesNotOwnAttackCooldownAuthority()
+        {
+            var source = File.ReadAllText(PlayerControllerPath);
+
+            StringAssert.DoesNotContain("PlayerAttackCooldownGate", source,
+                "Attack cooldown authority should move out of PlayerController.");
+            StringAssert.DoesNotContain("attackCooldownGate", source,
+                "PlayerController should not retain a cooldown gate field once attack authority lives in the loop runtime.");
+        }
+
+        [Test]
+        public void PlayerController_DoesNotExposeDirectAttackAuthorityMethods()
+        {
+            var source = File.ReadAllText(PlayerControllerPath);
+
+            StringAssert.DoesNotContain("TryTriggerAttack(", source,
+                "PlayerController should not own direct attack trigger authority.");
+            StringAssert.DoesNotContain("SetHitWindowActive(", source,
+                "PlayerController should not translate runtime attack phases into hitbox window authority.");
+        }
+
+        [Test]
+        public void PlayerAttackLoop_OwnsCooldownAuthorityInternally()
+        {
+            var source = File.ReadAllText(AttackLoopPath);
+
+            StringAssert.Contains("PlayerAttackCooldownGate", source,
+                "Attack loop runtime should own cooldown authority directly.");
+            StringAssert.Contains("TryConsume(", source,
+                "Attack loop runtime should consume cadence internally rather than relying on controller callbacks.");
+        }
+
+        [Test]
+        public void PlayerAttackLoop_DoesNotRequireExternalAttackCallbacks()
+        {
+            var source = File.ReadAllText(AttackLoopPath);
+
+            StringAssert.DoesNotContain("Func<bool> tryStartSwing", source,
+                "Attack loop runtime should not require an external attack callback once it owns cadence authority.");
+            StringAssert.DoesNotContain("Action<bool> setHitWindowActive", source,
+                "Attack loop runtime should expose hit-window state directly rather than pushing callbacks into the controller.");
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Player/PlayerAttackAuthorityOwnershipContractsTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Player/PlayerAttackAuthorityOwnershipContractsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8edae6be020e1174f987616d57beb73d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/EditMode/Player/PlayerAttackCadenceClockContractsTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Player/PlayerAttackCadenceClockContractsTests.cs
@@ -1,0 +1,29 @@
+using System.IO;
+using NUnit.Framework;
+
+namespace Castlebound.Tests.Player
+{
+    public class PlayerAttackCadenceClockContractsTests
+    {
+        private const string PlayerControllerPath =
+            "Assets/_Project/Scripts/_Project.Gameplay/Player/PlayerController.cs";
+
+        [Test]
+        public void PlayerController_UsesFixedStepClock_ForCooldownAuthority()
+        {
+            var source = File.ReadAllText(PlayerControllerPath);
+
+            StringAssert.Contains("attackCooldownGate.TryConsume(Time.fixedTime", source,
+                "Cooldown authority should use fixed-step time when attacks are processed from FixedUpdate.");
+        }
+
+        [Test]
+        public void PlayerController_DoesNotUseFrameClock_ForCooldownAuthority()
+        {
+            var source = File.ReadAllText(PlayerControllerPath);
+
+            StringAssert.DoesNotContain("attackCooldownGate.TryConsume(Time.time", source,
+                "Using frame clock in FixedUpdate attack authority can drop high-rate attempts under frame hitching.");
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Player/PlayerAttackCadenceClockContractsTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Player/PlayerAttackCadenceClockContractsTests.cs
@@ -5,25 +5,29 @@ namespace Castlebound.Tests.Player
 {
     public class PlayerAttackCadenceClockContractsTests
     {
-        private const string PlayerControllerPath =
-            "Assets/_Project/Scripts/_Project.Gameplay/Player/PlayerController.cs";
+        private const string PlayerAttackLoopPath =
+            "Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerAttackLoop.cs";
 
         [Test]
-        public void PlayerController_UsesFixedStepClock_ForCooldownAuthority()
+        public void PlayerAttackLoop_UsesInternalElapsedClock_ForCooldownAuthority()
         {
-            var source = File.ReadAllText(PlayerControllerPath);
+            var source = File.ReadAllText(PlayerAttackLoopPath);
 
-            StringAssert.Contains("attackCooldownGate.TryConsume(Time.fixedTime", source,
-                "Cooldown authority should use fixed-step time when attacks are processed from FixedUpdate.");
+            StringAssert.Contains("elapsedTime += deltaTime", source,
+                "Loop-owned cooldown authority should advance from the loop runtime clock.");
+            StringAssert.Contains("attackCooldownGate.TryConsume(elapsedTime", source,
+                "Cooldown authority should consume against the loop's internal elapsed clock.");
         }
 
         [Test]
-        public void PlayerController_DoesNotUseFrameClock_ForCooldownAuthority()
+        public void PlayerAttackLoop_DoesNotDependOnControllerTimeSources_ForCooldownAuthority()
         {
-            var source = File.ReadAllText(PlayerControllerPath);
+            var source = File.ReadAllText(PlayerAttackLoopPath);
 
-            StringAssert.DoesNotContain("attackCooldownGate.TryConsume(Time.time", source,
-                "Using frame clock in FixedUpdate attack authority can drop high-rate attempts under frame hitching.");
+            StringAssert.DoesNotContain("Time.fixedTime", source,
+                "Loop-owned cadence should not depend on controller-owned fixed time.");
+            StringAssert.DoesNotContain("Time.time", source,
+                "Loop-owned cadence should not depend on frame time sources.");
         }
     }
 }

--- a/Assets/_Project/_Tests/EditMode/Player/PlayerAttackCadenceClockContractsTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Player/PlayerAttackCadenceClockContractsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7027c4d0418d4f4da3156752201fc5f2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/EditMode/Player/PlayerAttackInputTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Player/PlayerAttackInputTests.cs
@@ -9,9 +9,9 @@ namespace Castlebound.Tests.Player
     /// The full OnFire(InputValue) path — including the value.isPressed guard
     /// added to prevent double-trigger on release — requires Input System fixtures
     /// and should be covered in a PlayMode test. Specifically verify:
-    ///   - SetTrigger("Attack") fires exactly once per pulse (not on release).
+    ///   - Held-fire intent is ignored while inputLocked is true.
     ///   - No attack when inputLocked is true.
-    ///   - Attack rate matches MobileInputDriver.baseAttackRate over several seconds.
+    ///   - Android held-fire intent remains active while the virtual right trigger is held.
     /// </summary>
     public class PlayerAttackInputTests
     {

--- a/Assets/_Project/_Tests/EditMode/Player/PlayerAttackLoopTimingTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Player/PlayerAttackLoopTimingTests.cs
@@ -71,33 +71,28 @@ namespace Castlebound.Tests.Player
         }
 
         [Test]
-        public void HeldIntent_DoesNotDropLoopActive_WhenCooldownTemporarilyDenied()
+        public void HeldIntent_RemainsActive_AcrossChainBoundary()
         {
-            loop.Tick(0f, 5f, true, () => true, null);
+            loop.Tick(0f, 5f, true);
             var firstSwingDuration = loop.CurrentSwingDuration;
 
-            // Complete one swing while start of next is denied.
-            loop.Tick(firstSwingDuration + 0.001f, 5f, true, () => false, null);
+            loop.Tick(firstSwingDuration + 0.001f, 5f, true);
 
             Assert.IsTrue(loop.IsSwingActive,
-                "Loop should remain active while held even if next swing cannot start on this tick.");
+                "Loop should remain active while held across chained swing boundaries.");
+            Assert.GreaterOrEqual(loop.CompletedSwingCount, 1,
+                "Held cadence should complete at least one swing before continuing into the next.");
         }
 
         [Test]
-        public void HeldIntent_RecoversWithoutIdlePulse_WhenStartBecomesAvailable()
+        public void HeldIntent_ContinuesWithoutIdlePulse_OverMultipleTicks()
         {
-            loop.Tick(0f, 5f, true, () => true, null);
-            var firstSwingDuration = loop.CurrentSwingDuration;
+            loop.Tick(0f, 5f, true);
+            for (var i = 0; i < 8; i++)
+                loop.Tick(0.05f, 5f, true);
 
-            // First attempt to chain is denied.
-            loop.Tick(firstSwingDuration + 0.001f, 5f, true, () => false, null);
             Assert.IsTrue(loop.IsSwingActive,
-                "Loop should stay active during temporary denial.");
-
-            // Next tick allows chaining; should continue active without idle pulse.
-            loop.Tick(0.01f, 5f, true, () => true, null);
-            Assert.IsTrue(loop.IsSwingActive,
-                "Loop should continue active once chaining is available again.");
+                "Loop should continue active across multiple ticks while held.");
         }
 
     }

--- a/Assets/_Project/_Tests/EditMode/Player/PlayerAttackLoopTimingTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Player/PlayerAttackLoopTimingTests.cs
@@ -1,0 +1,104 @@
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Castlebound.Tests.Player
+{
+    public class PlayerAttackLoopTimingTests
+    {
+        private GameObject root;
+        private PlayerAttackLoop loop;
+
+        [SetUp]
+        public void SetUp()
+        {
+            root = new GameObject("PlayerAttackLoop");
+            loop = root.AddComponent<PlayerAttackLoop>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(root);
+        }
+
+        [Test]
+        public void HeldFire_ChainsBackToBackWithoutIdleGap()
+        {
+            loop.Tick(0f, 2f, true);
+            loop.Tick(1.1f, 2f, true);
+
+            Assert.GreaterOrEqual(loop.CompletedSwingCount, 2,
+                "Held fire should chain swings without idle gaps.");
+            Assert.IsTrue(loop.IsSwingActive,
+                "Loop should still be in an active swing while held.");
+        }
+
+        [Test]
+        public void HigherEffectiveRate_ShortensTotalSwingDuration()
+        {
+            loop.Tick(0f, 1f, true);
+            var rateOneDuration = loop.CurrentSwingDuration;
+
+            loop.ResetLoopState();
+            loop.Tick(0f, 2f, true);
+            var rateTwoDuration = loop.CurrentSwingDuration;
+
+            Assert.Less(rateTwoDuration, rateOneDuration,
+                "Higher effective rate should shorten total swing duration.");
+        }
+
+        [Test]
+        public void MinSwingDuration_ClampsExtremeRates()
+        {
+            loop.Tick(0f, 100f, true);
+
+            Assert.That(loop.CurrentSwingDuration, Is.EqualTo(loop.MinSwingDuration).Within(0.001f),
+                "Extreme rates should clamp to minimum swing duration.");
+        }
+
+        [Test]
+        public void ReleaseStopsChaining_AfterCurrentSwing()
+        {
+            loop.Tick(0f, 2f, true);
+            var firstSwingDuration = loop.CurrentSwingDuration;
+
+            loop.Tick(firstSwingDuration + 0.05f, 2f, false);
+
+            Assert.AreEqual(1, loop.CompletedSwingCount,
+                "Release should allow current swing to finish, then stop chaining.");
+            Assert.IsFalse(loop.IsSwingActive,
+                "Loop should return to idle after finishing current swing on release.");
+        }
+
+        [Test]
+        public void HeldIntent_DoesNotDropLoopActive_WhenCooldownTemporarilyDenied()
+        {
+            loop.Tick(0f, 5f, true, () => true, null);
+            var firstSwingDuration = loop.CurrentSwingDuration;
+
+            // Complete one swing while start of next is denied.
+            loop.Tick(firstSwingDuration + 0.001f, 5f, true, () => false, null);
+
+            Assert.IsTrue(loop.IsSwingActive,
+                "Loop should remain active while held even if next swing cannot start on this tick.");
+        }
+
+        [Test]
+        public void HeldIntent_RecoversWithoutIdlePulse_WhenStartBecomesAvailable()
+        {
+            loop.Tick(0f, 5f, true, () => true, null);
+            var firstSwingDuration = loop.CurrentSwingDuration;
+
+            // First attempt to chain is denied.
+            loop.Tick(firstSwingDuration + 0.001f, 5f, true, () => false, null);
+            Assert.IsTrue(loop.IsSwingActive,
+                "Loop should stay active during temporary denial.");
+
+            // Next tick allows chaining; should continue active without idle pulse.
+            loop.Tick(0.01f, 5f, true, () => true, null);
+            Assert.IsTrue(loop.IsSwingActive,
+                "Loop should continue active once chaining is available again.");
+        }
+
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Player/PlayerAttackLoopTimingTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Player/PlayerAttackLoopTimingTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f1a4034d7b644026bacd59540328b85d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/EditMode/Player/PlayerAttackSingleClockContractsTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Player/PlayerAttackSingleClockContractsTests.cs
@@ -1,0 +1,62 @@
+using System.IO;
+using NUnit.Framework;
+
+namespace Castlebound.Tests.Player
+{
+    public class PlayerAttackSingleClockContractsTests
+    {
+        private const string PlayerControllerPath =
+            "Assets/_Project/Scripts/_Project.Gameplay/Player/PlayerController.cs";
+        private const string AttackLoopPath =
+            "Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerAttackLoop.cs";
+        private const string AttackAnimationDriverPath =
+            "Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerAttackAnimationDriver.cs";
+
+        [Test]
+        public void PlayerController_DoesNotUseAnimatorTrigger_AsCadenceAuthority()
+        {
+            var source = File.ReadAllText(PlayerControllerPath);
+
+            StringAssert.DoesNotContain("SetTrigger(\"Attack\")", source,
+                "Cadence should be owned by PlayerAttackLoop single clock, not Animator trigger pulses.");
+        }
+
+        [Test]
+        public void AttackAnimationDriver_ExposesLoopDrivenPresentationContract()
+        {
+            var source = File.ReadAllText(AttackAnimationDriverPath);
+
+            StringAssert.Contains("ApplyLoopPresentation", source,
+                "Animation driver should expose a loop-driven presentation method.");
+            StringAssert.Contains("normalizedSwingProgress", source,
+                "Presentation contract should accept normalized loop timing for deterministic visual sync.");
+        }
+
+        [Test]
+        public void AttackAnimationDriver_DoesNotEmitPerSwingAttackTrigger()
+        {
+            var source = File.ReadAllText(AttackAnimationDriverPath);
+
+            StringAssert.DoesNotContain("SetTrigger(", source,
+                "Looped high-rate presentation should not emit per-swing attack triggers.");
+        }
+
+        [Test]
+        public void AttackLoop_ExposesNormalizedSwingProgress()
+        {
+            var source = File.ReadAllText(AttackLoopPath);
+
+            StringAssert.Contains("NormalizedSwingProgress", source,
+                "Single-clock loop should expose normalized swing progress for presentation followers.");
+        }
+
+        [Test]
+        public void PlayerController_DelegatesLoopPresentation_ToAnimationDriver()
+        {
+            var source = File.ReadAllText(PlayerControllerPath);
+
+            StringAssert.Contains("attackAnimationDriver.ApplyLoopPresentation", source,
+                "PlayerController should delegate loop presentation to the animation driver.");
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Player/PlayerAttackSingleClockContractsTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Player/PlayerAttackSingleClockContractsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b3a80f06b2084cd5b6d962da6e70d9f9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/EditMode/Player/PlayerAttackWindowTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Player/PlayerAttackWindowTests.cs
@@ -1,0 +1,58 @@
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Castlebound.Tests.Player
+{
+    public class PlayerAttackWindowTests
+    {
+        private GameObject root;
+        private PlayerAttackLoop loop;
+
+        [SetUp]
+        public void SetUp()
+        {
+            root = new GameObject("PlayerAttackLoop");
+            loop = root.AddComponent<PlayerAttackLoop>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(root);
+        }
+
+        [Test]
+        public void HitWindow_OpensDuringActivePhase()
+        {
+            loop.Tick(0f, 1f, true);
+
+            loop.Tick(loop.CurrentWindupDuration * 0.9f, 1f, true);
+            Assert.IsFalse(loop.IsHitWindowOpen, "Hit window should not open during windup.");
+
+            loop.Tick(loop.CurrentWindupDuration * 0.2f, 1f, true);
+            Assert.IsTrue(loop.IsHitWindowOpen, "Hit window should open when entering active phase.");
+        }
+
+        [Test]
+        public void HitWindow_ClosesAtActivePhaseEnd()
+        {
+            loop.Tick(0f, 1f, true);
+            loop.Tick(loop.CurrentWindupDuration + (loop.CurrentActiveDuration * 0.5f), 1f, true);
+            Assert.IsTrue(loop.IsHitWindowOpen, "Hit window should be open mid-active phase.");
+
+            loop.Tick(loop.CurrentActiveDuration, 1f, true);
+            Assert.IsFalse(loop.IsHitWindowOpen, "Hit window should close after active phase ends.");
+        }
+
+        [Test]
+        public void HitWindow_DoesNotOpenOutsideActivePhase()
+        {
+            loop.Tick(0f, 1f, false);
+            Assert.IsFalse(loop.IsHitWindowOpen, "Hit window should be closed while idle.");
+
+            loop.Tick(0f, 1f, true);
+            loop.Tick(loop.CurrentWindupDuration + loop.CurrentActiveDuration + 0.001f, 1f, true);
+            Assert.IsFalse(loop.IsHitWindowOpen, "Hit window should be closed in recovery.");
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Player/PlayerAttackWindowTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Player/PlayerAttackWindowTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 78c25e7f0b7c41ce9a62632d3a4dfc99
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/PlayMode/Combat/PlayerAttackDamagePlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/Combat/PlayerAttackDamagePlayTests.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Reflection;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -66,6 +67,32 @@ namespace Castlebound.Tests.PlayMode.Combat
             Object.Destroy(secondEnemy);
         }
 
+        [UnityTest]
+        public IEnumerator HighRateHeldFire_StillDealsRepeatedDamage_WhenSwingIsShorterThanFixedStep()
+        {
+            yield return LoadMainPrototype();
+
+            var player = Object.FindObjectOfType<PlayerController>();
+            Assert.NotNull(player, "Expected PlayerController in MainPrototype.");
+
+            SetPlayerBaseAttackRate(player, 30f);
+
+            var enemy = SpawnEnemyAtPlayerHitbox(player);
+            var health = enemy.GetComponent<Health>();
+            Assert.NotNull(health, "Spawned enemy must have Health.");
+
+            var before = health.Current;
+            SetHeldFire(player, true);
+            yield return WaitForDamageAmountOrTimeout(player, enemy, health, before, 2, 0.5f);
+            SetHeldFire(player, false);
+
+            Assert.LessOrEqual(health.Current, before - 2,
+                "High-rate held fire should still apply repeated damage even when a full swing compresses below one fixed step.");
+
+            Object.Destroy(enemy);
+        }
+
+
         private static IEnumerator LoadMainPrototype()
         {
             var load = SceneManager.LoadSceneAsync("MainPrototype", LoadSceneMode.Single);
@@ -124,6 +151,34 @@ namespace Castlebound.Tests.PlayMode.Combat
             }
         }
 
+        private static IEnumerator WaitForDamageAmountOrTimeout(
+            PlayerController player,
+            GameObject enemy,
+            Health enemyHealth,
+            int initialHealth,
+            int requiredDamage,
+            float timeoutSeconds)
+        {
+            var hitbox = player.GetComponentInChildren<Hitbox>(true);
+            Assert.NotNull(hitbox, "Player must have a Hitbox child.");
+
+            var end = Time.realtimeSinceStartup + timeoutSeconds;
+            while (Time.realtimeSinceStartup < end)
+            {
+                if (enemy != null)
+                {
+                    enemy.transform.position = hitbox.transform.position;
+                    Physics2D.SyncTransforms();
+                }
+
+                if (enemyHealth != null && initialHealth - enemyHealth.Current >= requiredDamage)
+                    yield break;
+
+                yield return null;
+            }
+        }
+
+
         private static void SetHeldFire(PlayerController player, bool isHeld)
         {
             var fireInput = player.GetComponent<PlayerFireInputController>();
@@ -131,6 +186,14 @@ namespace Castlebound.Tests.PlayMode.Combat
             if (isHeld)
                 fireInput.Configure(null, () => true);
             fireInput.OnFirePressedStateChanged(isHeld);
+        }
+
+        private static void SetPlayerBaseAttackRate(PlayerController player, float attackRate)
+        {
+            const BindingFlags flags = BindingFlags.Instance | BindingFlags.NonPublic;
+            var field = typeof(PlayerController).GetField("baseAttackRate", flags);
+            Assert.NotNull(field, "PlayerController.baseAttackRate field was not found.");
+            field.SetValue(player, attackRate);
         }
     }
 }

--- a/Assets/_Project/_Tests/PlayMode/Combat/PlayerAttackDamagePlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/Combat/PlayerAttackDamagePlayTests.cs
@@ -22,9 +22,9 @@ namespace Castlebound.Tests.PlayMode.Combat
             Assert.NotNull(health, "Spawned enemy must have Health.");
 
             var before = health.Current;
-
-            player.animator.SetTrigger("Attack");
+            SetHeldFire(player, true);
             yield return WaitForDamageOrTimeout(player, enemy, health, before, 1.2f);
+            SetHeldFire(player, false);
 
             Assert.Less(health.Current, before,
                 "Attack animation should fire hitbox events and reduce enemy health.");
@@ -45,8 +45,9 @@ namespace Castlebound.Tests.PlayMode.Combat
             var firstHealth = firstEnemy.GetComponent<Health>();
             var firstBefore = firstHealth.Current;
 
-            player.animator.SetTrigger("Attack");
+            SetHeldFire(player, true);
             yield return WaitForDamageOrTimeout(player, firstEnemy, firstHealth, firstBefore, 1.2f);
+            SetHeldFire(player, false);
 
             Assert.Less(firstHealth.Current, firstBefore,
                 "First swing should damage the first enemy.");
@@ -56,8 +57,9 @@ namespace Castlebound.Tests.PlayMode.Combat
             var secondHealth = secondEnemy.GetComponent<Health>();
             var secondBefore = secondHealth.Current;
 
-            player.animator.SetTrigger("Attack");
+            SetHeldFire(player, true);
             yield return WaitForDamageOrTimeout(player, secondEnemy, secondHealth, secondBefore, 1.2f);
+            SetHeldFire(player, false);
 
             Assert.Less(secondHealth.Current, secondBefore,
                 "Second swing should still damage a new enemy (regression guard for one-and-done attack states).");
@@ -120,6 +122,15 @@ namespace Castlebound.Tests.PlayMode.Combat
 
                 yield return null;
             }
+        }
+
+        private static void SetHeldFire(PlayerController player, bool isHeld)
+        {
+            var fireInput = player.GetComponent<PlayerFireInputController>();
+            Assert.NotNull(fireInput, "Player must include PlayerFireInputController.");
+            if (isHeld)
+                fireInput.Configure(null, () => true);
+            fireInput.OnFirePressedStateChanged(isHeld);
         }
     }
 }

--- a/Assets/_Project/_Tests/PlayMode/Combat/PlayerAttackDamagePlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/Combat/PlayerAttackDamagePlayTests.cs
@@ -92,6 +92,30 @@ namespace Castlebound.Tests.PlayMode.Combat
             Object.Destroy(enemy);
         }
 
+        [UnityTest]
+        public IEnumerator SingleSwing_OnlyDamagesOverlappingEnemyOnce()
+        {
+            yield return LoadMainPrototype();
+
+            var player = Object.FindObjectOfType<PlayerController>();
+            Assert.NotNull(player, "Expected PlayerController in MainPrototype.");
+
+            var enemy = SpawnEnemyAtPlayerHitbox(player);
+            var health = enemy.GetComponent<Health>();
+            Assert.NotNull(health, "Spawned enemy must have Health.");
+
+            var before = health.Current;
+            SetHeldFire(player, true);
+            yield return WaitForDamageAmountOrTimeout(player, enemy, health, before, 1, 0.6f);
+            SetHeldFire(player, false);
+
+            yield return HoldEnemyInHitboxForDuration(player, enemy, 0.25f);
+
+            Assert.AreEqual(before - 1, health.Current,
+                "One sustained overlap during a single swing should only apply one hit to the same enemy.");
+
+            Object.Destroy(enemy);
+        }
 
         private static IEnumerator LoadMainPrototype()
         {
@@ -178,6 +202,26 @@ namespace Castlebound.Tests.PlayMode.Combat
             }
         }
 
+        private static IEnumerator HoldEnemyInHitboxForDuration(
+            PlayerController player,
+            GameObject enemy,
+            float durationSeconds)
+        {
+            var hitbox = player.GetComponentInChildren<Hitbox>(true);
+            Assert.NotNull(hitbox, "Player must have a Hitbox child.");
+
+            var end = Time.realtimeSinceStartup + durationSeconds;
+            while (Time.realtimeSinceStartup < end)
+            {
+                if (enemy != null)
+                {
+                    enemy.transform.position = hitbox.transform.position;
+                    Physics2D.SyncTransforms();
+                }
+
+                yield return null;
+            }
+        }
 
         private static void SetHeldFire(PlayerController player, bool isHeld)
         {

--- a/Assets/_Project/_Tests/PlayMode/Combat/PlayerAttackLoopIdleFlickerPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/Combat/PlayerAttackLoopIdleFlickerPlayTests.cs
@@ -1,0 +1,48 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Castlebound.Tests.PlayMode.Combat
+{
+    public class PlayerAttackLoopIdleFlickerPlayTests
+    {
+        [UnityTest]
+        public IEnumerator HeldAttack_DoesNotPulseIdle_WhenCooldownDeniesSingleTick()
+        {
+            var root = new GameObject("PlayerAttackLoop");
+            var loop = root.AddComponent<PlayerAttackLoop>();
+
+            bool denyThisTick = false;
+            bool TryStartSwing()
+            {
+                if (denyThisTick)
+                {
+                    denyThisTick = false;
+                    return false;
+                }
+
+                return true;
+            }
+
+            loop.Tick(0f, 5f, true, TryStartSwing, null);
+            float firstSwing = loop.CurrentSwingDuration;
+
+            // Deny exactly once at chain boundary.
+            denyThisTick = true;
+            loop.Tick(firstSwing + 0.001f, 5f, true, TryStartSwing, null);
+            Assert.IsTrue(loop.IsSwingActive,
+                "Loop should remain active during a one-tick cooldown denial while held.");
+
+            for (int i = 0; i < 5; i++)
+            {
+                loop.Tick(0.01f, 5f, true, TryStartSwing, null);
+                Assert.IsTrue(loop.IsSwingActive,
+                    "Held attack should not pulse to idle between chained swings.");
+                yield return null;
+            }
+
+            Object.Destroy(root);
+        }
+    }
+}

--- a/Assets/_Project/_Tests/PlayMode/Combat/PlayerAttackLoopIdleFlickerPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/Combat/PlayerAttackLoopIdleFlickerPlayTests.cs
@@ -8,35 +8,21 @@ namespace Castlebound.Tests.PlayMode.Combat
     public class PlayerAttackLoopIdleFlickerPlayTests
     {
         [UnityTest]
-        public IEnumerator HeldAttack_DoesNotPulseIdle_WhenCooldownDeniesSingleTick()
+        public IEnumerator HeldAttack_DoesNotPulseIdle_BetweenChainedSwings()
         {
             var root = new GameObject("PlayerAttackLoop");
             var loop = root.AddComponent<PlayerAttackLoop>();
 
-            bool denyThisTick = false;
-            bool TryStartSwing()
-            {
-                if (denyThisTick)
-                {
-                    denyThisTick = false;
-                    return false;
-                }
-
-                return true;
-            }
-
-            loop.Tick(0f, 5f, true, TryStartSwing, null);
+            loop.Tick(0f, 5f, true);
             float firstSwing = loop.CurrentSwingDuration;
 
-            // Deny exactly once at chain boundary.
-            denyThisTick = true;
-            loop.Tick(firstSwing + 0.001f, 5f, true, TryStartSwing, null);
+            loop.Tick(firstSwing + 0.001f, 5f, true);
             Assert.IsTrue(loop.IsSwingActive,
-                "Loop should remain active during a one-tick cooldown denial while held.");
+                "Loop should remain active through a chained swing boundary while held.");
 
             for (int i = 0; i < 5; i++)
             {
-                loop.Tick(0.01f, 5f, true, TryStartSwing, null);
+                loop.Tick(0.01f, 5f, true);
                 Assert.IsTrue(loop.IsSwingActive,
                     "Held attack should not pulse to idle between chained swings.");
                 yield return null;

--- a/Assets/_Project/_Tests/PlayMode/Combat/PlayerAttackLoopIdleFlickerPlayTests.cs.meta
+++ b/Assets/_Project/_Tests/PlayMode/Combat/PlayerAttackLoopIdleFlickerPlayTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8f6b77010ec54050aca881f11c6329d9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/PlayMode/Combat/PlayerHighRateCadenceConsistencyPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/Combat/PlayerHighRateCadenceConsistencyPlayTests.cs
@@ -1,0 +1,142 @@
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Castlebound.Tests.PlayMode.Combat
+{
+    public class PlayerHighRateCadenceConsistencyPlayTests
+    {
+        [UnityTest]
+        public IEnumerator Rate10_ProducesStableIntervals_OverTimeWindow()
+        {
+            var root = new GameObject("PlayerAttackLoop");
+            var loop = root.AddComponent<PlayerAttackLoop>();
+
+            var intervals = new List<float>();
+            float simTime = 0f;
+            float lastCompletionTime = -1f;
+            int lastCompleted = 0;
+            const float dt = 0.01f;
+
+            while (simTime < 2.5f)
+            {
+                loop.Tick(dt, 10f, true);
+                simTime += dt;
+
+                if (loop.CompletedSwingCount > lastCompleted)
+                {
+                    for (int i = lastCompleted; i < loop.CompletedSwingCount; i++)
+                    {
+                        if (lastCompletionTime >= 0f)
+                            intervals.Add(simTime - lastCompletionTime);
+                        lastCompletionTime = simTime;
+                    }
+
+                    lastCompleted = loop.CompletedSwingCount;
+                }
+
+                yield return null;
+            }
+
+            Assert.GreaterOrEqual(intervals.Count, 18, "Expected enough swing completions to evaluate cadence stability.");
+            Assert.That(Mean(intervals), Is.EqualTo(0.1f).Within(0.03f),
+                "Medium-rate cadence should remain near expected interval.");
+            Assert.Less(Max(intervals) - Min(intervals), 0.06f,
+                "Cadence intervals should remain reasonably stable at medium rate.");
+
+            Object.Destroy(root);
+        }
+
+        [UnityTest]
+        public IEnumerator Rate20_ProducesStableIntervals_WithoutTwoSwingDrift()
+        {
+            var root = new GameObject("PlayerAttackLoop");
+            var loop = root.AddComponent<PlayerAttackLoop>();
+
+            var intervals = new List<float>();
+            float simTime = 0f;
+            float lastCompletionTime = -1f;
+            int lastCompleted = 0;
+            const float dt = 0.005f;
+
+            while (simTime < 2f)
+            {
+                loop.Tick(dt, 20f, true);
+                simTime += dt;
+
+                if (loop.CompletedSwingCount > lastCompleted)
+                {
+                    for (int i = lastCompleted; i < loop.CompletedSwingCount; i++)
+                    {
+                        if (lastCompletionTime >= 0f)
+                            intervals.Add(simTime - lastCompletionTime);
+                        lastCompletionTime = simTime;
+                    }
+
+                    lastCompleted = loop.CompletedSwingCount;
+                }
+
+                yield return null;
+            }
+
+            Assert.GreaterOrEqual(intervals.Count, 25, "Expected enough high-rate completions for drift validation.");
+            Assert.That(Mean(intervals), Is.EqualTo(0.05f).Within(0.015f),
+                "High-rate cadence should remain near expected interval.");
+            Assert.Less(Max(intervals), 0.08f,
+                "High-rate cadence should not drift into periodic long gaps.");
+
+            Object.Destroy(root);
+        }
+
+        [UnityTest]
+        public IEnumerator HoldRelease_StopsFurtherSwingsPromptly()
+        {
+            var root = new GameObject("PlayerAttackLoop");
+            var loop = root.AddComponent<PlayerAttackLoop>();
+
+            for (int i = 0; i < 30; i++)
+            {
+                loop.Tick(0.01f, 4f, true);
+                yield return null;
+            }
+
+            var atRelease = loop.CompletedSwingCount;
+            for (int i = 0; i < 40; i++)
+            {
+                loop.Tick(0.01f, 4f, false);
+                yield return null;
+            }
+
+            Assert.LessOrEqual(loop.CompletedSwingCount, atRelease + 1,
+                "Release should stop further chaining after at most the in-flight swing.");
+
+            Object.Destroy(root);
+        }
+
+        private static float Mean(List<float> values)
+        {
+            float sum = 0f;
+            for (int i = 0; i < values.Count; i++)
+                sum += values[i];
+            return values.Count > 0 ? sum / values.Count : 0f;
+        }
+
+        private static float Min(List<float> values)
+        {
+            float min = float.MaxValue;
+            for (int i = 0; i < values.Count; i++)
+                min = Mathf.Min(min, values[i]);
+            return values.Count > 0 ? min : 0f;
+        }
+
+        private static float Max(List<float> values)
+        {
+            float max = float.MinValue;
+            for (int i = 0; i < values.Count; i++)
+                max = Mathf.Max(max, values[i]);
+            return values.Count > 0 ? max : 0f;
+        }
+    }
+}

--- a/Assets/_Project/_Tests/PlayMode/Combat/PlayerHighRateCadenceConsistencyPlayTests.cs.meta
+++ b/Assets/_Project/_Tests/PlayMode/Combat/PlayerHighRateCadenceConsistencyPlayTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 68d4348129c743a78bfe92d84e76677d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,29 @@
 
 ---
 
+## 2026-03-18 - feat(combat): high-rate cadence contracts (#148/#149/#150)
+
+### Summary
+- Moved attack cadence authority into `PlayerAttackLoop` so `PlayerController` remains orchestration-focused.
+- Preserved hit delivery for compressed high-rate swings and fixed the same-swing multi-hit regression on overlapping enemies.
+- Removed stale mobile attack-rate wiring so Android input now forwards held intent only while combat runtime owns cadence.
+
+### New or Updated Tests
+**EditMode**
+- `PlayerAttackAuthorityOwnershipContractsTests` — verifies attack cooldown authority moved out of `PlayerController` and into `PlayerAttackLoop`.
+- `PlayerAttackCadenceClockContractsTests` — verifies loop-owned cadence uses internal elapsed time instead of controller time sources.
+- `PlayerHoldFireContractsTests` — verifies `PlayerController` keeps held-fire intent delegated through `PlayerFireInputController` and into `PlayerAttackLoop`.
+- `PlayerAttackLoopTimingTests` — verifies chained swing timing, release behavior, and no-idle chaining across sustained held fire.
+- `MobileInputDriverOwnershipContractsTests` — verifies `MobileInputDriver` no longer exposes attack-rate APIs and `PlayerController` no longer syncs cadence into mobile input.
+
+**PlayMode**
+- `PlayerHighRateCadenceConsistencyPlayTests` — verifies stable loop cadence across sustained high-rate attack windows.
+- `PlayerAttackDamagePlayTests` — verifies compressed high-rate swings still deal repeated damage across swings without allowing same-swing multi-hit overlap.
+- `PlayerAttackLoopIdleFlickerPlayTests` — verifies held attack presentation does not pulse to idle between chained swings.
+
+### Notes
+- Manual validation confirmed PC and Android hold-fire paths still function, high-rate attacks remain responsive, and unarmed attacks return to one damage per swing.
+
 ## 2026-03-06 - feat(input): movement-first facing with conditional aim override (#153)
 
 ### Summary


### PR DESCRIPTION
## Why
High attack-speed values were being bottlenecked by input/event timing, one-frame mobile pulses, and animation-driven attack flow. Combat cadence needed to become runtime-authoritative so higher tiers produce real throughput without dropped swings, silent presentation caps, or repeated same-swing hit bugs.

## What changed
- Moved attack cadence authority into `PlayerAttackLoop` so combat throughput scales beyond click cadence
- Reworked attack presentation so animation follows runtime cadence instead of owning it
- Switched Android/mobile fire input to held right-trigger intent instead of pulse/timer-driven cadence
- Added EditMode and PlayMode regressions for cadence ownership, mobile hold-fire, high-rate runtime cadence, and chained attack stability
- Fixed compressed high-rate hit delivery so short swings still land damage
- Fixed repeated same-swing hitbox damage discovered during validation
- Updated `TEST_LOG` and clarified hitbox runtime comments

## How to test
1. Open `MainPrototype`
2. Press Play and verify low / normal / high attack-speed behavior still attacks correctly
3. Verify PC hold-fire and Android held-fire still work, and overlapping enemies only take one hit per swing
4. Run tests:
   - EditMode
   - PlayMode

## Checklist

- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated (if player-visible) - N/A
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched (if applicable)

## Related
- Closes #148
- Closes #149
- Closes #150
- Refs #156
- Refs #157