### PR TITLE
feat/tower-targeting-acquisition

### DIFF
--- a/Assets/_Project/Prefabs/Tower.prefab
+++ b/Assets/_Project/Prefabs/Tower.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: 2000000002}
   - component: {fileID: 2000000003}
   - component: {fileID: 2000000004}
+  - component: {fileID: 2000000005}
   m_Layer: 0
   m_Name: Tower
   m_TagString: Untagged
@@ -112,6 +113,24 @@ MonoBehaviour:
   m_EditorClassIdentifier:
   targetingProfile: {fileID: 11400000, guid: e004816ce28b4dc0934be9cac2fe7bb8, type: 2}
   targetBufferSize: 16
+--- !u!114 &2000000005
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2000000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30ed71147d4b4a269344be99909d25b0, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  aimEnabled: 1
+  targetingController: {fileID: 2000000004}
+  aimPivot: {fileID: 2000000011}
+  aimMode: 0
+  rotationSpeedDegrees: 720
+  aimOffsetDegrees: 0
 --- !u!1 &2000000010
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/_Project/Prefabs/Tower.prefab
+++ b/Assets/_Project/Prefabs/Tower.prefab
@@ -131,6 +131,9 @@ MonoBehaviour:
   aimMode: 0
   rotationSpeedDegrees: 720
   aimOffsetDegrees: 0
+  returnToIdleWhenNoTarget: 1
+  idleLocalAngleDegrees: 0
+  idleReturnSpeedDegrees: 360
 --- !u!1 &2000000010
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/_Project/Prefabs/Tower.prefab
+++ b/Assets/_Project/Prefabs/Tower.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 2000000001}
   - component: {fileID: 2000000002}
   - component: {fileID: 2000000003}
+  - component: {fileID: 2000000004}
   m_Layer: 0
   m_Name: Tower
   m_TagString: Untagged
@@ -97,6 +98,20 @@ MonoBehaviour:
   aimPivot: {fileID: 2000000011}
   towerVisual: {fileID: 2000000021}
   platformVisual: {fileID: 2000000031}
+--- !u!114 &2000000004
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2000000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 091115741b4a47b2a949443c9265aa5d, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  targetingProfile: {fileID: 11400000, guid: e004816ce28b4dc0934be9cac2fe7bb8, type: 2}
+  targetBufferSize: 16
 --- !u!1 &2000000010
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerAimController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerAimController.cs
@@ -11,6 +11,9 @@ namespace Castlebound.Gameplay.Tower
         [SerializeField] private TowerAimMode aimMode;
         [SerializeField] private float rotationSpeedDegrees = 720f;
         [SerializeField] private float aimOffsetDegrees;
+        [SerializeField] private bool returnToIdleWhenNoTarget;
+        [SerializeField] private float idleLocalAngleDegrees;
+        [SerializeField] private float idleReturnSpeedDegrees = 360f;
 
         public bool AimEnabled
         {
@@ -56,6 +59,24 @@ namespace Castlebound.Gameplay.Tower
             set => aimOffsetDegrees = value;
         }
 
