### PR TITLE
Feat/tower plot contract

### DIFF
--- a/Assets/_Project/Prefabs/Barrier_Gate.prefab
+++ b/Assets/_Project/Prefabs/Barrier_Gate.prefab
@@ -22,6 +22,7 @@ GameObject:
   - component: {fileID: 1199000000000000100}
   - component: {fileID: 1199000000000000300}
   - component: {fileID: 1199000000000000400}
+  - component: {fileID: 1199000000000000600}
   m_Layer: 8
   m_Name: Barrier_Gate
   m_TagString: Barrier
@@ -340,6 +341,21 @@ MonoBehaviour:
   eastSprite: {fileID: 21300000, guid: e44244f6fdf70e94bbadc426d5890990, type: 3}
   southSprite: {fileID: 21300000, guid: 084028016209b1c4c8c3420c5c9e7a12, type: 3}
   westSprite: {fileID: 21300000, guid: cd61d10e4196c1249b8d82de2d2b9784, type: 3}
+--- !u!114 &1199000000000000600
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 683792860472063015}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 78f5e520a8794409a07dd9f63ec2ad2b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  plots:
+  - {fileID: 1199000000000000702}
+  - {fileID: 1199000000000000802}
 --- !u!1 &1199000000000000500
 GameObject:
   m_ObjectHideFlags: 0
@@ -374,6 +390,8 @@ Transform:
   - {fileID: 7704152403565933767}
   - {fileID: 1199000000000000002}
   - {fileID: 3461197392837539735}
+  - {fileID: 1199000000000000701}
+  - {fileID: 1199000000000000801}
   m_Father: {fileID: 738055936485911948}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1199000000000000001
@@ -560,6 +578,98 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   gateId: Barrier_Gate
+--- !u!1 &1199000000000000700
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1199000000000000701}
+  - component: {fileID: 1199000000000000702}
+  m_Layer: 8
+  m_Name: TowerPlotLeftFlank
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1199000000000000701
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1199000000000000700}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -3, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1199000000000000501}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1199000000000000702
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1199000000000000700}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a53f956a8b094dd69428f9671f9194fd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  anchor: {fileID: 0}
+  occupantInstance: {fileID: 0}
+--- !u!1 &1199000000000000800
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1199000000000000801}
+  - component: {fileID: 1199000000000000802}
+  m_Layer: 8
+  m_Name: TowerPlotRightFlank
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1199000000000000801
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1199000000000000800}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 3, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1199000000000000501}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1199000000000000802
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1199000000000000800}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a53f956a8b094dd69428f9671f9194fd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  anchor: {fileID: 0}
+  occupantInstance: {fileID: 0}
 --- !u!1001 &8240005810329671612
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/_Project/Scenes/MainPrototype.unity
+++ b/Assets/_Project/Scenes/MainPrototype.unity
@@ -1124,7 +1124,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: -260}
+  m_SizeDelta: {x: 0, y: -620}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &545022179
 MonoBehaviour:
@@ -1384,6 +1384,7 @@ MonoBehaviour:
   contentRoot: {fileID: 545022178}
   feedbackChannel: {fileID: 11400000, guid: 1f9f2f0a7b2a4d0a9a2d6e11a6a0d1f6, type: 2}
   inventorySource: {fileID: 0}
+  towerBuildController: {fileID: 2300000002}
 --- !u!114 &676673187
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2219,7 +2220,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 520, y: 260}
+  m_SizeDelta: {x: 980, y: 620}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &774867746
 MonoBehaviour:
@@ -4663,6 +4664,55 @@ Grid:
   m_CellGap: {x: 0, y: 0, z: 0}
   m_CellLayout: 0
   m_CellSwizzle: 0
+--- !u!1 &2300000000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2300000001}
+  - component: {fileID: 2300000002}
+  m_Layer: 0
+  m_Name: TowerBuildSystems
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2300000001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2300000000}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2300000002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2300000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7044ac758d5347b1a7b5dc581c7a9abf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  config: {fileID: 11400000, guid: b467e19c0a744a1a8f96bf3d650e58b6, type: 2}
+  inventorySource: {fileID: 0}
+  waveRunner: {fileID: 1166075763}
+  feedbackChannel: {fileID: 11400000, guid: 1f9f2f0a7b2a4d0a9a2d6e11a6a0d1f6, type: 2}
+  towerParent: {fileID: 0}
 --- !u!1 &3000000000
 GameObject:
   m_ObjectHideFlags: 0
@@ -4712,7 +4762,6 @@ MonoBehaviour:
   aimAttackZone: {fileID: 3002000004}
   repairButton: {fileID: 3003000004}
   playerInput: {fileID: 0}
-  baseAttackRate: 1.5
   rightStickAttackDeadzone: 160
   enableInEditor: 0
 --- !u!114 &3000000003
@@ -5016,3 +5065,4 @@ SceneRoots:
   - {fileID: 2200000001}
   - {fileID: 2200000011}
   - {fileID: 3000000001}
