### PR TITLE
Feat/tower runtime core

### DIFF
--- a/Assets/_Project/Prefabs/Tower.prefab
+++ b/Assets/_Project/Prefabs/Tower.prefab
@@ -1,0 +1,299 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2000000000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2000000001}
+  - component: {fileID: 2000000002}
+  - component: {fileID: 2000000003}
+  m_Layer: 0
+  m_Name: Tower
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2000000001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2000000000}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2000000011}
+  - {fileID: 2000000031}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &2000000002
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2000000000}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 2.5, y: 2.5}
+  m_EdgeRadius: 0
+--- !u!114 &2000000003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2000000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8ec82cd20e3b4088a853d04a374353fa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  maxHealth: 10
+  currentHealth: 10
+  aimPivot: {fileID: 2000000011}
+  towerVisual: {fileID: 2000000021}
+  platformVisual: {fileID: 2000000031}
+--- !u!1 &2000000010
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2000000011}
+  m_Layer: 0
+  m_Name: AimPivot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2000000011
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2000000010}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2000000021}
+  m_Father: {fileID: 2000000001}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2000000020
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2000000021}
+  - component: {fileID: 2000000022}
+  m_Layer: 0
+  m_Name: TowerVisual
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2000000021
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2000000020}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.75, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2000000011}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &2000000022
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2000000020}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 1
+  m_Sprite: {fileID: 21300000, guid: a85120fb50560e4448e516b378dec303, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.64, y: 0.64}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!1 &2000000030
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2000000031}
+  - component: {fileID: 2000000032}
+  m_Layer: 0
+  m_Name: PlatformVisual
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2000000031
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2000000030}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: -0.15, z: 0}
+  m_LocalScale: {x: 2.2, y: 2.2, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2000000001}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &2000000032
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2000000030}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 9bb08e864bf06a248aa24eaadea88105, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.64, y: 0.64}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0