+        public bool ReturnToIdleWhenNoTarget
+        {
+            get => returnToIdleWhenNoTarget;
+            set => returnToIdleWhenNoTarget = value;
+        }
+
+        public float IdleLocalAngleDegrees
+        {
+            get => idleLocalAngleDegrees;
+            set => idleLocalAngleDegrees = value;
+        }
+
+        public float IdleReturnSpeedDegrees
+        {
+            get => idleReturnSpeedDegrees;
+            set => idleReturnSpeedDegrees = Mathf.Max(0f, value);
+        }
+
         private void Reset()
         {
             EnsureReferences();
@@ -65,11 +86,13 @@ namespace Castlebound.Gameplay.Tower
         {
             EnsureReferences();
             rotationSpeedDegrees = Mathf.Max(0f, rotationSpeedDegrees);
+            idleReturnSpeedDegrees = Mathf.Max(0f, idleReturnSpeedDegrees);
         }
 
         private void OnValidate()
         {
             rotationSpeedDegrees = Mathf.Max(0f, rotationSpeedDegrees);
+            idleReturnSpeedDegrees = Mathf.Max(0f, idleReturnSpeedDegrees);
             EnsureReferences();
         }
 
@@ -87,8 +110,14 @@ namespace Castlebound.Gameplay.Tower
 
             EnsureReferences();
 
-            if (targetingController == null || aimPivot == null || targetingController.CurrentTarget == null)
+            if (targetingController == null || aimPivot == null)
             {
+                return;
+            }
+
+            if (targetingController.CurrentTarget == null)
+            {
+                ReturnToIdle(deltaTime);
                 return;
             }
 
@@ -114,6 +143,20 @@ namespace Castlebound.Gameplay.Tower
         private float GetTargetAngle(Vector3 direction)
         {
             return Mathf.Atan2(direction.y, direction.x) * Mathf.Rad2Deg - 90f + aimOffsetDegrees;
+        }
+
+        private void ReturnToIdle(float deltaTime)
+        {
+            if (!returnToIdleWhenNoTarget)
+            {
+                return;
+            }
+
+            var idleRotation = Quaternion.Euler(0f, 0f, idleLocalAngleDegrees);
+            aimPivot.localRotation = Quaternion.RotateTowards(
+                aimPivot.localRotation,
+                idleRotation,
+                idleReturnSpeedDegrees * Mathf.Max(0f, deltaTime));
         }
 
         private void EnsureReferences()

--- a/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerAimController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerAimController.cs
@@ -1,0 +1,136 @@
+using UnityEngine;
+
+namespace Castlebound.Gameplay.Tower
+{
+    [DefaultExecutionOrder(100)]
+    public class TowerAimController : MonoBehaviour
+    {
+        [SerializeField] private bool aimEnabled = true;
+        [SerializeField] private TowerTargetingController targetingController;
+        [SerializeField] private Transform aimPivot;
+        [SerializeField] private TowerAimMode aimMode;
+        [SerializeField] private float rotationSpeedDegrees = 720f;
+        [SerializeField] private float aimOffsetDegrees;
+
+        public bool AimEnabled
+        {
+            get => aimEnabled;
+            set => aimEnabled = value;
+        }
+
+        public TowerTargetingController TargetingController
+        {
+            get
+            {
+                EnsureReferences();
+                return targetingController;
+            }
+            set => targetingController = value;
+        }
+
+        public Transform AimPivot
+        {
+            get
+            {
+                EnsureReferences();
+                return aimPivot;
+            }
+            set => aimPivot = value;
+        }
+
+        public TowerAimMode AimMode
+        {
+            get => aimMode;
+            set => aimMode = value;
+        }
+
+        public float RotationSpeedDegrees
+        {
+            get => rotationSpeedDegrees;
+            set => rotationSpeedDegrees = Mathf.Max(0f, value);
+        }
+
+        public float AimOffsetDegrees
+        {
+            get => aimOffsetDegrees;
+            set => aimOffsetDegrees = value;
+        }
+
+        private void Reset()
+        {
+            EnsureReferences();
+        }
+
+        private void Awake()
+        {
+            EnsureReferences();
+            rotationSpeedDegrees = Mathf.Max(0f, rotationSpeedDegrees);
+        }
+
+        private void OnValidate()
+        {
+            rotationSpeedDegrees = Mathf.Max(0f, rotationSpeedDegrees);
+            EnsureReferences();
+        }
+
+        private void LateUpdate()
+        {
+            ApplyAimNow(Time.deltaTime);
+        }
+
+        public void ApplyAimNow(float deltaTime)
+        {
+            if (!aimEnabled)
+            {
+                return;
+            }
+
+            EnsureReferences();
+
+            if (targetingController == null || aimPivot == null || targetingController.CurrentTarget == null)
+            {
+                return;
+            }
+
+            var direction = targetingController.CurrentTarget.position - aimPivot.position;
+            if (direction.sqrMagnitude <= Mathf.Epsilon)
+            {
+                return;
+            }
+
+            var targetRotation = Quaternion.Euler(0f, 0f, GetTargetAngle(direction));
+            if (aimMode == TowerAimMode.RotateToward)
+            {
+                aimPivot.rotation = Quaternion.RotateTowards(
+                    aimPivot.rotation,
+                    targetRotation,
+                    rotationSpeedDegrees * Mathf.Max(0f, deltaTime));
+                return;
+            }
+
+            aimPivot.rotation = targetRotation;
+        }
+
+        private float GetTargetAngle(Vector3 direction)
+        {
+            return Mathf.Atan2(direction.y, direction.x) * Mathf.Rad2Deg - 90f + aimOffsetDegrees;
+        }
+
+        private void EnsureReferences()
+        {
+            if (targetingController == null)
+            {
+                targetingController = GetComponent<TowerTargetingController>();
+            }
+
+            if (aimPivot == null)
+            {
+                var runtime = GetComponent<TowerRuntime>();
+                if (runtime != null)
+                {
+                    aimPivot = runtime.AimPivot;
+                }
+            }
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerAimController.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerAimController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 30ed71147d4b4a269344be99909d25b0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerAimMode.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerAimMode.cs
@@ -1,0 +1,8 @@
+namespace Castlebound.Gameplay.Tower
+{
+    public enum TowerAimMode
+    {
+        Instant = 0,
+        RotateToward = 1
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerAimMode.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerAimMode.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cd148399932e47c5847487160d8af092
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerTargetSelectionMode.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerTargetSelectionMode.cs
@@ -1,0 +1,8 @@
+namespace Castlebound.Gameplay.Tower
+{
+    public enum TowerTargetSelectionMode
+    {
+        Nearest = 0,
+        Farthest = 1
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerTargetSelectionMode.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerTargetSelectionMode.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: aa98f2ebd2bc41b1895170175e5b2936
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerTargetingController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerTargetingController.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using Castlebound.Gameplay.AI;
 
 namespace Castlebound.Gameplay.Tower
 {
@@ -109,6 +110,12 @@ namespace Castlebound.Gameplay.Tower
             }
 
             if (candidateCollider.transform == transform || candidateCollider.transform.IsChildOf(transform))
+            {
+                return false;
+            }
+
+            var regionState = candidateCollider.GetComponentInParent<EnemyRegionState>();
+            if (regionState != null && regionState.EnemyInside)
             {
                 return false;
             }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerTargetingController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerTargetingController.cs
@@ -1,0 +1,140 @@
+using UnityEngine;
+
+namespace Castlebound.Gameplay.Tower
+{
+    public class TowerTargetingController : MonoBehaviour
+    {
+        private const int MinTargetBufferSize = 1;
+
+        [SerializeField] private TowerTargetingProfile targetingProfile;
+        [SerializeField] private int targetBufferSize = 16;
+
+        private Collider2D[] targetBuffer;
+        private float nextScanTime;
+
+        public TowerTargetingProfile TargetingProfile
+        {
+            get => targetingProfile;
+            set => targetingProfile = value;
+        }
+
+        public Transform CurrentTarget { get; private set; }
+
+        public int TargetBufferSize
+        {
+            get => targetBufferSize;
+            set
+            {
+                targetBufferSize = Mathf.Max(MinTargetBufferSize, value);
+                EnsureTargetBuffer();
+            }
+        }
+
+        private void Awake()
+        {
+            EnsureTargetBuffer();
+        }
+
+        private void OnValidate()
+        {
+            targetBufferSize = Mathf.Max(MinTargetBufferSize, targetBufferSize);
+        }
+
+        private void Update()
+        {
+            if (targetingProfile == null || Time.time < nextScanTime)
+            {
+                return;
+            }
+
+            AcquireTargetNow();
+            nextScanTime = Time.time + targetingProfile.ScanInterval;
+        }
+
+        public Transform AcquireTargetNow()
+        {
+            EnsureTargetBuffer();
+            CurrentTarget = null;
+
+            if (targetingProfile == null || targetingProfile.MaxRange <= 0f)
+            {
+                return null;
+            }
+
+            var origin = (Vector2)transform.position;
+            var hitCount = Physics2D.OverlapCircleNonAlloc(
+                origin,
+                targetingProfile.MaxRange,
+                targetBuffer,
+                targetingProfile.TargetLayers);
+
+            var minRangeSqr = targetingProfile.MinRange * targetingProfile.MinRange;
+            var maxRangeSqr = targetingProfile.MaxRange * targetingProfile.MaxRange;
+            var bestScore = targetingProfile.SelectionMode == TowerTargetSelectionMode.Nearest
+                ? float.PositiveInfinity
+                : float.NegativeInfinity;
+
+            for (var i = 0; i < hitCount; i++)
+            {
+                var candidateCollider = targetBuffer[i];
+                targetBuffer[i] = null;
+
+                if (!IsValidCandidate(candidateCollider, origin, minRangeSqr, maxRangeSqr, out var distanceSqr))
+                {
+                    continue;
+                }
+
+                if (IsBetterCandidate(distanceSqr, bestScore))
+                {
+                    bestScore = distanceSqr;
+                    CurrentTarget = candidateCollider.transform;
+                }
+            }
+
+            return CurrentTarget;
+        }
+
+        private bool IsValidCandidate(
+            Collider2D candidateCollider,
+            Vector2 origin,
+            float minRangeSqr,
+            float maxRangeSqr,
+            out float distanceSqr)
+        {
+            distanceSqr = 0f;
+
+            if (candidateCollider == null || !candidateCollider.enabled || !candidateCollider.gameObject.activeInHierarchy)
+            {
+                return false;
+            }
+
+            if (candidateCollider.transform == transform || candidateCollider.transform.IsChildOf(transform))
+            {
+                return false;
+            }
+
+            distanceSqr = ((Vector2)candidateCollider.transform.position - origin).sqrMagnitude;
+            return distanceSqr >= minRangeSqr && distanceSqr <= maxRangeSqr;
+        }
+
+        private bool IsBetterCandidate(float distanceSqr, float bestScore)
+        {
+            if (targetingProfile.SelectionMode == TowerTargetSelectionMode.Farthest)
+            {
+                return distanceSqr > bestScore;
+            }
+
+            return distanceSqr < bestScore;
+        }
+
+        private void EnsureTargetBuffer()
+        {
+            targetBufferSize = Mathf.Max(MinTargetBufferSize, targetBufferSize);
+
+            if (targetBuffer == null || targetBuffer.Length != targetBufferSize)
+            {
+                targetBuffer = new Collider2D[targetBufferSize];
+            }
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerTargetingController.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerTargetingController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 091115741b4a47b2a949443c9265aa5d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerTargetingProfile.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerTargetingProfile.cs
@@ -1,0 +1,55 @@
+using UnityEngine;
+
+namespace Castlebound.Gameplay.Tower
+{
+    [CreateAssetMenu(menuName = "Castlebound/Tower/Tower Targeting Profile")]
+    public class TowerTargetingProfile : ScriptableObject
+    {
+        [SerializeField] private float minRange;
+        [SerializeField] private float maxRange = 5f;
+        [SerializeField] private float scanInterval = 0.2f;
+        [SerializeField] private LayerMask targetLayers;
+        [SerializeField] private TowerTargetSelectionMode selectionMode;
+
+        public float MinRange
+        {
+            get => minRange;
+            set
+            {
+                minRange = Mathf.Max(0f, value);
+                maxRange = Mathf.Max(minRange, maxRange);
+            }
+        }
+
+        public float MaxRange
+        {
+            get => maxRange;
+            set => maxRange = Mathf.Max(minRange, value);
+        }
+
+        public float ScanInterval
+        {
+            get => scanInterval;
+            set => scanInterval = Mathf.Max(0.02f, value);
+        }
+
+        public LayerMask TargetLayers
+        {
+            get => targetLayers;
+            set => targetLayers = value;
+        }
+
+        public TowerTargetSelectionMode SelectionMode
+        {
+            get => selectionMode;
+            set => selectionMode = value;
+        }
+
+        private void OnValidate()
+        {
+            minRange = Mathf.Max(0f, minRange);
+            maxRange = Mathf.Max(minRange, maxRange);
+            scanInterval = Mathf.Max(0.02f, scanInterval);
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerTargetingProfile.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerTargetingProfile.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 06d7787f81f746c0a7119dc098e046c1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Tower/BaseTowerTargetingProfile.asset
+++ b/Assets/_Project/Tower/BaseTowerTargetingProfile.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier:
   minRange: 0
   maxRange: 5
-  scanInterval: 0.2
+  scanInterval: 0.1
   targetLayers:
     serializedVersion: 2
     m_Bits: 128

--- a/Assets/_Project/Tower/BaseTowerTargetingProfile.asset
+++ b/Assets/_Project/Tower/BaseTowerTargetingProfile.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 06d7787f81f746c0a7119dc098e046c1, type: 3}
+  m_Name: BaseTowerTargetingProfile
+  m_EditorClassIdentifier:
+  minRange: 0
+  maxRange: 5
+  scanInterval: 0.2
+  targetLayers:
+    serializedVersion: 2
+    m_Bits: 128
+  selectionMode: 0

--- a/Assets/_Project/Tower/BaseTowerTargetingProfile.asset.meta
+++ b/Assets/_Project/Tower/BaseTowerTargetingProfile.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e004816ce28b4dc0934be9cac2fe7bb8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/_Tests/EditMode/Tower/TowerAimControllerTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Tower/TowerAimControllerTests.cs
@@ -1,0 +1,126 @@
+using Castlebound.Gameplay.Tower;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Castlebound.Tests.Tower
+{
+    public class TowerAimControllerTests
+    {
+        private const int TargetLayer = 0;
+
+        private GameObject towerObject;
+        private Transform aimPivot;
+        private TowerTargetingController targetingController;
+        private TowerAimController aimController;
+        private TowerTargetingProfile targetingProfile;
+
+        [SetUp]
+        public void SetUp()
+        {
+            towerObject = new GameObject("Tower");
+            aimPivot = new GameObject("AimPivot").transform;
+            aimPivot.SetParent(towerObject.transform);
+
+            targetingController = towerObject.AddComponent<TowerTargetingController>();
+            targetingProfile = ScriptableObject.CreateInstance<TowerTargetingProfile>();
+            targetingProfile.MaxRange = 5f;
+            targetingProfile.TargetLayers = 1 << TargetLayer;
+            targetingController.TargetingProfile = targetingProfile;
+
+            aimController = towerObject.AddComponent<TowerAimController>();
+            aimController.TargetingController = targetingController;
+            aimController.AimPivot = aimPivot;
+            aimController.AimMode = TowerAimMode.Instant;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(targetingProfile);
+            Object.DestroyImmediate(towerObject);
+
+            foreach (var gameObject in Object.FindObjectsOfType<GameObject>())
+            {
+                if (gameObject.name.StartsWith("Enemy"))
+                {
+                    Object.DestroyImmediate(gameObject);
+                }
+            }
+        }
+
+        [Test]
+        public void ApplyAimNow_RotatesAimPivotTowardCurrentTarget_WhenEnabled()
+        {
+            CreateEnemy("Enemy_Right", new Vector2(2f, 0f));
+            Physics2D.SyncTransforms();
+            targetingController.AcquireTargetNow();
+
+            aimController.ApplyAimNow(0f);
+
+            Assert.That(Mathf.DeltaAngle(aimPivot.eulerAngles.z, -90f), Is.EqualTo(0f).Within(0.01f));
+        }
+
+        [Test]
+        public void ApplyAimNow_DoesNotRotateAimPivot_WhenAimIsDisabled()
+        {
+            aimController.AimEnabled = false;
+            CreateEnemy("Enemy_Right", new Vector2(2f, 0f));
+            Physics2D.SyncTransforms();
+            targetingController.AcquireTargetNow();
+
+            aimController.ApplyAimNow(0f);
+
+            Assert.That(Mathf.DeltaAngle(aimPivot.eulerAngles.z, 0f), Is.EqualTo(0f).Within(0.01f));
+        }
+
+        [Test]
+        public void ApplyAimNow_DoesNothingSafely_WhenNoTargetExists()
+        {
+            aimPivot.rotation = Quaternion.Euler(0f, 0f, 35f);
+
+            aimController.ApplyAimNow(0f);
+
+            Assert.That(Mathf.DeltaAngle(aimPivot.eulerAngles.z, 35f), Is.EqualTo(0f).Within(0.01f));
+        }
+
+        [Test]
+        public void ApplyAimNow_TracksMovingCurrentTarget_WithoutReacquiring()
+        {
+            var enemy = CreateEnemy("Enemy_Moving", new Vector2(2f, 0f));
+            Physics2D.SyncTransforms();
+            targetingController.AcquireTargetNow();
+            aimController.ApplyAimNow(0f);
+
+            enemy.transform.position = new Vector2(0f, 2f);
+            Physics2D.SyncTransforms();
+            aimController.ApplyAimNow(0f);
+
+            Assert.That(Mathf.DeltaAngle(aimPivot.eulerAngles.z, 0f), Is.EqualTo(0f).Within(0.01f));
+        }
+
+        [Test]
+        public void ApplyAimNow_RotatesTowardTarget_WhenConfiguredForSmoothAim()
+        {
+            aimController.AimMode = TowerAimMode.RotateToward;
+            aimController.RotationSpeedDegrees = 90f;
+            CreateEnemy("Enemy_Right", new Vector2(2f, 0f));
+            Physics2D.SyncTransforms();
+            targetingController.AcquireTargetNow();
+
+            aimController.ApplyAimNow(0.5f);
+
+            Assert.That(Mathf.DeltaAngle(aimPivot.eulerAngles.z, -45f), Is.EqualTo(0f).Within(0.01f));
+        }
+
+        private static GameObject CreateEnemy(string objectName, Vector2 position)
+        {
+            var enemy = new GameObject(objectName)
+            {
+                layer = TargetLayer
+            };
+            enemy.transform.position = position;
+            enemy.AddComponent<CircleCollider2D>();
+            return enemy;
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Tower/TowerAimControllerTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Tower/TowerAimControllerTests.cs
@@ -84,6 +84,30 @@ namespace Castlebound.Tests.Tower
         }
 
         [Test]
+        public void ApplyAimNow_ReturnsTowardIdle_WhenNoTargetExistsAndIdleReturnEnabled()
+        {
+            aimController.ReturnToIdleWhenNoTarget = true;
+            aimController.IdleLocalAngleDegrees = 0f;
+            aimController.IdleReturnSpeedDegrees = 90f;
+            aimPivot.localRotation = Quaternion.Euler(0f, 0f, 90f);
+
+            aimController.ApplyAimNow(0.5f);
+
+            Assert.That(Mathf.DeltaAngle(aimPivot.localEulerAngles.z, 45f), Is.EqualTo(0f).Within(0.01f));
+        }
+
+        [Test]
+        public void ApplyAimNow_DoesNotReturnToIdle_WhenIdleReturnIsDisabled()
+        {
+            aimController.ReturnToIdleWhenNoTarget = false;
+            aimPivot.localRotation = Quaternion.Euler(0f, 0f, 90f);
+
+            aimController.ApplyAimNow(0.5f);
+
+            Assert.That(Mathf.DeltaAngle(aimPivot.localEulerAngles.z, 90f), Is.EqualTo(0f).Within(0.01f));
+        }
+
+        [Test]
         public void ApplyAimNow_TracksMovingCurrentTarget_WithoutReacquiring()
         {
             var enemy = CreateEnemy("Enemy_Moving", new Vector2(2f, 0f));
@@ -96,6 +120,39 @@ namespace Castlebound.Tests.Tower
             aimController.ApplyAimNow(0f);
 
             Assert.That(Mathf.DeltaAngle(aimPivot.eulerAngles.z, 0f), Is.EqualTo(0f).Within(0.01f));
+        }
+
+        [Test]
+        public void ApplyAimNow_AimsAtCurrentTargetInsteadOfReturningToIdle()
+        {
+            aimController.ReturnToIdleWhenNoTarget = true;
+            aimController.IdleLocalAngleDegrees = 0f;
+            aimController.IdleReturnSpeedDegrees = 90f;
+            aimPivot.localRotation = Quaternion.Euler(0f, 0f, 90f);
+            CreateEnemy("Enemy_Right", new Vector2(2f, 0f));
+            Physics2D.SyncTransforms();
+            targetingController.AcquireTargetNow();
+
+            aimController.ApplyAimNow(0.5f);
+
+            Assert.That(Mathf.DeltaAngle(aimPivot.eulerAngles.z, -90f), Is.EqualTo(0f).Within(0.01f));
+        }
+
+        [Test]
+        public void ApplyAimNow_ReturnsTowardIdle_WhenCurrentTargetIsDestroyed()
+        {
+            aimController.ReturnToIdleWhenNoTarget = true;
+            aimController.IdleLocalAngleDegrees = 0f;
+            aimController.IdleReturnSpeedDegrees = 90f;
+            aimPivot.localRotation = Quaternion.Euler(0f, 0f, 90f);
+            var enemy = CreateEnemy("Enemy_Destroyed", new Vector2(2f, 0f));
+            Physics2D.SyncTransforms();
+            targetingController.AcquireTargetNow();
+            Object.DestroyImmediate(enemy);
+
+            aimController.ApplyAimNow(0.5f);
+
+            Assert.That(Mathf.DeltaAngle(aimPivot.localEulerAngles.z, 45f), Is.EqualTo(0f).Within(0.01f));
         }
 
         [Test]

--- a/Assets/_Project/_Tests/EditMode/Tower/TowerAimControllerTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Tower/TowerAimControllerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1aae78f2044e4effacb1288b187ebccf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/_Tests/EditMode/Tower/TowerRuntimeContractTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Tower/TowerRuntimeContractTests.cs
@@ -91,6 +91,7 @@ namespace Castlebound.Tests.Tower
                 Assert.That(profile.MinRange, Is.GreaterThanOrEqualTo(0f), "Tower targeting min range must be non-negative.");
                 Assert.That(profile.MaxRange, Is.GreaterThan(profile.MinRange), "Tower targeting max range must exceed min range.");
                 Assert.That(profile.ScanInterval, Is.GreaterThan(0f), "Tower targeting scan interval must be above zero.");
+                Assert.That(profile.ScanInterval, Is.LessThanOrEqualTo(0.1f), "Base arrow tower should acquire targets responsively.");
                 Assert.That(profile.SelectionMode, Is.EqualTo(TowerTargetSelectionMode.Nearest), "Base tower should acquire the nearest valid enemy.");
 
                 var enemiesLayer = LayerMask.NameToLayer("Enemies");
@@ -99,6 +100,32 @@ namespace Castlebound.Tests.Tower
                     profile.TargetLayers.value & (1 << enemiesLayer),
                     Is.Not.Zero,
                     "Base tower targeting profile must include the Enemies layer.");
+            }
+            finally
+            {
+                PrefabTestUtil.Unload(prefabRoot);
+            }
+        }
+
+        [Test]
+        public void TowerPrefab_SerializesAimContract_ForBaseArrowTower()
+        {
+            var prefabRoot = PrefabTestUtil.Load(TowerPrefabPath);
+
+            try
+            {
+                var runtime = prefabRoot.GetComponent<TowerRuntime>();
+                var targetingController = prefabRoot.GetComponent<TowerTargetingController>();
+                var aimController = prefabRoot.GetComponent<TowerAimController>();
+
+                Assert.NotNull(runtime, "Tower prefab must include TowerRuntime.");
+                Assert.NotNull(targetingController, "Tower prefab must include TowerTargetingController.");
+                Assert.NotNull(aimController, "Base arrow tower prefab must include TowerAimController.");
+                Assert.IsTrue(aimController.AimEnabled, "Base arrow tower should aim at acquired targets by default.");
+                Assert.AreSame(targetingController, aimController.TargetingController, "TowerAimController should read from the prefab targeting controller.");
+                Assert.AreSame(runtime.AimPivot, aimController.AimPivot, "TowerAimController should rotate the TowerRuntime AimPivot.");
+                Assert.That(aimController.AimMode, Is.EqualTo(TowerAimMode.Instant), "Base arrow tower should snap aim until attack presentation needs smoothing.");
+                Assert.That(aimController.RotationSpeedDegrees, Is.GreaterThanOrEqualTo(0f), "Tower aim rotation speed must be non-negative.");
             }
             finally
             {

--- a/Assets/_Project/_Tests/EditMode/Tower/TowerRuntimeContractTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Tower/TowerRuntimeContractTests.cs
@@ -126,6 +126,9 @@ namespace Castlebound.Tests.Tower
                 Assert.AreSame(runtime.AimPivot, aimController.AimPivot, "TowerAimController should rotate the TowerRuntime AimPivot.");
                 Assert.That(aimController.AimMode, Is.EqualTo(TowerAimMode.Instant), "Base arrow tower should snap aim until attack presentation needs smoothing.");
                 Assert.That(aimController.RotationSpeedDegrees, Is.GreaterThanOrEqualTo(0f), "Tower aim rotation speed must be non-negative.");
+                Assert.IsTrue(aimController.ReturnToIdleWhenNoTarget, "Base arrow tower should return to forward aim when no target is available.");
+                Assert.That(aimController.IdleLocalAngleDegrees, Is.EqualTo(0f), "Base arrow tower idle aim should match the authored forward rest angle.");
+                Assert.That(aimController.IdleReturnSpeedDegrees, Is.GreaterThan(0f), "Base arrow tower idle return speed must be above zero.");
             }
             finally
             {

--- a/Assets/_Project/_Tests/EditMode/Tower/TowerRuntimeContractTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Tower/TowerRuntimeContractTests.cs
@@ -76,6 +76,36 @@ namespace Castlebound.Tests.Tower
             }
         }
 
+        [Test]
+        public void TowerPrefab_SerializesTargetingContract_ForBaseTower()
+        {
+            var prefabRoot = PrefabTestUtil.Load(TowerPrefabPath);
+
+            try
+            {
+                var targetingController = prefabRoot.GetComponent<TowerTargetingController>();
+                Assert.NotNull(targetingController, "Tower prefab must include TowerTargetingController.");
+
+                var profile = targetingController.TargetingProfile;
+                Assert.NotNull(profile, "TowerTargetingController must reference a targeting profile.");
+                Assert.That(profile.MinRange, Is.GreaterThanOrEqualTo(0f), "Tower targeting min range must be non-negative.");
+                Assert.That(profile.MaxRange, Is.GreaterThan(profile.MinRange), "Tower targeting max range must exceed min range.");
+                Assert.That(profile.ScanInterval, Is.GreaterThan(0f), "Tower targeting scan interval must be above zero.");
+                Assert.That(profile.SelectionMode, Is.EqualTo(TowerTargetSelectionMode.Nearest), "Base tower should acquire the nearest valid enemy.");
+
+                var enemiesLayer = LayerMask.NameToLayer("Enemies");
+                Assert.That(enemiesLayer, Is.GreaterThanOrEqualTo(0), "Project must define the Enemies layer.");
+                Assert.That(
+                    profile.TargetLayers.value & (1 << enemiesLayer),
+                    Is.Not.Zero,
+                    "Base tower targeting profile must include the Enemies layer.");
+            }
+            finally
+            {
+                PrefabTestUtil.Unload(prefabRoot);
+            }
+        }
+
         private static Transform FindChildRecursive(Transform root, string childName)
         {
             foreach (var child in root.GetComponentsInChildren<Transform>(true))

--- a/Assets/_Project/_Tests/EditMode/Tower/TowerTargetingControllerTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Tower/TowerTargetingControllerTests.cs
@@ -1,0 +1,137 @@
+using Castlebound.Gameplay.Tower;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Castlebound.Tests.Tower
+{
+    public class TowerTargetingControllerTests
+    {
+        private const int TargetLayer = 0;
+
+        private GameObject towerObject;
+        private TowerTargetingController targetingController;
+        private TowerTargetingProfile targetingProfile;
+
+        [SetUp]
+        public void SetUp()
+        {
+            towerObject = new GameObject("Tower");
+            targetingController = towerObject.AddComponent<TowerTargetingController>();
+            targetingProfile = ScriptableObject.CreateInstance<TowerTargetingProfile>();
+            targetingProfile.MinRange = 0f;
+            targetingProfile.MaxRange = 5f;
+            targetingProfile.ScanInterval = 0.2f;
+            targetingProfile.TargetLayers = 1 << TargetLayer;
+            targetingProfile.SelectionMode = TowerTargetSelectionMode.Nearest;
+            targetingController.TargetingProfile = targetingProfile;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(targetingProfile);
+            Object.DestroyImmediate(towerObject);
+
+            foreach (var gameObject in Object.FindObjectsOfType<GameObject>())
+            {
+                if (gameObject.name.StartsWith("Enemy"))
+                {
+                    Object.DestroyImmediate(gameObject);
+                }
+            }
+        }
+
+        [Test]
+        public void AcquireTargetNow_ReturnsNull_WhenNoEnemiesAreInRange()
+        {
+            var target = targetingController.AcquireTargetNow();
+
+            Assert.IsNull(target);
+            Assert.IsNull(targetingController.CurrentTarget);
+        }
+
+        [Test]
+        public void AcquireTargetNow_IgnoresEnemyInsideMinimumRange()
+        {
+            targetingProfile.MinRange = 2f;
+            targetingProfile.MaxRange = 5f;
+            var closeEnemy = CreateEnemy("Enemy_Close", new Vector2(1f, 0f));
+            CreateEnemy("Enemy_Valid", new Vector2(3f, 0f));
+            Physics2D.SyncTransforms();
+
+            var target = targetingController.AcquireTargetNow();
+
+            Assert.AreNotSame(closeEnemy.transform, target);
+            Assert.That(target.name, Is.EqualTo("Enemy_Valid"));
+        }
+
+        [Test]
+        public void AcquireTargetNow_IgnoresEnemyOutsideMaximumRange()
+        {
+            targetingProfile.MaxRange = 3f;
+            CreateEnemy("Enemy_Far", new Vector2(4f, 0f));
+            Physics2D.SyncTransforms();
+
+            var target = targetingController.AcquireTargetNow();
+
+            Assert.IsNull(target);
+            Assert.IsNull(targetingController.CurrentTarget);
+        }
+
+        [Test]
+        public void AcquireTargetNow_SelectsNearestValidEnemy_WhenConfiguredForNearest()
+        {
+            targetingProfile.SelectionMode = TowerTargetSelectionMode.Nearest;
+            CreateEnemy("Enemy_Farther", new Vector2(4f, 0f));
+            var nearestEnemy = CreateEnemy("Enemy_Nearest", new Vector2(2f, 0f));
+            Physics2D.SyncTransforms();
+
+            var target = targetingController.AcquireTargetNow();
+
+            Assert.AreSame(nearestEnemy.transform, target);
+            Assert.AreSame(nearestEnemy.transform, targetingController.CurrentTarget);
+        }
+
+        [Test]
+        public void AcquireTargetNow_SelectsFarthestValidEnemy_WhenConfiguredForFarthest()
+        {
+            targetingProfile.SelectionMode = TowerTargetSelectionMode.Farthest;
+            CreateEnemy("Enemy_Nearer", new Vector2(2f, 0f));
+            var farthestEnemy = CreateEnemy("Enemy_Farthest", new Vector2(4f, 0f));
+            Physics2D.SyncTransforms();
+
+            var target = targetingController.AcquireTargetNow();
+
+            Assert.AreSame(farthestEnemy.transform, target);
+            Assert.AreSame(farthestEnemy.transform, targetingController.CurrentTarget);
+        }
+
+        [Test]
+        public void AcquireTargetNow_ClearsCurrentTarget_WhenTargetLeavesRange()
+        {
+            targetingProfile.MaxRange = 3f;
+            var enemy = CreateEnemy("Enemy_Target", new Vector2(2f, 0f));
+            Physics2D.SyncTransforms();
+
+            targetingController.AcquireTargetNow();
+            enemy.transform.position = new Vector2(4f, 0f);
+            Physics2D.SyncTransforms();
+
+            var target = targetingController.AcquireTargetNow();
+
+            Assert.IsNull(target);
+            Assert.IsNull(targetingController.CurrentTarget);
+        }
+
+        private static GameObject CreateEnemy(string objectName, Vector2 position)
+        {
+            var enemy = new GameObject(objectName)
+            {
+                layer = TargetLayer
+            };
+            enemy.transform.position = position;
+            enemy.AddComponent<CircleCollider2D>();
+            return enemy;
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Tower/TowerTargetingControllerTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Tower/TowerTargetingControllerTests.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+using Castlebound.Gameplay.AI;
 using Castlebound.Gameplay.Tower;
 using NUnit.Framework;
 using UnityEngine;
@@ -107,6 +109,33 @@ namespace Castlebound.Tests.Tower
         }
 
         [Test]
+        public void AcquireTargetNow_IgnoresEnemyInsideCastleRegion()
+        {
+            var insideEnemy = CreateEnemy("Enemy_Inside", new Vector2(2f, 0f), true);
+            Physics2D.SyncTransforms();
+
+            var target = targetingController.AcquireTargetNow();
+
+            Assert.AreNotSame(insideEnemy.transform, target);
+            Assert.IsNull(target);
+            Assert.IsNull(targetingController.CurrentTarget);
+        }
+
+        [Test]
+        public void AcquireTargetNow_SelectsNextOutsideEnemy_WhenNearestEnemyIsInsideCastleRegion()
+        {
+            var insideEnemy = CreateEnemy("Enemy_Inside", new Vector2(1f, 0f), true);
+            var outsideEnemy = CreateEnemy("Enemy_Outside", new Vector2(3f, 0f));
+            Physics2D.SyncTransforms();
+
+            var target = targetingController.AcquireTargetNow();
+
+            Assert.AreNotSame(insideEnemy.transform, target);
+            Assert.AreSame(outsideEnemy.transform, target);
+            Assert.AreSame(outsideEnemy.transform, targetingController.CurrentTarget);
+        }
+
+        [Test]
         public void AcquireTargetNow_ClearsCurrentTarget_WhenTargetLeavesRange()
         {
             targetingProfile.MaxRange = 3f;
@@ -123,7 +152,23 @@ namespace Castlebound.Tests.Tower
             Assert.IsNull(targetingController.CurrentTarget);
         }
 
-        private static GameObject CreateEnemy(string objectName, Vector2 position)
+        [Test]
+        public void AcquireTargetNow_ClearsCurrentTarget_WhenTargetEntersCastleRegion()
+        {
+            var enemy = CreateEnemy("Enemy_Target", new Vector2(2f, 0f));
+            var regionState = enemy.AddComponent<EnemyRegionState>();
+            Physics2D.SyncTransforms();
+
+            targetingController.AcquireTargetNow();
+            SetEnemyInside(regionState, true);
+
+            var target = targetingController.AcquireTargetNow();
+
+            Assert.IsNull(target);
+            Assert.IsNull(targetingController.CurrentTarget);
+        }
+
+        private static GameObject CreateEnemy(string objectName, Vector2 position, bool enemyInside = false)
         {
             var enemy = new GameObject(objectName)
             {
@@ -131,7 +176,20 @@ namespace Castlebound.Tests.Tower
             };
             enemy.transform.position = position;
             enemy.AddComponent<CircleCollider2D>();
+            if (enemyInside)
+            {
+                SetEnemyInside(enemy.AddComponent<EnemyRegionState>(), true);
+            }
+
             return enemy;
+        }
+
+        private static void SetEnemyInside(EnemyRegionState regionState, bool enemyInside)
+        {
+            var enemyInsideField = typeof(EnemyRegionState).GetField(
+                "enemyInside",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            enemyInsideField.SetValue(regionState, enemyInside);
         }
     }
 }

--- a/Assets/_Project/_Tests/EditMode/Tower/TowerTargetingControllerTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Tower/TowerTargetingControllerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0d41c766ace04fda9d2103f34aa5ab4a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,23 @@
 
 ---
 
+## 2026-04-30 - feat(tower): targeting acquisition contract
+
+### Summary
+- Added a tower targeting profile contract for prefab-specific min range, max range, scan interval, target layers, and nearest/farthest selection.
+- Added a tower targeting controller that acquires targets with a reusable non-alloc 2D physics buffer.
+- Covered mortar-style dead zones, oil-style close range, nearest targeting, farthest targeting, and target clearing behavior.
+
+### New or Updated Tests
+**EditMode**
+- `TowerTargetingControllerTests` - verifies no-target, min/max range filtering, nearest/farthest selection, and current target clearing.
+
+**PlayMode**
+- N/A - N/A
+
+### Notes
+- EditMode and PlayMode passed per user before commit.
+
 ## 2026-04-30 - fix(tower): allow zero-cost builds
 
 ### Summary

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,23 @@
 
 ---
 
+## 2026-05-01 - feat(tower): wire targeting prefab contract
+
+### Summary
+- Added a base tower targeting profile asset for the default tower prefab.
+- Wired `Tower.prefab` with `TowerTargetingController` and the base targeting profile.
+- Added prefab contract coverage for targeting profile assignment, range settings, scan interval, nearest selection, and Enemies layer targeting.
+
+### New or Updated Tests
+**EditMode**
+- `TowerRuntimeContractTests` - verifies the Tower prefab serializes the base targeting controller and profile contract.
+
+**PlayMode**
+- N/A - N/A
+
+### Notes
+- EditMode and PlayMode passed per user before commit.
+
 ## 2026-04-30 - feat(tower): targeting acquisition contract
 
 ### Summary

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,23 @@
 
 ---
 
+## 2026-05-02 - feat(tower): filter inside castle targets
+
+### Summary
+- Updated tower targeting so enemies marked inside the castle region are ignored.
+- Kept enemies without region state targetable for simple tests and future non-enemy target dummies.
+- Added regression coverage for selecting the next outside enemy and clearing a target that enters the castle.
+
+### New or Updated Tests
+**EditMode**
+- `TowerTargetingControllerTests` - verifies inside-castle enemies are ignored, outside enemies remain targetable, and current targets clear after entering the castle.
+
+**PlayMode**
+- N/A - N/A
+
+### Notes
+- EditMode and PlayMode passed per user before commit.
+
 ## 2026-05-01 - feat(tower): add optional aim tracking
 
 ### Summary

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,24 @@
 
 ---
 
+## 2026-05-01 - feat(tower): add optional aim tracking
+
+### Summary
+- Added an optional tower aim controller that rotates a configured aim pivot toward the acquired target.
+- Wired the base Tower prefab as the arrow tower with aiming enabled by default.
+- Added coverage for enabled aim, disabled aim, moving target tracking, no-target safety, smooth rotation, and prefab aim wiring.
+
+### New or Updated Tests
+**EditMode**
+- `TowerAimControllerTests` - verifies aim rotation, disabled aim behavior, no-target safety, and smooth rotate-toward behavior.
+- `TowerRuntimeContractTests` - verifies the Tower prefab serializes the base arrow tower aim contract.
+
+**PlayMode**
+- N/A - N/A
+
+### Notes
+- EditMode and PlayMode passed per user before commit.
+
 ## 2026-05-01 - feat(tower): wire targeting prefab contract
 
 ### Summary

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,24 @@
 
 ---
 
+## 2026-05-02 - feat(tower): return aim to idle
+
+### Summary
+- Added optional idle aim return so towers rotate back to their forward rest angle when no valid target exists.
+- Wired the base Tower prefab to return to forward aim when its target is lost, destroyed, or no longer valid.
+- Kept idle return visual-only and bypassed whenever a valid current target exists.
+
+### New or Updated Tests
+**EditMode**
+- `TowerAimControllerTests` - verifies idle return, disabled idle return, destroyed-target return, and valid-target priority over idle return.
+- `TowerRuntimeContractTests` - verifies the Tower prefab serializes idle aim return settings for the base arrow tower.
+
+**PlayMode**
+- N/A - N/A
+
+### Notes
+- EditMode and PlayMode passed per user before commit.
+
 ## 2026-05-02 - feat(tower): filter inside castle targets
 
 ### Summary


### PR DESCRIPTION
## Why
Towers need a reusable, prefab-friendly targeting foundation before attack execution can be added. This PR lets towers acquire valid outside-castle enemies, visually aim at them, and return to idle when no valid target remains.

## What changed
- Added data-driven tower targeting profiles with range, scan interval, layer mask, and selection mode.
- Added non-alloc tower target acquisition with nearest/farthest selection.
- Wired the base Tower prefab with targeting and aim components.
- Added optional aim tracking and idle return behavior for the base arrow tower.
- Filtered out enemies that have entered the castle region.
- Added EditMode coverage for targeting rules, aim behavior, prefab contracts, and regressions.

## How to test
1. Open the relevant scene or demo
2. Press Play → verify towers acquire outside enemies, aim smoothly, ignore enemies inside the castle, switch to another valid target, and return to idle when no target remains
3. Run tests:
   - EditMode
   - PlayMode

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated (N/A - prefab-driven, no scene change needed)
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched 

## Related
- Closes #159