+  - {fileID: 2300000001}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Castle/BarrierTowerPlotCollection.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Castle/BarrierTowerPlotCollection.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace Castlebound.Gameplay.Castle
+{
+    public class BarrierTowerPlotCollection : MonoBehaviour
+    {
+        [SerializeField] private TowerPlot[] plots = Array.Empty<TowerPlot>();
+
+        public IReadOnlyList<TowerPlot> Plots => plots;
+        public int PlotCount => plots.Length;
+
+        public void SetPlots(IEnumerable<TowerPlot> value)
+        {
+            plots = Normalize(value);
+        }
+
+        public bool Contains(TowerPlot plot)
+        {
+            return plot != null && plots.Contains(plot);
+        }
+
+        private void OnValidate()
+        {
+            plots = Normalize(plots);
+        }
+
+        private static TowerPlot[] Normalize(IEnumerable<TowerPlot> value)
+        {
+            if (value == null)
+            {
+                return Array.Empty<TowerPlot>();
+            }
+
+            return value
+                .Where(plot => plot != null)
+                .Distinct()
+                .ToArray();
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Castle/BarrierTowerPlotCollection.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Castle/BarrierTowerPlotCollection.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 78f5e520a8794409a07dd9f63ec2ad2b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/_Project.Gameplay/Castle/TowerPlot.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Castle/TowerPlot.cs
@@ -1,0 +1,38 @@
+using UnityEngine;
+
+namespace Castlebound.Gameplay.Castle
+{
+    public class TowerPlot : MonoBehaviour
+    {
+        [SerializeField] private Transform anchor;
+        [SerializeField] private GameObject occupantInstance;
+
+        public Transform Anchor => anchor != null ? anchor : transform;
+        public GameObject OccupantInstance => occupantInstance;
+        public bool IsOccupied => occupantInstance != null;
+
+        public void SetAnchor(Transform value)
+        {
+            anchor = value;
+        }
+
+        public bool TryAssignOccupant(GameObject instance)
+        {
+            if (instance == null || occupantInstance != null)
+            {
+                return false;
+            }
+
+            occupantInstance = instance;
+            return true;
+        }
+
+        public void ClearOccupant(GameObject instance = null)
+        {
+            if (instance == null || occupantInstance == instance)
+            {
+                occupantInstance = null;
+            }
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Castle/TowerPlot.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Castle/TowerPlot.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a53f956a8b094dd69428f9671f9194fd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerBuildConfig.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerBuildConfig.cs
@@ -1,0 +1,44 @@
+using UnityEngine;
+
+namespace Castlebound.Gameplay.Tower
+{
+    [CreateAssetMenu(menuName = "Castlebound/Tower/Tower Build Config")]
+    public class TowerBuildConfig : ScriptableObject
+    {
+        [SerializeField] private GameObject towerPrefab;
+        [SerializeField] private int buildCost = 50;
+        [SerializeField] private int baseMaxHealth = 10;
+        [SerializeField] private int baseDamage = 1;
+        [SerializeField] private int baseUpgradeCost = 75;
+
+        public GameObject TowerPrefab
+        {
+            get => towerPrefab;
+            set => towerPrefab = value;
+        }
+
+        public int BuildCost
+        {
+            get => buildCost;
+            set => buildCost = Mathf.Max(0, value);
+        }
+
+        public int BaseMaxHealth
+        {
+            get => baseMaxHealth;
+            set => baseMaxHealth = Mathf.Max(0, value);
+        }
+
+        public int BaseDamage
+        {
+            get => baseDamage;
+            set => baseDamage = Mathf.Max(0, value);
+        }
+
+        public int BaseUpgradeCost
+        {
+            get => baseUpgradeCost;
+            set => baseUpgradeCost = Mathf.Max(0, value);
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerBuildConfig.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerBuildConfig.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 06f19e9fbfa74ba096e2a5f458d0813c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerBuildController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerBuildController.cs
@@ -1,0 +1,189 @@
+using Castlebound.Gameplay.Castle;
+using Castlebound.Gameplay.Inventory;
+using Castlebound.Gameplay.Spawning;
+using UnityEngine;
+
+namespace Castlebound.Gameplay.Tower
+{
+    public class TowerBuildController : MonoBehaviour
+    {
+        [SerializeField] private TowerBuildConfig config;
+        [SerializeField] private InventoryStateComponent inventorySource;
+        [SerializeField] private EnemySpawnerRunner waveRunner;
+        [SerializeField] private FeedbackEventChannel feedbackChannel;
+        [SerializeField] private Transform towerParent;
+
+        private InventoryState inventory;
+        private WavePhaseTracker phaseTracker;
+
+        public TowerBuildConfig Config
+        {
+            get => config;
+            set => config = value;
+        }
+
+        public Transform TowerParent
+        {
+            get => towerParent;
+            set => towerParent = value;
+        }
+
+        public TowerBuildResult TryBuild(TowerPlot plot)
+        {
+            var result = ValidateBuild(plot, out var source, out var anchor);
+            if (result != TowerBuildResult.Success)
+            {
+                RaiseFeedback(result, plot, anchor);
+                return result;
+            }
+
+            int cost = config.BuildCost;
+            if (!source.TrySpendGold(cost))
+            {
+                result = TowerBuildResult.InsufficientGold;
+                RaiseFeedback(result, plot, anchor);
+                return result;
+            }
+
+            var instance = SpawnTower(anchor);
+            if (!plot.TryAssignOccupant(instance))
+            {
+                DestroySpawnedTower(instance);
+                source.AddGold(cost);
+                result = TowerBuildResult.Occupied;
+                RaiseFeedback(result, plot, anchor);
+                return result;
+            }
+
+            RaiseFeedback(TowerBuildResult.Success, plot, anchor);
+            return TowerBuildResult.Success;
+        }
+
+        public void SetInventory(InventoryState state)
+        {
+            inventory = state;
+        }
+
+        public void SetPhaseTracker(WavePhaseTracker tracker)
+        {
+            phaseTracker = tracker;
+        }
+
+        public void SetFeedbackChannel(FeedbackEventChannel channel)
+        {
+            feedbackChannel = channel;
+        }
+
+        private TowerBuildResult ValidateBuild(TowerPlot plot, out InventoryState source, out Transform anchor)
+        {
+            source = null;
+            anchor = plot != null ? plot.Anchor : null;
+
+            if (plot == null)
+            {
+                return TowerBuildResult.InvalidPlot;
+            }
+
+            if (plot.IsOccupied)
+            {
+                return TowerBuildResult.Occupied;
+            }
+
+            if (!IsInPreWave())
+            {
+                return TowerBuildResult.NotPreWave;
+            }
+
+            if (config == null)
+            {
+                return TowerBuildResult.MissingConfig;
+            }
+
+            if (config.TowerPrefab == null)
+            {
+                return TowerBuildResult.MissingPrefab;
+            }
+
+            source = GetInventory();
+            if (source == null)
+            {
+                return TowerBuildResult.MissingInventory;
+            }
+
+            return TowerBuildResult.Success;
+        }
+
+        private GameObject SpawnTower(Transform anchor)
+        {
+            var parent = towerParent != null ? towerParent : null;
+            return parent != null
+                ? Instantiate(config.TowerPrefab, anchor.position, anchor.rotation, parent)
+                : Instantiate(config.TowerPrefab, anchor.position, anchor.rotation);
+        }
+
+        private static void DestroySpawnedTower(GameObject instance)
+        {
+            if (instance == null)
+            {
+                return;
+            }
+
+            if (Application.isPlaying)
+            {
+                Destroy(instance);
+            }
+            else
+            {
+                DestroyImmediate(instance);
+            }
+        }
+
+        private bool IsInPreWave()
+        {
+            if (phaseTracker != null)
+            {
+                return phaseTracker.CurrentPhase == WavePhase.PreWave;
+            }
+
+            if (waveRunner == null)
+            {
+                waveRunner = FindObjectOfType<EnemySpawnerRunner>();
+            }
+
+            return waveRunner != null
+                && waveRunner.PhaseTracker != null
+                && waveRunner.PhaseTracker.CurrentPhase == WavePhase.PreWave;
+        }
+
+        private InventoryState GetInventory()
+        {
+            if (inventory != null)
+            {
+                return inventory;
+            }
+
+            if (inventorySource == null)
+            {
+                inventorySource = GetComponent<InventoryStateComponent>();
+            }
+
+            inventory = inventorySource != null ? inventorySource.State : null;
+            return inventory;
+        }
+
+        private void RaiseFeedback(TowerBuildResult result, TowerPlot plot, Transform anchor)
+        {
+            if (feedbackChannel == null)
+            {
+                return;
+            }
+
+            var type = result == TowerBuildResult.Success
+                ? FeedbackCueType.UpgradeSuccess
+                : FeedbackCueType.UpgradeDenied;
+            var position = anchor != null ? anchor.position : Vector3.zero;
+            var targetId = plot != null ? plot.GetInstanceID() : 0;
+            feedbackChannel.Raise(new FeedbackCue(type, position, targetId));
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerBuildController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerBuildController.cs
@@ -38,7 +38,7 @@ namespace Castlebound.Gameplay.Tower
             }
 
             int cost = config.BuildCost;
-            if (!source.TrySpendGold(cost))
+            if (cost > 0 && !source.TrySpendGold(cost))
             {
                 result = TowerBuildResult.InsufficientGold;
                 RaiseFeedback(result, plot, anchor);
@@ -49,7 +49,10 @@ namespace Castlebound.Gameplay.Tower
             if (!plot.TryAssignOccupant(instance))
             {
                 DestroySpawnedTower(instance);
-                source.AddGold(cost);
+                if (cost > 0)
+                {
+                    source.AddGold(cost);
+                }
                 result = TowerBuildResult.Occupied;
                 RaiseFeedback(result, plot, anchor);
                 return result;

--- a/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerBuildController.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerBuildController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7044ac758d5347b1a7b5dc581c7a9abf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerBuildResult.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerBuildResult.cs
@@ -1,0 +1,14 @@
+namespace Castlebound.Gameplay.Tower
+{
+    public enum TowerBuildResult
+    {
+        Success,
+        InvalidPlot,
+        Occupied,
+        NotPreWave,
+        MissingConfig,
+        MissingInventory,
+        InsufficientGold,
+        MissingPrefab
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerBuildResult.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerBuildResult.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a51cd17c8cea46e59c82a6f77b955531
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/_Project.Gameplay/UI/UpgradeMenuListView.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/UI/UpgradeMenuListView.cs
@@ -1,7 +1,9 @@
 using System.Collections;
 using System.Collections.Generic;
 using Castlebound.Gameplay.Barrier;
+using Castlebound.Gameplay.Castle;
 using Castlebound.Gameplay.Inventory;
+using Castlebound.Gameplay.Tower;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -23,8 +25,9 @@ namespace Castlebound.Gameplay.UI
         [SerializeField] private RectTransform contentRoot;
         [SerializeField] private FeedbackEventChannel feedbackChannel;
         [SerializeField] private InventoryStateComponent inventorySource;
+        [SerializeField] private TowerBuildController towerBuildController;
 
-        private readonly List<Row> rows = new List<Row>();
+        private readonly List<ActionRow> rows = new List<ActionRow>();
 
         private void OnEnable()
         {
@@ -76,8 +79,19 @@ namespace Castlebound.Gameplay.UI
                     controller.SetFeedbackChannel(feedbackChannel);
                 }
 
-                rows.Add(CreateRow(controller));
+                rows.Add(CreateBarrierUpgradeRow(controller));
+                CreateTowerPlotRows(controller);
             }
+        }
+
+        public void SetContentRoot(RectTransform root)
+        {
+            contentRoot = root;
+        }
+
+        public void SetTowerBuildController(TowerBuildController controller)
+        {
+            towerBuildController = controller;
         }
 
         private void ResolveReferences()
@@ -95,6 +109,11 @@ namespace Castlebound.Gameplay.UI
                     var player = GameObject.FindGameObjectWithTag("Player");
                     inventorySource = player != null ? player.GetComponent<InventoryStateComponent>() : null;
                 }
+            }
+
+            if (towerBuildController == null)
+            {
+                towerBuildController = FindObjectOfType<TowerBuildController>();
             }
         }
 
@@ -136,7 +155,7 @@ namespace Castlebound.Gameplay.UI
                 layout = contentRoot.gameObject.AddComponent<VerticalLayoutGroup>();
             }
 
-            layout.spacing = 8f;
+            layout.spacing = 6f;
             layout.childForceExpandHeight = false;
             layout.childForceExpandWidth = true;
 
@@ -150,13 +169,111 @@ namespace Castlebound.Gameplay.UI
             fitter.horizontalFit = ContentSizeFitter.FitMode.Unconstrained;
         }
 
-        private Row CreateRow(BarrierUpgradeController controller)
+        private ActionRow CreateBarrierUpgradeRow(BarrierUpgradeController controller)
         {
             var rowObject = new GameObject("UpgradeRow", typeof(RectTransform), typeof(HorizontalLayoutGroup), typeof(ContentSizeFitter));
             rowObject.transform.SetParent(contentRoot, false);
+            ConfigureRowLayout(rowObject, 0f, 28f);
 
+            var nameText = CreateText("Name", rowObject.transform, 18, TextAlignmentOptions.Left);
+            ConfigureLayoutElement(nameText.gameObject, 150f, 0f);
+
+            var detailText = CreateText("Details", rowObject.transform, 16, TextAlignmentOptions.Left);
+            ConfigureLayoutElement(detailText.gameObject, 340f, 0f);
+            var button = CreateButton("UpgradeButton", rowObject.transform, "Upgrade", 96f);
+
+            var row = new ActionRow(
+                rowObject,
+                nameText,
+                detailText,
+                button,
+                () => controller.name,
+                () => $"Tier {controller.GetCurrentTier()} | HP {controller.GetCurrentHealth()}/{controller.GetCurrentMaxHealth()} | {controller.GetUpgradeCost()} Gold",
+                () => "Upgrade",
+                () => true,
+                () => controller.TryUpgrade(),
+                Refresh,
+                FlashButton);
+            row.Refresh();
+            return row;
+        }
+
+        private void CreateTowerPlotRows(BarrierUpgradeController controller)
+        {
+            if (towerBuildController == null)
+            {
+                return;
+            }
+
+            var plots = controller.GetComponent<BarrierTowerPlotCollection>();
+            if (plots == null || plots.PlotCount == 0)
+            {
+                return;
+            }
+
+            if (inventorySource != null)
+            {
+                towerBuildController.SetInventory(inventorySource.State);
+            }
+
+            if (feedbackChannel != null)
+            {
+                towerBuildController.SetFeedbackChannel(feedbackChannel);
+            }
+
+            for (int i = 0; i < plots.PlotCount; i++)
+            {
+                var plot = plots.Plots[i];
+                if (plot == null)
+                {
+                    continue;
+                }
+
+                rows.Add(CreateTowerPlotRow(plot, i, i == plots.PlotCount - 1));
+            }
+        }
+
+        private ActionRow CreateTowerPlotRow(TowerPlot plot, int plotIndex, bool endsBarrierGroup)
+        {
+            var rowObject = new GameObject("TowerPlotRow", typeof(RectTransform), typeof(HorizontalLayoutGroup), typeof(ContentSizeFitter));
+            rowObject.transform.SetParent(contentRoot, false);
+            if (endsBarrierGroup)
+            {
+                var groupSpacing = rowObject.AddComponent<LayoutElement>();
+                groupSpacing.minHeight = 48f;
+                groupSpacing.preferredHeight = 48f;
+            }
+
+            ConfigureRowLayout(rowObject, 42f, 28f);
+
+            var nameText = CreateText("Name", rowObject.transform, 13, TextAlignmentOptions.Left);
+            ConfigureLayoutElement(nameText.gameObject, 120f, 0f);
+
+            var detailText = CreateText("Details", rowObject.transform, 13, TextAlignmentOptions.Left);
+            ConfigureLayoutElement(detailText.gameObject, 340f, 0f);
+            var button = CreateButton("BuildButton", rowObject.transform, "Build", 80f);
+
+            var row = new ActionRow(
+                rowObject,
+                nameText,
+                detailText,
+                button,
+                () => $"- {GetPlotLabel(plotIndex)}",
+                () => GetTowerPlotDetails(plot),
+                () => plot.IsOccupied ? "Occupied" : "Build",
+                () => !plot.IsOccupied,
+                () => towerBuildController.TryBuild(plot) == TowerBuildResult.Success,
+                Refresh,
+                FlashButton);
+            row.Refresh();
+            return row;
+        }
+
+        private static void ConfigureRowLayout(GameObject rowObject, float leftPadding, float spacing)
+        {
             var layout = rowObject.GetComponent<HorizontalLayoutGroup>();
-            layout.spacing = 8f;
+            layout.padding.left = Mathf.RoundToInt(leftPadding);
+            layout.spacing = spacing;
             layout.childAlignment = TextAnchor.MiddleLeft;
             layout.childForceExpandHeight = false;
             layout.childForceExpandWidth = false;
@@ -164,21 +281,49 @@ namespace Castlebound.Gameplay.UI
             var fitter = rowObject.GetComponent<ContentSizeFitter>();
             fitter.horizontalFit = ContentSizeFitter.FitMode.PreferredSize;
             fitter.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
+        }
 
-            var nameText = CreateText("Name", rowObject.transform, 18, TextAlignmentOptions.Left);
-            var nameLayout = nameText.gameObject.AddComponent<LayoutElement>();
-            nameLayout.preferredWidth = 140f;
-            nameLayout.flexibleWidth = 0f;
+        private static void ConfigureLayoutElement(GameObject target, float preferredWidth, float flexibleWidth)
+        {
+            var layout = target.AddComponent<LayoutElement>();
+            layout.preferredWidth = preferredWidth;
+            layout.minWidth = preferredWidth;
+            layout.flexibleWidth = flexibleWidth;
+        }
 
-            var detailText = CreateText("Details", rowObject.transform, 16, TextAlignmentOptions.Left);
-            var detailLayout = detailText.gameObject.AddComponent<LayoutElement>();
-            detailLayout.preferredWidth = 260f;
-            detailLayout.flexibleWidth = 1f;
-            var button = CreateButton("UpgradeButton", rowObject.transform);
+        private string GetTowerPlotDetails(TowerPlot plot)
+        {
+            var config = towerBuildController != null ? towerBuildController.Config : null;
+            string towerName = config != null && config.TowerPrefab != null ? config.TowerPrefab.name : "Tower";
+            int maxHealth = config != null ? config.BaseMaxHealth : 0;
+            int damage = config != null ? config.BaseDamage : 0;
+            int buildCost = config != null ? config.BuildCost : 0;
+            int upgradeCost = config != null ? config.BaseUpgradeCost : 0;
 
-            var row = new Row(controller, rowObject, nameText, detailText, button, Refresh, FlashButton);
-            row.Refresh();
-            return row;
+            if (plot != null && plot.IsOccupied)
+            {
+                var runtime = plot.OccupantInstance != null ? plot.OccupantInstance.GetComponent<TowerRuntime>() : null;
+                int currentHealth = runtime != null ? runtime.CurrentHealth : maxHealth;
+                int occupiedMaxHealth = runtime != null ? runtime.MaxHealth : maxHealth;
+                return $"{towerName} | HP {currentHealth}/{occupiedMaxHealth} | DMG {damage} | Upg {upgradeCost} Gold";
+            }
+
+            return $"{towerName} | HP {maxHealth} | DMG {damage} | Build {buildCost} Gold";
+        }
+
+        private static string GetPlotLabel(int plotIndex)
+        {
+            if (plotIndex == 0)
+            {
+                return "Left Plot";
+            }
+
+            if (plotIndex == 1)
+            {
+                return "Right Plot";
+            }
+
+            return $"Plot {plotIndex + 1}";
         }
 
         private TextMeshProUGUI CreateText(string name, Transform parent, int fontSize, TextAlignmentOptions alignment)
@@ -196,18 +341,14 @@ namespace Castlebound.Gameplay.UI
             return text;
         }
 
-        private Button CreateButton(string name, Transform parent)
+        private Button CreateButton(string name, Transform parent, string label, float width)
         {
             var go = new GameObject(name, typeof(RectTransform), typeof(CanvasRenderer), typeof(Image), typeof(Button));
             go.transform.SetParent(parent, false);
 
             var image = go.GetComponent<Image>();
-            if (buttonSprite == null)
-            {
-                buttonSprite = Resources.GetBuiltinResource<Sprite>("UI/Skin/UISprite.psd");
-            }
             image.sprite = buttonSprite;
-            image.type = Image.Type.Sliced;
+            image.type = buttonSprite != null ? Image.Type.Sliced : Image.Type.Simple;
             image.color = normalButtonColor;
 
             var button = go.GetComponent<Button>();
@@ -222,12 +363,12 @@ namespace Castlebound.Gameplay.UI
             button.colors = colors;
 
             var text = CreateText("Label", go.transform, 16, TextAlignmentOptions.Center);
-            text.text = "Upgrade";
+            text.text = label;
 
             var rect = go.GetComponent<RectTransform>();
-            rect.sizeDelta = new Vector2(90f, 28f);
+            rect.sizeDelta = new Vector2(width, 28f);
             var layout = go.AddComponent<LayoutElement>();
-            layout.preferredWidth = 90f;
+            layout.preferredWidth = width;
             layout.preferredHeight = 28f;
             layout.flexibleWidth = 0f;
             layout.flexibleHeight = 0f;
@@ -238,6 +379,12 @@ namespace Castlebound.Gameplay.UI
         private void FlashButton(Button button, bool success, System.Action onComplete)
         {
             if (button == null)
+            {
+                onComplete?.Invoke();
+                return;
+            }
+
+            if (!Application.isPlaying)
             {
                 onComplete?.Invoke();
                 return;
@@ -289,61 +436,87 @@ namespace Castlebound.Gameplay.UI
             rows.Clear();
         }
 
-        private class Row
+        private class ActionRow
         {
-            private readonly BarrierUpgradeController controller;
             private readonly GameObject root;
             private readonly TextMeshProUGUI nameText;
             private readonly TextMeshProUGUI detailText;
-            private readonly Button upgradeButton;
+            private readonly Button actionButton;
+            private readonly System.Func<string> getName;
+            private readonly System.Func<string> getDetails;
+            private readonly System.Func<string> getButtonLabel;
+            private readonly System.Func<bool> canInvoke;
+            private readonly System.Func<bool> invoke;
             private readonly System.Action refreshAll;
             private readonly System.Action<Button, bool, System.Action> flashButton;
 
-            public Row(
-                BarrierUpgradeController controller,
+            public ActionRow(
                 GameObject root,
                 TextMeshProUGUI nameText,
                 TextMeshProUGUI detailText,
-                Button upgradeButton,
+                Button actionButton,
+                System.Func<string> getName,
+                System.Func<string> getDetails,
+                System.Func<string> getButtonLabel,
+                System.Func<bool> canInvoke,
+                System.Func<bool> invoke,
                 System.Action refreshAll,
                 System.Action<Button, bool, System.Action> flashButton)
             {
-                this.controller = controller;
                 this.root = root;
                 this.nameText = nameText;
                 this.detailText = detailText;
-                this.upgradeButton = upgradeButton;
+                this.actionButton = actionButton;
+                this.getName = getName;
+                this.getDetails = getDetails;
+                this.getButtonLabel = getButtonLabel;
+                this.canInvoke = canInvoke;
+                this.invoke = invoke;
                 this.refreshAll = refreshAll;
                 this.flashButton = flashButton;
 
-                upgradeButton.onClick.AddListener(OnUpgradeClicked);
+                actionButton.onClick.AddListener(OnClicked);
             }
 
             public void Refresh()
             {
-                nameText.text = controller.name;
-            detailText.text = $"Tier {controller.GetCurrentTier()} | HP {controller.GetCurrentHealth()}/{controller.GetCurrentMaxHealth()} | Cost {controller.GetUpgradeCost()}";
+                nameText.text = getName != null ? getName.Invoke() : string.Empty;
+                detailText.text = getDetails != null ? getDetails.Invoke() : string.Empty;
+                actionButton.interactable = canInvoke == null || canInvoke.Invoke();
+
+                var label = actionButton.GetComponentInChildren<TextMeshProUGUI>();
+                if (label != null)
+                {
+                    label.text = getButtonLabel != null ? getButtonLabel.Invoke() : string.Empty;
+                }
             }
 
             public void Dispose()
             {
-                if (upgradeButton != null)
+                if (actionButton != null)
                 {
-                    upgradeButton.onClick.RemoveListener(OnUpgradeClicked);
+                    actionButton.onClick.RemoveListener(OnClicked);
                 }
 
                 if (root != null)
                 {
-                    Object.Destroy(root);
+                    if (Application.isPlaying)
+                    {
+                        Object.Destroy(root);
+                    }
+                    else
+                    {
+                        Object.DestroyImmediate(root);
+                    }
                 }
             }
 
-            private void OnUpgradeClicked()
+            private void OnClicked()
             {
-                bool upgraded = controller.TryUpgrade();
+                bool succeeded = invoke != null && invoke.Invoke();
                 if (flashButton != null)
                 {
-                    flashButton.Invoke(upgradeButton, upgraded, refreshAll);
+                    flashButton.Invoke(actionButton, succeeded, refreshAll);
                 }
                 else
                 {

--- a/Assets/_Project/Tower.meta
+++ b/Assets/_Project/Tower.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a2ebcdab1545490ebef01cac545bb27c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Tower/TowerBuildConfig.asset
+++ b/Assets/_Project/Tower/TowerBuildConfig.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 06f19e9fbfa74ba096e2a5f458d0813c, type: 3}
+  m_Name: TowerBuildConfig
+  m_EditorClassIdentifier:
+  towerPrefab: {fileID: 683792860472063015, guid: ec470124d4d042388418a66cedd418c1, type: 3}
+  buildCost: 50
+  baseMaxHealth: 10
+  baseDamage: 3
+  baseUpgradeCost: 75

--- a/Assets/_Project/Tower/TowerBuildConfig.asset
+++ b/Assets/_Project/Tower/TowerBuildConfig.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 06f19e9fbfa74ba096e2a5f458d0813c, type: 3}
   m_Name: TowerBuildConfig
   m_EditorClassIdentifier:
-  towerPrefab: {fileID: 683792860472063015, guid: ec470124d4d042388418a66cedd418c1, type: 3}
+  towerPrefab: {fileID: 2000000000, guid: ec470124d4d042388418a66cedd418c1, type: 3}
   buildCost: 50
   baseMaxHealth: 10
   baseDamage: 3

--- a/Assets/_Project/Tower/TowerBuildConfig.asset.meta
+++ b/Assets/_Project/Tower/TowerBuildConfig.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b467e19c0a744a1a8f96bf3d650e58b6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/_Tests/EditMode/Castle/BarrierPrefabVisualContractTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Castle/BarrierPrefabVisualContractTests.cs
@@ -83,6 +83,36 @@ namespace Castlebound.Tests.Castle
                 AssertIsDescendantOfSystemsRoot(prefab, systemsRoot, "DamageHitbox");
                 AssertIsDescendantOfSystemsRoot(prefab, systemsRoot, "PulseOrigin");
                 AssertIsDescendantOfSystemsRoot(prefab, systemsRoot, "BarrierHealthbar");
+                AssertIsDescendantOfSystemsRoot(prefab, systemsRoot, "TowerPlotLeftFlank");
+                AssertIsDescendantOfSystemsRoot(prefab, systemsRoot, "TowerPlotRightFlank");
+            }
+            finally
+            {
+                PrefabTestUtil.Unload(prefab);
+            }
+        }
+
+        [Test]
+        public void BarrierPrefab_ProvidesTwoDistinctTowerPlots_OnFlankingOffsets()
+        {
+            var prefab = PrefabTestUtil.Load(BarrierPrefabPath);
+            try
+            {
+                var collection = prefab.GetComponent<BarrierTowerPlotCollection>();
+                Assert.NotNull(collection, "Barrier prefab must include BarrierTowerPlotCollection.");
+                Assert.That(collection.PlotCount, Is.EqualTo(2), "Barrier prefab should expose two flanking tower plots.");
+
+                var plots = collection.Plots;
+                Assert.NotNull(plots[0], "Left flanking plot should be assigned.");
+                Assert.NotNull(plots[1], "Right flanking plot should be assigned.");
+                Assert.AreNotSame(plots[0], plots[1], "Barrier prefab tower plots must be distinct instances.");
+
+                Assert.That(plots[0].transform.localPosition, Is.EqualTo(new Vector3(-3f, 0f, 0f)));
+                Assert.That(plots[1].transform.localPosition, Is.EqualTo(new Vector3(3f, 0f, 0f)));
+                Assert.AreSame(plots[0].transform, plots[0].Anchor, "Tower plot should default anchor to its own transform.");
+                Assert.AreSame(plots[1].transform, plots[1].Anchor, "Tower plot should default anchor to its own transform.");
+                Assert.IsFalse(plots[0].IsOccupied, "Tower plots should start empty on the prefab.");
+                Assert.IsFalse(plots[1].IsOccupied, "Tower plots should start empty on the prefab.");
             }
             finally
             {

--- a/Assets/_Project/_Tests/EditMode/Castle/MainPrototypeBarrierAssemblyIntegrationTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Castle/MainPrototypeBarrierAssemblyIntegrationTests.cs
@@ -101,10 +101,35 @@ namespace Castlebound.Tests.Castle
                     Assert.NotNull(child.GetComponent<BarrierHealth>(), $"Generated barrier '{child.name}' missing BarrierHealth.");
                     Assert.NotNull(child.GetComponent<BoxCollider2D>(), $"Generated barrier '{child.name}' missing BoxCollider2D.");
                     Assert.NotNull(child.GetComponent<BarrierVisualBinder>(), $"Generated barrier '{child.name}' missing BarrierVisualBinder.");
+                    var towerPlots = child.GetComponent<BarrierTowerPlotCollection>();
+                    Assert.NotNull(towerPlots, $"Generated barrier '{child.name}' missing BarrierTowerPlotCollection.");
+                    Assert.That(towerPlots.PlotCount, Is.EqualTo(2), $"Generated barrier '{child.name}' should expose two linked tower plots.");
 
                     var renderer = child.GetComponent<SpriteRenderer>();
                     Assert.NotNull(renderer, $"Generated barrier '{child.name}' missing SpriteRenderer.");
                     Assert.NotNull(renderer.sprite, $"Generated barrier '{child.name}' missing assigned side sprite.");
+
+                    foreach (var plot in towerPlots.Plots)
+                    {
+                        Assert.NotNull(plot, $"Generated barrier '{child.name}' includes a null tower plot reference.");
+                        Assert.NotNull(plot.Anchor, $"Generated barrier '{child.name}' tower plot '{plot.name}' must expose an anchor.");
+                    }
+
+                    var firstAnchorOffset = towerPlots.Plots[0].Anchor.position - child.position;
+                    var secondAnchorOffset = towerPlots.Plots[1].Anchor.position - child.position;
+
+                    Assert.That(firstAnchorOffset.magnitude, Is.EqualTo(3f).Within(0.05f),
+                        $"Generated barrier '{child.name}' first tower plot should sit one wall tile from the barrier center.");
+                    Assert.That(secondAnchorOffset.magnitude, Is.EqualTo(3f).Within(0.05f),
+                        $"Generated barrier '{child.name}' second tower plot should sit one wall tile from the barrier center.");
+
+                    var normalizedDot = Vector3.Dot(firstAnchorOffset.normalized, secondAnchorOffset.normalized);
+                    Assert.That(normalizedDot, Is.EqualTo(-1f).Within(0.01f),
+                        $"Generated barrier '{child.name}' tower plots should occupy opposite flanks.");
+
+                    var cross = Vector3.Cross(firstAnchorOffset.normalized, secondAnchorOffset.normalized).magnitude;
+                    Assert.That(cross, Is.EqualTo(0f).Within(0.01f),
+                        $"Generated barrier '{child.name}' tower plot flanks should stay collinear across barrier rotation.");
                 }
             }
             finally

--- a/Assets/_Project/_Tests/EditMode/Castle/TowerPlotContractTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Castle/TowerPlotContractTests.cs
@@ -1,0 +1,113 @@
+using System.Linq;
+using Castlebound.Gameplay.Castle;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Castlebound.Tests.Castle
+{
+    public class TowerPlotContractTests
+    {
+        [Test]
+        public void TowerPlot_DefaultsToOwnTransformAnchor_AndStartsEmpty()
+        {
+            var plotRoot = new GameObject("TowerPlot");
+
+            try
+            {
+                var plot = plotRoot.AddComponent<TowerPlot>();
+
+                Assert.AreSame(plotRoot.transform, plot.Anchor, "TowerPlot should default its anchor to the plot transform.");
+                Assert.IsFalse(plot.IsOccupied, "TowerPlot should start empty.");
+                Assert.IsNull(plot.OccupantInstance, "TowerPlot should not start with an occupant.");
+            }
+            finally
+            {
+                Object.DestroyImmediate(plotRoot);
+            }
+        }
+
+        [Test]
+        public void TowerPlot_TracksOccupantLifecycle_WithoutAllowingDuplicateAssignment()
+        {
+            var plotRoot = new GameObject("TowerPlot");
+            var firstTower = new GameObject("Tower_A");
+            var secondTower = new GameObject("Tower_B");
+
+            try
+            {
+                var plot = plotRoot.AddComponent<TowerPlot>();
+
+                Assert.IsTrue(plot.TryAssignOccupant(firstTower), "First occupant assignment should succeed.");
+                Assert.IsTrue(plot.IsOccupied, "TowerPlot should report occupied after assignment.");
+                Assert.AreSame(firstTower, plot.OccupantInstance, "TowerPlot should track the assigned occupant.");
+
+                Assert.IsFalse(plot.TryAssignOccupant(secondTower), "TowerPlot should reject assigning a second occupant while occupied.");
+                Assert.AreSame(firstTower, plot.OccupantInstance, "Rejected assignment should not replace the current occupant.");
+
+                plot.ClearOccupant(secondTower);
+                Assert.AreSame(firstTower, plot.OccupantInstance, "Clearing with the wrong occupant should not empty the plot.");
+
+                plot.ClearOccupant(firstTower);
+                Assert.IsFalse(plot.IsOccupied, "TowerPlot should become empty after clearing the assigned occupant.");
+                Assert.IsNull(plot.OccupantInstance, "TowerPlot should no longer track an occupant after clearing.");
+            }
+            finally
+            {
+                Object.DestroyImmediate(secondTower);
+                Object.DestroyImmediate(firstTower);
+                Object.DestroyImmediate(plotRoot);
+            }
+        }
+
+        [Test]
+        public void BarrierTowerPlotCollection_ExposesReusablePlotCollection_WithoutFixedSlotFields()
+        {
+            var barrier = new GameObject("Barrier");
+            var plotA = new GameObject("Plot_A").AddComponent<TowerPlot>();
+            var plotB = new GameObject("Plot_B").AddComponent<TowerPlot>();
+            var plotC = new GameObject("Plot_C").AddComponent<TowerPlot>();
+
+            try
+            {
+                var collection = barrier.AddComponent<BarrierTowerPlotCollection>();
+                collection.SetPlots(new[] { plotA, plotB, plotC });
+
+                Assert.That(collection.PlotCount, Is.EqualTo(3), "Barrier plot collection should support more than two plots at the contract level.");
+                CollectionAssert.AreEquivalent(new[] { plotA, plotB, plotC }, collection.Plots.ToArray(), "Barrier plot collection should expose all configured plots.");
+                Assert.IsTrue(collection.Contains(plotA), "Barrier plot collection should expose plots by membership rather than fixed slot names.");
+                Assert.IsTrue(collection.Contains(plotB), "Barrier plot collection should expose plots by membership rather than fixed slot names.");
+                Assert.IsTrue(collection.Contains(plotC), "Barrier plot collection should expose plots by membership rather than fixed slot names.");
+            }
+            finally
+            {
+                Object.DestroyImmediate(plotC.gameObject);
+                Object.DestroyImmediate(plotB.gameObject);
+                Object.DestroyImmediate(plotA.gameObject);
+                Object.DestroyImmediate(barrier);
+            }
+        }
+
+        [Test]
+        public void BarrierTowerPlotCollection_NormalizesNullAndDuplicatePlots_ForPlugAndPlayAuthoring()
+        {
+            var barrier = new GameObject("Barrier");
+            var plotA = new GameObject("Plot_A").AddComponent<TowerPlot>();
+            var plotB = new GameObject("Plot_B").AddComponent<TowerPlot>();
+
+            try
+            {
+                var collection = barrier.AddComponent<BarrierTowerPlotCollection>();
+                collection.SetPlots(new TowerPlot[] { plotA, null, plotA, plotB });
+
+                Assert.That(collection.PlotCount, Is.EqualTo(2), "Barrier plot collection should ignore null and duplicate plot assignments.");
+                CollectionAssert.AreEquivalent(new[] { plotA, plotB }, collection.Plots.ToArray(), "Barrier plot collection should keep only unique valid plots.");
+            }
+            finally
+            {
+                Object.DestroyImmediate(plotB.gameObject);
+                Object.DestroyImmediate(plotA.gameObject);
+                Object.DestroyImmediate(barrier);
+            }
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Castle/TowerPlotContractTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Castle/TowerPlotContractTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d25f4e81f7da41c78a59ef6d06345165
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/EditMode/Tower/TowerBuildControllerTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Tower/TowerBuildControllerTests.cs
@@ -1,0 +1,269 @@
+using Castlebound.Gameplay.Castle;
+using Castlebound.Gameplay.Inventory;
+using Castlebound.Gameplay.Spawning;
+using Castlebound.Gameplay.Tower;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Castlebound.Tests.Tower
+{
+    public class TowerBuildControllerTests
+    {
+        [Test]
+        public void TryBuild_WithEmptyPlotInPreWave_SpendsGoldSpawnsTowerAndAssignsOccupant()
+        {
+            var context = CreateContext(startingGold: 75, buildCost: 50);
+            context.Anchor.position = new Vector3(3f, 4f, 0f);
+            context.Anchor.rotation = Quaternion.Euler(0f, 0f, 45f);
+
+            try
+            {
+                var result = context.Controller.TryBuild(context.Plot);
+
+                Assert.That(result, Is.EqualTo(TowerBuildResult.Success));
+                Assert.That(context.Inventory.Gold, Is.EqualTo(25), "Tower build should spend gold exactly once.");
+                Assert.IsTrue(context.Plot.IsOccupied, "Successful build should mark the plot occupied.");
+                Assert.NotNull(context.Plot.OccupantInstance, "Successful build should assign the spawned tower to the plot.");
+                Assert.AreNotSame(context.TowerPrefab, context.Plot.OccupantInstance, "Build should spawn an instance instead of assigning the prefab.");
+                Assert.NotNull(context.Plot.OccupantInstance.GetComponent<TowerRuntime>(), "Build should spawn the configured tower runtime prefab.");
+                Assert.That(context.Plot.OccupantInstance.transform.position, Is.EqualTo(context.Anchor.position));
+                Assert.That(context.Plot.OccupantInstance.transform.rotation.eulerAngles.z, Is.EqualTo(45f).Within(0.001f));
+                Assert.AreSame(context.TowerParent, context.Plot.OccupantInstance.transform.parent);
+            }
+            finally
+            {
+                context.Destroy();
+            }
+        }
+
+        [Test]
+        public void TryBuild_WithOccupiedPlot_RejectsWithoutSpendingOrSpawning()
+        {
+            var context = CreateContext(startingGold: 75, buildCost: 50);
+            var existingTower = new GameObject("ExistingTower");
+            context.Plot.TryAssignOccupant(existingTower);
+
+            try
+            {
+                var result = context.Controller.TryBuild(context.Plot);
+
+                Assert.That(result, Is.EqualTo(TowerBuildResult.Occupied));
+                Assert.That(context.Inventory.Gold, Is.EqualTo(75), "Occupied plots should not spend gold.");
+                Assert.AreSame(existingTower, context.Plot.OccupantInstance, "Rejected build should keep the existing tower assigned.");
+                Assert.That(context.TowerParent.childCount, Is.EqualTo(0), "Occupied plots should not spawn replacement towers.");
+            }
+            finally
+            {
+                Object.DestroyImmediate(existingTower);
+                context.Destroy();
+            }
+        }
+
+        [Test]
+        public void TryBuild_WithInvalidPrerequisites_RejectsBeforeSpendingOrSpawning()
+        {
+            var context = CreateContext(startingGold: 75, buildCost: 50);
+
+            try
+            {
+                Assert.That(context.Controller.TryBuild(null), Is.EqualTo(TowerBuildResult.InvalidPlot));
+
+                context.Phase.SetPhase(WavePhase.InWave);
+                Assert.That(context.Controller.TryBuild(context.Plot), Is.EqualTo(TowerBuildResult.NotPreWave));
+                context.Phase.SetPhase(WavePhase.PreWave);
+
+                context.Controller.Config = null;
+                Assert.That(context.Controller.TryBuild(context.Plot), Is.EqualTo(TowerBuildResult.MissingConfig));
+
+                context.Controller.Config = context.Config;
+                context.Config.TowerPrefab = null;
+                Assert.That(context.Controller.TryBuild(context.Plot), Is.EqualTo(TowerBuildResult.MissingPrefab));
+
+                context.Config.TowerPrefab = context.TowerPrefab;
+                context.Controller.SetInventory(null);
+                Assert.That(context.Controller.TryBuild(context.Plot), Is.EqualTo(TowerBuildResult.MissingInventory));
+
+                Assert.That(context.Inventory.Gold, Is.EqualTo(75), "Invalid builds should not spend gold.");
+                Assert.IsFalse(context.Plot.IsOccupied, "Invalid builds should not occupy the plot.");
+                Assert.That(context.TowerParent.childCount, Is.EqualTo(0), "Invalid builds should not spawn towers.");
+            }
+            finally
+            {
+                context.Destroy();
+            }
+        }
+
+        [Test]
+        public void TryBuild_WithInsufficientGold_RejectsWithoutSpawning()
+        {
+            var context = CreateContext(startingGold: 25, buildCost: 50);
+
+            try
+            {
+                var result = context.Controller.TryBuild(context.Plot);
+
+                Assert.That(result, Is.EqualTo(TowerBuildResult.InsufficientGold));
+                Assert.That(context.Inventory.Gold, Is.EqualTo(25), "Insufficient gold should not change inventory.");
+                Assert.IsFalse(context.Plot.IsOccupied, "Insufficient gold should not occupy the plot.");
+                Assert.That(context.TowerParent.childCount, Is.EqualTo(0), "Insufficient gold should not spawn towers.");
+            }
+            finally
+            {
+                context.Destroy();
+            }
+        }
+
+        [Test]
+        public void TryBuild_RaisesSuccessAndDeniedFeedback_ForMenuFlashReuse()
+        {
+            var context = CreateContext(startingGold: 75, buildCost: 50);
+            var channel = ScriptableObject.CreateInstance<FeedbackEventChannel>();
+            context.Controller.SetFeedbackChannel(channel);
+
+            FeedbackCueType? lastType = null;
+            int raisedCount = 0;
+            channel.Raised += cue =>
+            {
+                lastType = cue.Type;
+                raisedCount++;
+            };
+
+            try
+            {
+                Assert.That(context.Controller.TryBuild(context.Plot), Is.EqualTo(TowerBuildResult.Success));
+                Assert.That(lastType, Is.EqualTo(FeedbackCueType.UpgradeSuccess));
+
+                Assert.That(context.Controller.TryBuild(context.Plot), Is.EqualTo(TowerBuildResult.Occupied));
+                Assert.That(lastType, Is.EqualTo(FeedbackCueType.UpgradeDenied));
+                Assert.That(raisedCount, Is.EqualTo(2));
+            }
+            finally
+            {
+                Object.DestroyImmediate(channel);
+                context.Destroy();
+            }
+        }
+
+        [Test]
+        public void TowerBuildConfig_ClampsNumericAuthoringValues()
+        {
+            var config = ScriptableObject.CreateInstance<TowerBuildConfig>();
+
+            try
+            {
+                config.BuildCost = -1;
+                config.BaseMaxHealth = -1;
+                config.BaseDamage = -1;
+                config.BaseUpgradeCost = -1;
+
+                Assert.That(config.BuildCost, Is.EqualTo(0));
+                Assert.That(config.BaseMaxHealth, Is.EqualTo(0));
+                Assert.That(config.BaseDamage, Is.EqualTo(0));
+                Assert.That(config.BaseUpgradeCost, Is.EqualTo(0));
+            }
+            finally
+            {
+                Object.DestroyImmediate(config);
+            }
+        }
+
+        private static BuildContext CreateContext(int startingGold, int buildCost)
+        {
+            var root = new GameObject("TowerBuildController");
+            var controller = root.AddComponent<TowerBuildController>();
+            var phase = new WavePhaseTracker();
+            phase.SetPhase(WavePhase.PreWave);
+            controller.SetPhaseTracker(phase);
+
+            var inventory = new InventoryState();
+            inventory.AddGold(startingGold);
+            controller.SetInventory(inventory);
+
+            var config = ScriptableObject.CreateInstance<TowerBuildConfig>();
+            config.BuildCost = buildCost;
+
+            var towerPrefab = new GameObject("ArcherTower");
+            towerPrefab.AddComponent<TowerRuntime>();
+            config.TowerPrefab = towerPrefab;
+            controller.Config = config;
+
+            var towerParent = new GameObject("TowerParent").transform;
+            controller.TowerParent = towerParent;
+
+            var plotRoot = new GameObject("TowerPlot");
+            var anchor = new GameObject("Anchor").transform;
+            anchor.SetParent(plotRoot.transform, false);
+            var plot = plotRoot.AddComponent<TowerPlot>();
+            plot.SetAnchor(anchor);
+
+            return new BuildContext(root, controller, phase, inventory, config, towerPrefab, towerParent, plotRoot, plot, anchor);
+        }
+
+        private sealed class BuildContext
+        {
+            private readonly GameObject root;
+            private readonly GameObject plotRoot;
+
+            public BuildContext(
+                GameObject root,
+                TowerBuildController controller,
+                WavePhaseTracker phase,
+                InventoryState inventory,
+                TowerBuildConfig config,
+                GameObject towerPrefab,
+                Transform towerParent,
+                GameObject plotRoot,
+                TowerPlot plot,
+                Transform anchor)
+            {
+                this.root = root;
+                Controller = controller;
+                Phase = phase;
+                Inventory = inventory;
+                Config = config;
+                TowerPrefab = towerPrefab;
+                TowerParent = towerParent;
+                this.plotRoot = plotRoot;
+                Plot = plot;
+                Anchor = anchor;
+            }
+
+            public TowerBuildController Controller { get; }
+            public WavePhaseTracker Phase { get; }
+            public InventoryState Inventory { get; }
+            public TowerBuildConfig Config { get; }
+            public GameObject TowerPrefab { get; }
+            public Transform TowerParent { get; }
+            public TowerPlot Plot { get; }
+            public Transform Anchor { get; }
+
+            public void Destroy()
+            {
+                if (Config != null)
+                {
+                    Object.DestroyImmediate(Config);
+                }
+
+                if (TowerPrefab != null)
+                {
+                    Object.DestroyImmediate(TowerPrefab);
+                }
+
+                if (TowerParent != null)
+                {
+                    Object.DestroyImmediate(TowerParent.gameObject);
+                }
+
+                if (plotRoot != null)
+                {
+                    Object.DestroyImmediate(plotRoot);
+                }
+
+                if (root != null)
+                {
+                    Object.DestroyImmediate(root);
+                }
+            }
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Tower/TowerBuildControllerTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Tower/TowerBuildControllerTests.cs
@@ -114,6 +114,27 @@ namespace Castlebound.Tests.Tower
         }
 
         [Test]
+        public void TryBuild_WithZeroCost_AllowsBuildWithoutSpendingGold()
+        {
+            var context = CreateContext(startingGold: 0, buildCost: 0);
+
+            try
+            {
+                var result = context.Controller.TryBuild(context.Plot);
+
+                Assert.That(result, Is.EqualTo(TowerBuildResult.Success));
+                Assert.That(context.Inventory.Gold, Is.EqualTo(0), "Zero-cost builds should not call the spend path or change gold.");
+                Assert.IsTrue(context.Plot.IsOccupied, "Zero-cost builds should still occupy the plot.");
+                Assert.NotNull(context.Plot.OccupantInstance, "Zero-cost builds should still spawn and assign a tower.");
+                Assert.That(context.TowerParent.childCount, Is.EqualTo(1), "Zero-cost builds should spawn exactly one tower.");
+            }
+            finally
+            {
+                context.Destroy();
+            }
+        }
+
+        [Test]
         public void TryBuild_RaisesSuccessAndDeniedFeedback_ForMenuFlashReuse()
         {
             var context = CreateContext(startingGold: 75, buildCost: 50);

--- a/Assets/_Project/_Tests/EditMode/Tower/TowerBuildControllerTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Tower/TowerBuildControllerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2098622228bb4d438ac2c517e4d4a14e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/EditMode/UI/UpgradeMenuListViewTowerRowsTests.cs
+++ b/Assets/_Project/_Tests/EditMode/UI/UpgradeMenuListViewTowerRowsTests.cs
@@ -1,0 +1,370 @@
+using System.Linq;
+using System.Reflection;
+using Castlebound.Gameplay.Barrier;
+using Castlebound.Gameplay.Castle;
+using Castlebound.Gameplay.Inventory;
+using Castlebound.Gameplay.Spawning;
+using Castlebound.Gameplay.Tower;
+using Castlebound.Gameplay.UI;
+using NUnit.Framework;
+using UnityEditor.SceneManagement;
+using TMPro;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.UI;
+
+namespace Castlebound.Tests.UI
+{
+    public class UpgradeMenuListViewTowerRowsTests
+    {
+        [Test]
+        public void Refresh_RendersBarrierUpgradeRowAndTowerPlotChildRows()
+        {
+            var context = CreateContext();
+
+            try
+            {
+                context.View.Refresh();
+
+                AssertTextExists(context.ContentRoot, "North Barrier");
+                AssertTextExists(context.ContentRoot, "Tier 0 | HP 10/10 | 20 Gold");
+                AssertTextExists(context.ContentRoot, "- Left Plot");
+                AssertTextExists(context.ContentRoot, "- Right Plot");
+                AssertTextExists(context.ContentRoot, "ArcherTower | HP 10 | DMG 3 | Build 50 Gold");
+                Assert.That(context.ContentRoot.GetComponentsInChildren<Button>(true).Length, Is.EqualTo(3));
+            }
+            finally
+            {
+                context.Destroy();
+            }
+        }
+
+        [Test]
+        public void BuildButton_InvokesTowerBuildController_AndAssignsPlotOccupant()
+        {
+            var context = CreateContext();
+
+            try
+            {
+                context.View.Refresh();
+                var buildButton = FindButtonByLabel(context.ContentRoot, "Build");
+
+                buildButton.onClick.Invoke();
+
+                Assert.That(context.Inventory.Gold, Is.EqualTo(50), "Build button should delegate spending to TowerBuildController.");
+                Assert.IsTrue(context.LeftPlot.IsOccupied, "Build button should build into the selected plot.");
+                Assert.NotNull(context.LeftPlot.OccupantInstance.GetComponent<TowerRuntime>());
+                Assert.That(context.TowerParent.childCount, Is.EqualTo(1));
+            }
+            finally
+            {
+                context.Destroy();
+            }
+        }
+
+        [Test]
+        public void Refresh_RendersOccupiedPlotAsUnavailableWithoutHidingBarrier()
+        {
+            var context = CreateContext();
+            var existingTower = new GameObject("ArcherTower_Instance");
+            existingTower.AddComponent<TowerRuntime>();
+            context.LeftPlot.TryAssignOccupant(existingTower);
+
+            try
+            {
+                context.View.Refresh();
+
+                AssertTextExists(context.ContentRoot, "North Barrier");
+                AssertTextExists(context.ContentRoot, "ArcherTower | HP 10/10 | DMG 3 | Upg 75 Gold");
+
+                var occupiedButton = FindButtonByLabel(context.ContentRoot, "Occupied");
+                Assert.IsFalse(occupiedButton.interactable, "Occupied tower plots should render as unavailable.");
+
+                var buildButtons = FindButtonsByLabel(context.ContentRoot, "Build");
+                Assert.That(buildButtons.Length, Is.EqualTo(1), "Only the remaining empty plot should expose a build action.");
+            }
+            finally
+            {
+                Object.DestroyImmediate(existingTower);
+                context.Destroy();
+            }
+        }
+
+        [Test]
+        public void BarrierUpgradeButton_StillInvokesExistingUpgradeFlow()
+        {
+            var context = CreateContext();
+
+            try
+            {
+                context.View.Refresh();
+                var upgradeButton = FindButtonByLabel(context.ContentRoot, "Upgrade");
+
+                upgradeButton.onClick.Invoke();
+
+                Assert.That(context.BarrierController.GetCurrentTier(), Is.EqualTo(1));
+                Assert.That(context.Inventory.Gold, Is.EqualTo(80), "Barrier upgrade should keep using the existing barrier controller path.");
+                Assert.IsFalse(context.LeftPlot.IsOccupied, "Barrier upgrade should not build towers.");
+            }
+            finally
+            {
+                context.Destroy();
+            }
+        }
+
+        [Test]
+        public void MainPrototype_WiresTowerBuildController_ForUpgradeMenuRows()
+        {
+            Scene scene = default;
+
+            try
+            {
+                scene = EditorSceneManager.OpenScene("Assets/_Project/Scenes/MainPrototype.unity", OpenSceneMode.Additive);
+                Assert.IsTrue(scene.isLoaded, "MainPrototype scene failed to load.");
+
+                var view = FindInScene<UpgradeMenuListView>(scene);
+                Assert.NotNull(view, "MainPrototype must include UpgradeMenuListView.");
+
+                var controller = FindInScene<TowerBuildController>(scene);
+                Assert.NotNull(controller, "MainPrototype must include TowerBuildController so tower child rows can render.");
+                Assert.NotNull(controller.Config, "TowerBuildController must reference TowerBuildConfig.");
+                Assert.NotNull(controller.Config.TowerPrefab, "TowerBuildConfig must reference the tower prefab.");
+
+                var panel = FindTransform(scene, "UpgradeMenuPanel") as RectTransform;
+                Assert.NotNull(panel, "MainPrototype must include UpgradeMenuPanel.");
+                Assert.That(panel.sizeDelta, Is.EqualTo(new Vector2(980f, 620f)), "UpgradeMenuPanel should be large enough for barrier-owned tower rows.");
+
+                var field = typeof(UpgradeMenuListView).GetField("towerBuildController", BindingFlags.NonPublic | BindingFlags.Instance);
+                Assert.NotNull(field, "UpgradeMenuListView should serialize its TowerBuildController reference.");
+                Assert.AreSame(controller, field.GetValue(view), "UpgradeMenuListView should be wired to the scene TowerBuildController.");
+            }
+            finally
+            {
+                if (scene.IsValid() && scene.isLoaded)
+                {
+                    EditorSceneManager.CloseScene(scene, true);
+                }
+            }
+        }
+
+        private static TestContext CreateContext()
+        {
+            var inventory = new InventoryState();
+            inventory.AddGold(100);
+            var phase = new WavePhaseTracker();
+            phase.SetPhase(WavePhase.PreWave);
+
+            var contentRoot = new GameObject("UpgradeMenuContent", typeof(RectTransform)).GetComponent<RectTransform>();
+
+            var viewRoot = new GameObject("UpgradeMenuListView");
+            var view = viewRoot.AddComponent<UpgradeMenuListView>();
+            view.SetContentRoot(contentRoot);
+
+            var barrier = new GameObject("North Barrier");
+            var health = barrier.AddComponent<BarrierHealth>();
+            health.MaxHealth = 10;
+            health.CurrentHealth = 10;
+
+            var barrierConfig = ScriptableObject.CreateInstance<BarrierUpgradeConfig>();
+            barrierConfig.BaseMaxHealth = 10;
+            barrierConfig.BaseCost = 20;
+            barrierConfig.CostPerTier = 10;
+
+            var barrierController = barrier.AddComponent<BarrierUpgradeController>();
+            barrierController.Config = barrierConfig;
+            barrierController.SetInventory(inventory);
+            barrierController.SetPhaseTracker(phase);
+
+            var leftPlot = CreatePlot("LeftPlot", barrier.transform, new Vector3(-1f, 0f, 0f));
+            var rightPlot = CreatePlot("RightPlot", barrier.transform, new Vector3(1f, 0f, 0f));
+            var collection = barrier.AddComponent<BarrierTowerPlotCollection>();
+            collection.SetPlots(new[] { leftPlot, rightPlot });
+
+            var towerRoot = new GameObject("TowerBuildController");
+            var towerController = towerRoot.AddComponent<TowerBuildController>();
+            towerController.SetInventory(inventory);
+            towerController.SetPhaseTracker(phase);
+
+            var towerConfig = ScriptableObject.CreateInstance<TowerBuildConfig>();
+            towerConfig.BuildCost = 50;
+            towerConfig.BaseMaxHealth = 10;
+            towerConfig.BaseDamage = 3;
+            towerConfig.BaseUpgradeCost = 75;
+
+            var towerPrefab = new GameObject("ArcherTower");
+            towerPrefab.AddComponent<TowerRuntime>();
+            towerConfig.TowerPrefab = towerPrefab;
+            towerController.Config = towerConfig;
+
+            var towerParent = new GameObject("TowerParent").transform;
+            towerController.TowerParent = towerParent;
+            view.SetTowerBuildController(towerController);
+
+            return new TestContext(
+                viewRoot,
+                contentRoot.gameObject,
+                barrier,
+                barrierConfig,
+                barrierController,
+                leftPlot,
+                rightPlot,
+                towerRoot,
+                towerConfig,
+                towerPrefab,
+                towerParent,
+                inventory);
+        }
+
+        private static TowerPlot CreatePlot(string name, Transform parent, Vector3 position)
+        {
+            var root = new GameObject(name);
+            root.transform.SetParent(parent, false);
+            root.transform.localPosition = position;
+            return root.AddComponent<TowerPlot>();
+        }
+
+        private static void AssertTextExists(Transform root, string expected)
+        {
+            var texts = root.GetComponentsInChildren<TextMeshProUGUI>(true);
+            Assert.IsTrue(texts.Any(text => text.text == expected), $"Expected UI text '{expected}' was not found.");
+        }
+
+        private static Button FindButtonByLabel(Transform root, string label)
+        {
+            var buttons = FindButtonsByLabel(root, label);
+            Assert.That(buttons.Length, Is.GreaterThan(0), $"Expected button '{label}' was not found.");
+            return buttons[0];
+        }
+
+        private static Button[] FindButtonsByLabel(Transform root, string label)
+        {
+            return root.GetComponentsInChildren<Button>(true)
+                .Where(button =>
+                {
+                    var text = button.GetComponentInChildren<TextMeshProUGUI>(true);
+                    return text != null && text.text == label;
+                })
+                .ToArray();
+        }
+
+        private static T FindInScene<T>(Scene scene) where T : Component
+        {
+            foreach (var root in scene.GetRootGameObjects())
+            {
+                var component = root.GetComponentInChildren<T>(true);
+                if (component != null)
+                {
+                    return component;
+                }
+            }
+
+            return null;
+        }
+
+        private static Transform FindTransform(Scene scene, string name)
+        {
+            foreach (var root in scene.GetRootGameObjects())
+            {
+                foreach (var transform in root.GetComponentsInChildren<Transform>(true))
+                {
+                    if (transform.name == name)
+                    {
+                        return transform;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private sealed class TestContext
+        {
+            private readonly GameObject viewRoot;
+            private readonly GameObject contentRoot;
+            private readonly GameObject barrier;
+            private readonly BarrierUpgradeConfig barrierConfig;
+            private readonly GameObject towerRoot;
+            private readonly TowerBuildConfig towerConfig;
+            private readonly GameObject towerPrefab;
+
+            public TestContext(
+                GameObject viewRoot,
+                GameObject contentRoot,
+                GameObject barrier,
+                BarrierUpgradeConfig barrierConfig,
+                BarrierUpgradeController barrierController,
+                TowerPlot leftPlot,
+                TowerPlot rightPlot,
+                GameObject towerRoot,
+                TowerBuildConfig towerConfig,
+                GameObject towerPrefab,
+                Transform towerParent,
+                InventoryState inventory)
+            {
+                this.viewRoot = viewRoot;
+                this.contentRoot = contentRoot;
+                this.barrier = barrier;
+                this.barrierConfig = barrierConfig;
+                BarrierController = barrierController;
+                LeftPlot = leftPlot;
+                RightPlot = rightPlot;
+                this.towerRoot = towerRoot;
+                this.towerConfig = towerConfig;
+                this.towerPrefab = towerPrefab;
+                TowerParent = towerParent;
+                Inventory = inventory;
+            }
+
+            public UpgradeMenuListView View => viewRoot.GetComponent<UpgradeMenuListView>();
+            public Transform ContentRoot => contentRoot.transform;
+            public BarrierUpgradeController BarrierController { get; }
+            public TowerPlot LeftPlot { get; }
+            public TowerPlot RightPlot { get; }
+            public Transform TowerParent { get; }
+            public InventoryState Inventory { get; }
+
+            public void Destroy()
+            {
+                if (TowerParent != null)
+                {
+                    Object.DestroyImmediate(TowerParent.gameObject);
+                }
+
+                if (towerPrefab != null)
+                {
+                    Object.DestroyImmediate(towerPrefab);
+                }
+
+                if (towerConfig != null)
+                {
+                    Object.DestroyImmediate(towerConfig);
+                }
+
+                if (towerRoot != null)
+                {
+                    Object.DestroyImmediate(towerRoot);
+                }
+
+                if (barrierConfig != null)
+                {
+                    Object.DestroyImmediate(barrierConfig);
+                }
+
+                if (barrier != null)
+                {
+                    Object.DestroyImmediate(barrier);
+                }
+
+                if (contentRoot != null)
+                {
+                    Object.DestroyImmediate(contentRoot);
+                }
+
+                if (viewRoot != null)
+                {
+                    Object.DestroyImmediate(viewRoot);
+                }
+            }
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/UI/UpgradeMenuListViewTowerRowsTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/UI/UpgradeMenuListViewTowerRowsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 91ba43d8bad24879a0c372bae962edc1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/PlayMode/Tower/TowerBuildUpgradeMenuVerticalSlicePlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/Tower/TowerBuildUpgradeMenuVerticalSlicePlayTests.cs
@@ -1,0 +1,164 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Castlebound.Gameplay.Castle;
+using Castlebound.Gameplay.Inventory;
+using Castlebound.Gameplay.Spawning;
+using Castlebound.Gameplay.Tower;
+using Castlebound.Gameplay.UI;
+using NUnit.Framework;
+using UnityEngine.EventSystems;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.TestTools;
+using UnityEngine.UI;
+
+namespace Castlebound.Tests.PlayMode.Tower
+{
+    public class TowerBuildUpgradeMenuVerticalSlicePlayTests
+    {
+        private const string MainPrototypeSceneName = "MainPrototype";
+
+        [UnityTest]
+        public IEnumerator MainPrototype_UpgradeMenu_BuildsTowerOnBarrierPlot_AndBlocksRepurchase()
+        {
+            yield return LoadMainPrototype();
+
+            var menu = FindInActiveScene<UpgradeMenuController>();
+            var listView = FindInActiveScene<UpgradeMenuListView>();
+            var buildController = FindInActiveScene<TowerBuildController>();
+            var inventorySource = FindInActiveScene<InventoryStateComponent>();
+            Assert.NotNull(menu, "Expected MainPrototype to include UpgradeMenuController.");
+            Assert.NotNull(listView, "Expected MainPrototype to include UpgradeMenuListView.");
+            Assert.NotNull(buildController, "Expected MainPrototype to include TowerBuildController.");
+            Assert.NotNull(buildController.Config, "TowerBuildController must have a build config.");
+            Assert.NotNull(buildController.Config.TowerPrefab, "TowerBuildConfig must reference the real tower prefab.");
+            Assert.NotNull(inventorySource, "Expected MainPrototype to expose an inventory source for upgrade purchases.");
+
+            var tracker = new WavePhaseTracker();
+            menu.SetPhaseTracker(tracker);
+            buildController.SetPhaseTracker(tracker);
+            buildController.SetInventory(inventorySource.State);
+            listView.SetTowerBuildController(buildController);
+
+            int startingGold = inventorySource.State.Gold;
+            inventorySource.State.AddGold(buildController.Config.BuildCost * 2);
+            int goldBeforeBuild = inventorySource.State.Gold;
+            int towerCountBeforeBuild = Object.FindObjectsOfType<TowerRuntime>().Length;
+
+            var plots = FindPlots();
+            Assert.That(plots.Count, Is.GreaterThan(0), "Expected generated barriers to expose tower plots.");
+            Assert.That(plots.Any(plot => !plot.IsOccupied), Is.True, "Expected at least one empty tower plot before building.");
+            menu.ToggleMenu();
+            yield return null;
+
+            Assert.IsTrue(menu.IsMenuOpen, "Upgrade menu should open in pre-wave.");
+            var buildButton = FindActiveButtonWithLabel("Build");
+            Assert.NotNull(buildButton, "Expected the upgrade menu to expose a Build button for an empty tower plot.");
+            Assert.IsTrue(buildButton.interactable, "Empty tower plot Build button should be interactable.");
+            Assert.That(buildButton.onClick.GetPersistentEventCount(), Is.EqualTo(0), "Runtime-created build buttons should use non-persistent listeners.");
+
+            var eventSystem = EventSystem.current;
+            if (eventSystem == null)
+            {
+                eventSystem = new GameObject("TestEventSystem").AddComponent<EventSystem>();
+            }
+
+            ExecuteEvents.Execute(buildButton.gameObject, new PointerEventData(eventSystem), ExecuteEvents.pointerClickHandler);
+            yield return null;
+            yield return new WaitForSeconds(0.2f);
+
+            var occupiedPlots = FindPlots().Where(plot => plot.IsOccupied).ToList();
+            if (occupiedPlots.Count != 1)
+            {
+                var directResult = buildController.TryBuild(plots.First(plot => !plot.IsOccupied));
+                Assert.Fail($"Expected one occupied tower plot after menu build click, but found {occupiedPlots.Count}. Direct build result on an empty plot was {directResult}.");
+            }
+
+            var occupiedPlot = occupiedPlots[0];
+            Assert.NotNull(occupiedPlot.OccupantInstance, "Built plot should reference the spawned tower instance.");
+            Assert.NotNull(occupiedPlot.OccupantInstance.GetComponent<TowerRuntime>(), "Build should spawn the real Tower prefab runtime.");
+            Assert.That(Object.FindObjectsOfType<TowerRuntime>().Length, Is.EqualTo(towerCountBeforeBuild + 1), "Build should add one tower runtime to the scene.");
+            Assert.That(inventorySource.State.Gold, Is.EqualTo(goldBeforeBuild - buildController.Config.BuildCost), "Build should spend gold exactly once.");
+
+            int goldAfterBuild = inventorySource.State.Gold;
+            int towerCountAfterBuild = Object.FindObjectsOfType<TowerRuntime>().Length;
+
+            var occupiedButton = FindActiveButtonWithLabel("Occupied");
+            Assert.NotNull(occupiedButton, "Occupied plot should remain visible in the menu as a blocked row.");
+            Assert.IsFalse(occupiedButton.interactable, "Occupied plot row should not allow repeat purchase.");
+
+            var duplicateResult = buildController.TryBuild(occupiedPlot);
+            yield return null;
+
+            Assert.That(duplicateResult, Is.EqualTo(TowerBuildResult.Occupied), "Repeat build attempts on the same plot should be rejected.");
+            Assert.That(inventorySource.State.Gold, Is.EqualTo(goldAfterBuild), "Rejected duplicate builds should not spend gold again.");
+            Assert.That(Object.FindObjectsOfType<TowerRuntime>().Length, Is.EqualTo(towerCountAfterBuild), "Rejected duplicate builds should not spawn another tower.");
+
+            if (startingGold == 0)
+            {
+                Assert.That(inventorySource.State.Gold, Is.EqualTo(buildController.Config.BuildCost), "Test setup should leave only the second grant after one successful purchase.");
+            }
+        }
+
+        private static IEnumerator LoadMainPrototype()
+        {
+            var load = SceneManager.LoadSceneAsync(MainPrototypeSceneName, LoadSceneMode.Single);
+            while (!load.isDone)
+            {
+                yield return null;
+            }
+
+            yield return null;
+            yield return new WaitForFixedUpdate();
+        }
+
+        private static List<TowerPlot> FindPlots()
+        {
+            return Object.FindObjectsOfType<BarrierTowerPlotCollection>()
+                .SelectMany(collection => collection.Plots)
+                .Where(plot => plot != null)
+                .ToList();
+        }
+
+        private static Button FindActiveButtonWithLabel(string label)
+        {
+            return Object.FindObjectsOfType<Button>()
+                .Where(button => button.gameObject.activeInHierarchy && button.name == "BuildButton")
+                .FirstOrDefault(button =>
+                {
+                    foreach (var component in button.GetComponentsInChildren<Component>())
+                    {
+                        if (component == null || component.GetType().Name != "TextMeshProUGUI")
+                        {
+                            continue;
+                        }
+
+                        var textProperty = component.GetType().GetProperty("text");
+                        var text = textProperty != null ? textProperty.GetValue(component) as string : null;
+                        if (text == label)
+                        {
+                            return true;
+                        }
+                    }
+
+                    return false;
+                });
+        }
+
+        private static T FindInActiveScene<T>() where T : Component
+        {
+            var scene = SceneManager.GetActiveScene();
+            foreach (var root in scene.GetRootGameObjects())
+            {
+                var component = root.GetComponentInChildren<T>(true);
+                if (component != null)
+                {
+                    return component;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/Assets/_Project/_Tests/PlayMode/Tower/TowerBuildUpgradeMenuVerticalSlicePlayTests.cs.meta
+++ b/Assets/_Project/_Tests/PlayMode/Tower/TowerBuildUpgradeMenuVerticalSlicePlayTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 31f8e555d3f2486f9668d747641e03a3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,23 @@
 
 ---
 
+## 2026-04-30 - fix(tower): allow zero-cost builds
+
+### Summary
+- Fixed tower build orchestration so `BuildCost` values of `0` skip the spend call instead of being rejected as insufficient gold.
+- Kept normal positive-cost spending and rollback behavior unchanged.
+- Added regression coverage for successful zero-cost tower builds with no gold.
+
+### New or Updated Tests
+**EditMode**
+- `TowerBuildControllerTests` - verifies zero-cost tower builds succeed without changing gold.
+
+**PlayMode**
+- N/A - N/A
+
+### Notes
+- N/A
+
 ## 2026-04-29 - test(playmode): tower build vertical slice
 
 ### Summary

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,23 @@
 
 ---
 
+## 2026-04-29 - feat(gameplay): tower build orchestration
+
+### Summary
+- Added a `TowerBuildConfig` asset contract for tower prefab, build cost, and visible future stat fields.
+- Added a focused `TowerBuildController` that gates builds to pre-wave, validates plot availability, spends gold once, spawns the configured tower, and assigns it to the plot.
+- Reused upgrade success/denied feedback cues so the existing menu flash colors can support tower build outcomes.
+
+### New or Updated Tests
+**EditMode**
+- `TowerBuildControllerTests` - verifies successful build, invalid prerequisite rejection, occupied plot rejection, insufficient gold rejection, feedback reuse, and config value clamping.
+
+**PlayMode**
+- N/A - N/A
+
+### Notes
+- N/A
+
 ## 2026-04-29 - feat(castle): authored barrier flank tower plots
 
 ### Summary

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,23 @@
 
 ---
 
+## 2026-04-27 - feat(castle): tower plot contract
+
+### Summary
+- Added a reusable `TowerPlot` contract that owns plot anchor and occupancy state without taking on build or UI responsibilities.
+- Added `BarrierTowerPlotCollection` so barriers reference a collection of plots instead of fixed left/right slot fields.
+- Added EditMode coverage for empty/occupied plot lifecycle, collection-based barrier linkage, and plug-and-play normalization of null/duplicate plot wiring.
+
+### New or Updated Tests
+**EditMode**
+- `TowerPlotContractTests` - verifies plot anchor fallback, occupant lifecycle, collection-based barrier linkage, and reusable multi-plot authoring behavior.
+
+**PlayMode**
+- N/A - N/A
+
+### Notes
+- Step 1 intentionally stops at plot contract/state only; build orchestration and authored plot placement follow in later PR slices.
+
 ## 2026-04-14 - feat(tower): prefab asset contract coverage
 
 ### Summary

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,23 @@
 
 ---
 
+## 2026-04-29 - test(playmode): tower build vertical slice
+
+### Summary
+- Added a MainPrototype PlayMode smoke for the real between-wave upgrade menu tower build path.
+- Verified a menu Build action spends gold once, spawns the configured Tower prefab, and assigns the spawned runtime to a barrier tower plot.
+- Verified occupied plot rows stay visible but disabled and duplicate build attempts do not spend or spawn again.
+
+### New or Updated Tests
+**EditMode**
+- N/A - N/A
+
+**PlayMode**
+- `TowerBuildUpgradeMenuVerticalSlicePlayTests` - verifies the integrated barrier plot tower build path through the upgrade menu and duplicate purchase rejection.
+
+### Notes
+- N/A
+
 ## 2026-04-29 - feat(ui): barrier tower build rows
 
 ### Summary

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,29 @@
 
 ---
 
+## 2026-04-29 - feat(ui): barrier tower build rows
+
+### Summary
+- Extended the between-wave upgrade list to render barrier-owned tower plot child rows beneath each barrier upgrade row.
+- Kept tower build spending and spawning delegated to `TowerBuildController` while the UI only renders plot state and invokes actions.
+- Added occupied plot presentation so built tower slots stay visible but cannot be repurchased.
+- Wired `MainPrototype` to a scene-level `TowerBuildController` and `TowerBuildConfig` so tower rows appear in normal gameplay.
+- Tightened tower row text and indentation so child plot rows fit inside the existing menu and read as subordinate barrier actions.
+- Replaced shorthand currency copy with game-facing `Gold` labels.
+- Enlarged `UpgradeMenuPanel` in `MainPrototype` so the barrier-owned tower rows fit in the authored menu.
+- Widened row columns and added barrier-group spacing so buttons do not cover text and each barrier block reads separately.
+- Increased the gap before row buttons and between barrier groups for clearer menu scanning.
+
+### New or Updated Tests
+**EditMode**
+- `UpgradeMenuListViewTowerRowsTests` - verifies barrier upgrade rows, tower child rows, build invocation, occupied plot disabling, existing barrier upgrade action behavior, and MainPrototype tower build wiring.
+
+**PlayMode**
+- N/A - N/A
+
+### Notes
+- N/A
+
 ## 2026-04-29 - feat(gameplay): tower build orchestration
 
 ### Summary

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,24 @@
 
 ---
 
+## 2026-04-29 - feat(castle): authored barrier flank tower plots
+
+### Summary
+- Authored two reusable tower plot anchors on the barrier prefab so generated barriers inherit left/right flank slots automatically.
+- Kept tower plot ownership on `BarrierTowerPlotCollection` while letting `SystemsRoot` rotation carry plot orientation per barrier side.
+- Added prefab and generated-barrier integration coverage for two-slot plot wiring and lattice-aligned plot anchors.
+
+### New or Updated Tests
+**EditMode**
+- `BarrierPrefabVisualContractTests` - verifies the barrier prefab exposes two distinct flank plots under `SystemsRoot`.
+- `MainPrototypeBarrierAssemblyIntegrationTests` - verifies generated barriers inherit two linked tower plots with lattice-aligned anchors.
+
+**PlayMode**
+- N/A - N/A
+
+### Notes
+- Future handoff note: a tile-driven plot-generation pipeline may be added later, but this commit intentionally authors the first flank slots on the barrier prefab itself.
+
 ## 2026-04-27 - feat(castle): tower plot contract
 
 ### Summary


### PR DESCRIPTION
## Why
Adds the first full tower build vertical slice so generated barriers expose tower slots and players can build towers from the between-wave upgrade menu.

## What changed
- Added reusable tower plot and barrier plot collection contracts
- Authored two flank tower plots on generated barrier prefabs
- Added tower build orchestration for validation, gold spending, spawning, and occupancy assignment
- Extended the upgrade menu with barrier-owned tower plot rows
- Added EditMode and PlayMode coverage for the full build path
- Allows valid zero-cost tower build configs to spawn towers without spending gold

## How to test
1. Open `MainPrototype`
2. Press Play → open/verify the between-wave upgrade menu
3. Build a tower from a barrier plot and verify duplicate purchase is blocked
4. Run tests:
   - EditMode
   - PlayMode

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated (if player-visible)
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched 

## Related
- Closes #162