--- a/Assets/_Project/Prefabs/Tower.prefab.meta
+++ b/Assets/_Project/Prefabs/Tower.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ec470124d4d042388418a66cedd418c1
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/_Project.Gameplay/Tower.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Tower.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f385c9868e554eafaadb169c1129fc87
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerRuntime.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerRuntime.cs
@@ -1,0 +1,85 @@
+using UnityEngine;
+
+namespace Castlebound.Gameplay.Tower
+{
+    public class TowerRuntime : MonoBehaviour
+    {
+        [SerializeField] private int maxHealth = 10;
+        [SerializeField] private int currentHealth = 10;
+        [SerializeField] private Transform aimPivot;
+        [SerializeField] private Transform towerVisual;
+        [SerializeField] private Transform platformVisual;
+
+        public int MaxHealth => maxHealth;
+        public int CurrentHealth => currentHealth;
+        public Transform AimPivot
+        {
+            get
+            {
+                EnsureReferences();
+                return aimPivot;
+            }
+        }
+
+        public Transform TowerVisual
+        {
+            get
+            {
+                EnsureReferences();
+                return towerVisual;
+            }
+        }
+
+        public Transform PlatformVisual
+        {
+            get
+            {
+                EnsureReferences();
+                return platformVisual;
+            }
+        }
+
+        private void Reset()
+        {
+            maxHealth = Mathf.Max(1, maxHealth);
+            currentHealth = maxHealth;
+            EnsureReferences();
+        }
+
+        private void Awake()
+        {
+            NormalizeState();
+            EnsureReferences();
+        }
+
+        private void OnValidate()
+        {
+            NormalizeState();
+            EnsureReferences();
+        }
+
+        private void NormalizeState()
+        {
+            maxHealth = Mathf.Max(1, maxHealth);
+            currentHealth = Mathf.Clamp(currentHealth, 1, maxHealth);
+        }
+
+        private void EnsureReferences()
+        {
+            if (aimPivot == null)
+            {
+                aimPivot = transform.Find("AimPivot");
+            }
+
+            if (towerVisual == null && aimPivot != null)
+            {
+                towerVisual = aimPivot.Find("TowerVisual");
+            }
+
+            if (platformVisual == null)
+            {
+                platformVisual = transform.Find("PlatformVisual");
+            }
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerRuntime.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerRuntime.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8ec82cd20e3b4088a853d04a374353fa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/EditMode/Tower.meta
+++ b/Assets/_Project/_Tests/EditMode/Tower.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3fe6b5f204ed4dbaa3881cd16f33d9a4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/EditMode/Tower/TowerRuntimeContractTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Tower/TowerRuntimeContractTests.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using Castlebound.Gameplay.Tower;
 using UnityEngine;
 
 namespace Castlebound.Tests.Tower
@@ -44,6 +45,30 @@ namespace Castlebound.Tests.Tower
                 var platformVisual = FindChildRecursive(prefabRoot.transform, "PlatformVisual");
                 Assert.NotNull(platformVisual, "Tower prefab must include a PlatformVisual child.");
                 Assert.AreEqual(prefabRoot.transform, platformVisual.parent, "PlatformVisual should remain directly under the tower root.");
+            }
+            finally
+            {
+                PrefabTestUtil.Unload(prefabRoot);
+            }
+        }
+
+        [Test]
+        public void TowerPrefab_SerializesRuntimeReferences_ToApprovedChildren()
+        {
+            var prefabRoot = PrefabTestUtil.Load(TowerPrefabPath);
+
+            try
+            {
+                var runtime = prefabRoot.GetComponent<TowerRuntime>();
+                Assert.NotNull(runtime, "Tower prefab must include TowerRuntime.");
+
+                var aimPivot = FindChildRecursive(prefabRoot.transform, "AimPivot");
+                var towerVisual = FindChildRecursive(prefabRoot.transform, "TowerVisual");
+                var platformVisual = FindChildRecursive(prefabRoot.transform, "PlatformVisual");
+
+                Assert.AreSame(aimPivot, runtime.AimPivot, "TowerRuntime AimPivot should serialize to the AimPivot child.");
+                Assert.AreSame(towerVisual, runtime.TowerVisual, "TowerRuntime TowerVisual should serialize to the TowerVisual child.");
+                Assert.AreSame(platformVisual, runtime.PlatformVisual, "TowerRuntime PlatformVisual should serialize to the PlatformVisual child.");
             }
             finally
             {

--- a/Assets/_Project/_Tests/EditMode/Tower/TowerRuntimeContractTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Tower/TowerRuntimeContractTests.cs
@@ -1,0 +1,67 @@
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Castlebound.Tests.Tower
+{
+    public class TowerRuntimeContractTests
+    {
+        private const string TowerPrefabPath = "Assets/_Project/Prefabs/Tower.prefab";
+
+        [Test]
+        public void TowerPrefab_ProvidesNormalizedRootAndRuntimeStateContract()
+        {
+            var prefabRoot = PrefabTestUtil.Load(TowerPrefabPath);
+
+            try
+            {
+                Assert.That(
+                    prefabRoot.transform.localScale,
+                    Is.EqualTo(Vector3.one),
+                    "Tower prefab root must remain normalized at scale (1,1,1).");
+
+                var runtime = prefabRoot.GetComponent("TowerRuntime");
+                Assert.NotNull(runtime, "Tower prefab must include TowerRuntime.");
+                Assert.NotNull(prefabRoot.GetComponent<Collider2D>(), "Tower prefab root must include a Collider2D.");
+
+                var maxHealthProperty = runtime.GetType().GetProperty("MaxHealth");
+                var currentHealthProperty = runtime.GetType().GetProperty("CurrentHealth");
+                Assert.NotNull(maxHealthProperty, "TowerRuntime must expose MaxHealth.");
+                Assert.NotNull(currentHealthProperty, "TowerRuntime must expose CurrentHealth.");
+
+                var maxHealth = (int)maxHealthProperty.GetValue(runtime);
+                var currentHealth = (int)currentHealthProperty.GetValue(runtime);
+
+                Assert.That(maxHealth, Is.GreaterThan(0), "TowerRuntime MaxHealth must initialize above zero.");
+                Assert.That(currentHealth, Is.EqualTo(maxHealth), "TowerRuntime should initialize at full health.");
+
+                var aimPivot = FindChildRecursive(prefabRoot.transform, "AimPivot");
+                Assert.NotNull(aimPivot, "Tower prefab must include an AimPivot child.");
+
+                var towerVisual = FindChildRecursive(prefabRoot.transform, "TowerVisual");
+                Assert.NotNull(towerVisual, "Tower prefab must include a TowerVisual child.");
+                Assert.IsTrue(towerVisual.IsChildOf(aimPivot), "TowerVisual should be parented under AimPivot for future rotation.");
+
+                var platformVisual = FindChildRecursive(prefabRoot.transform, "PlatformVisual");
+                Assert.NotNull(platformVisual, "Tower prefab must include a PlatformVisual child.");
+                Assert.AreEqual(prefabRoot.transform, platformVisual.parent, "PlatformVisual should remain directly under the tower root.");
+            }
+            finally
+            {
+                PrefabTestUtil.Unload(prefabRoot);
+            }
+        }
+
+        private static Transform FindChildRecursive(Transform root, string childName)
+        {
+            foreach (var child in root.GetComponentsInChildren<Transform>(true))
+            {
+                if (child.name == childName)
+                {
+                    return child;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Tower/TowerRuntimeContractTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Tower/TowerRuntimeContractTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7e95a532026746dc9b5929ec48cf92bc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/PlayMode/Tower.meta
+++ b/Assets/_Project/_Tests/PlayMode/Tower.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 29e6a43023df42f292d400adc1e759af
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/PlayMode/Tower/TowerSpawnInitPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/Tower/TowerSpawnInitPlayTests.cs
@@ -1,0 +1,51 @@
+using System.Collections;
+using Castlebound.Gameplay.Tower;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Castlebound.Tests.PlayMode.Tower
+{
+    public class TowerSpawnInitPlayTests
+    {
+        [UnityTest]
+        public IEnumerator SpawnedTower_InitializesRuntimeAndHierarchyContract()
+        {
+            var tower = CreateTower();
+
+            yield return null;
+
+            var runtime = tower.GetComponent<TowerRuntime>();
+            Assert.NotNull(runtime, "Spawned tower must include TowerRuntime.");
+            Assert.That(runtime.MaxHealth, Is.GreaterThan(0), "Tower runtime must initialize with positive max health.");
+            Assert.That(runtime.CurrentHealth, Is.EqualTo(runtime.MaxHealth), "Tower runtime should initialize at full health.");
+            Assert.NotNull(runtime.AimPivot, "Tower runtime must resolve AimPivot.");
+            Assert.NotNull(runtime.TowerVisual, "Tower runtime must resolve TowerVisual.");
+            Assert.NotNull(runtime.PlatformVisual, "Tower runtime must resolve PlatformVisual.");
+            Assert.AreEqual(runtime.AimPivot, runtime.TowerVisual.parent, "TowerVisual should remain parented under AimPivot.");
+            Assert.AreEqual(tower.transform, runtime.PlatformVisual.parent, "PlatformVisual should remain parented under the tower root.");
+
+            Object.Destroy(tower);
+        }
+
+        private static GameObject CreateTower()
+        {
+            var root = new GameObject("Tower");
+            root.AddComponent<BoxCollider2D>();
+            root.AddComponent<TowerRuntime>();
+
+            var aimPivot = new GameObject("AimPivot");
+            aimPivot.transform.SetParent(root.transform, false);
+
+            var towerVisual = new GameObject("TowerVisual");
+            towerVisual.transform.SetParent(aimPivot.transform, false);
+            towerVisual.AddComponent<SpriteRenderer>();
+
+            var platformVisual = new GameObject("PlatformVisual");
+            platformVisual.transform.SetParent(root.transform, false);
+            platformVisual.AddComponent<SpriteRenderer>();
+
+            return root;
+        }
+    }
+}

--- a/Assets/_Project/_Tests/PlayMode/Tower/TowerSpawnInitPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/Tower/TowerSpawnInitPlayTests.cs
@@ -3,11 +3,16 @@ using Castlebound.Gameplay.Tower;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
 
 namespace Castlebound.Tests.PlayMode.Tower
 {
     public class TowerSpawnInitPlayTests
     {
+        private const string TowerPrefabPath = "Assets/_Project/Prefabs/Tower.prefab";
+
         [UnityTest]
         public IEnumerator SpawnedTower_InitializesRuntimeAndHierarchyContract()
         {
@@ -26,6 +31,38 @@ namespace Castlebound.Tests.PlayMode.Tower
             Assert.AreEqual(tower.transform, runtime.PlatformVisual.parent, "PlatformVisual should remain parented under the tower root.");
 
             Object.Destroy(tower);
+        }
+
+        [UnityTest]
+        public IEnumerator TowerPrefab_InstantiatesWithExpectedRuntimeShell()
+        {
+#if UNITY_EDITOR
+            var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(TowerPrefabPath);
+            Assert.NotNull(prefab, "Expected Tower prefab asset to be loadable in PlayMode.");
+
+            var tower = Object.Instantiate(prefab);
+
+            yield return null;
+
+            var runtime = tower.GetComponent<TowerRuntime>();
+            Assert.NotNull(runtime, "Instantiated Tower prefab must include TowerRuntime.");
+            Assert.NotNull(tower.GetComponent<Collider2D>(), "Instantiated Tower prefab must include a Collider2D on the root.");
+            Assert.That(runtime.MaxHealth, Is.GreaterThan(0), "Tower runtime must initialize with positive max health.");
+            Assert.That(runtime.CurrentHealth, Is.EqualTo(runtime.MaxHealth), "Tower runtime should initialize at full health.");
+            Assert.NotNull(runtime.AimPivot, "Tower prefab instance must expose AimPivot.");
+            Assert.NotNull(runtime.TowerVisual, "Tower prefab instance must expose TowerVisual.");
+            Assert.NotNull(runtime.PlatformVisual, "Tower prefab instance must expose PlatformVisual.");
+            Assert.AreEqual("AimPivot", runtime.AimPivot.name, "Tower runtime should bind to the prefab AimPivot child.");
+            Assert.AreEqual("TowerVisual", runtime.TowerVisual.name, "Tower runtime should bind to the prefab TowerVisual child.");
+            Assert.AreEqual("PlatformVisual", runtime.PlatformVisual.name, "Tower runtime should bind to the prefab PlatformVisual child.");
+            Assert.AreEqual(runtime.AimPivot, runtime.TowerVisual.parent, "TowerVisual should remain parented under AimPivot.");
+            Assert.AreEqual(tower.transform, runtime.PlatformVisual.parent, "PlatformVisual should remain parented under the tower root.");
+
+            Object.Destroy(tower);
+#else
+            Assert.Fail("Tower prefab PlayMode smoke requires the Unity editor.");
+            yield break;
+#endif
         }
 
         private static GameObject CreateTower()

--- a/Assets/_Project/_Tests/PlayMode/Tower/TowerSpawnInitPlayTests.cs.meta
+++ b/Assets/_Project/_Tests/PlayMode/Tower/TowerSpawnInitPlayTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d8e028fe55964db7baa5081c87f9abbb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,23 @@
 
 ---
 
+## 2026-03-25 - feat(tower): prefab + core runtime
+
+### Summary
+- Added a minimal `TowerRuntime` that owns tower core state only: health bounds plus cached hierarchy references for future tower systems.
+- Introduced `Tower.prefab` with the locked stationary-root contract: root collider/runtime, `AimPivot`, `TowerVisual`, and `PlatformVisual`.
+- Added EditMode and PlayMode tower contract coverage while keeping targeting, firing, projectiles, and build integration out of this PR.
+
+### New or Updated Tests
+**EditMode**
+- `TowerRuntimeContractTests` — verifies `Tower.prefab` exists, stays normalized, includes runtime/collider state, and preserves the approved child hierarchy contract.
+
+**PlayMode**
+- `TowerSpawnInitPlayTests` — verifies a spawned tower initializes runtime state and resolves the required hierarchy references at runtime.
+
+### Notes
+- EditMode suite passed via `ci/run-editmode.ps1`. Tower PlayMode coverage was validated manually in the Unity editor after fixing runtime reference resolution for dynamic construction order.
+
 ## 2026-03-18 - feat(combat): high-rate cadence contracts (#148/#149/#150)
 
 ### Summary

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,23 @@
 
 ---
 
+## 2026-04-14 - feat(tower): prefab asset contract coverage
+
+### Summary
+- Added stronger tower shell regression coverage around the real prefab asset rather than only synthetic runtime construction.
+- Locked the serialized `TowerRuntime` child bindings to the approved `AimPivot`, `TowerVisual`, and `PlatformVisual` nodes.
+- Added a PlayMode smoke that instantiates the actual `Tower.prefab` and verifies the runtime shell contract survives asset instantiation.
+
+### New or Updated Tests
+**EditMode**
+- `TowerRuntimeContractTests` - verifies `TowerRuntime` serialized references bind to the intended prefab children.
+
+**PlayMode**
+- `TowerSpawnInitPlayTests` - instantiates the real `Tower.prefab` and verifies root collider/runtime plus hierarchy reference contract.
+
+### Notes
+- Manual validation still recommended in the Unity editor before merging `#158`.
+
 ## 2026-03-25 - feat(tower): prefab + core runtime
 
 ### Summary


### PR DESCRIPTION
## Why
The tower/build path needs a real tower object with a stable runtime shell before placement, targeting, aiming, and attack behavior can be layered safely. This PR establishes that shell while keeping combat and build logic out of `TowerRuntime`.

## What changed
- Added a reusable `Tower.prefab` with the approved stationary-root hierarchy
- Added `TowerRuntime` for core tower state and lazy hierarchy reference resolution
- Added EditMode and PlayMode contract coverage for the prefab, runtime state, serialized bindings, and real prefab instantiation
- Updated `TEST_LOG` for the new tower shell coverage

## How to test
1. Open the relevant scene or demo (if applicable)
2. Press Play and verify expected behavior
3. Run tests:
   - EditMode
   - PlayMode

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated (if player-visible) - N/A
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched (if applicable)

## Related
- Closes #158
