### PR TITLE
feat(tower): add projectile attack execution

### DIFF
--- a/Assets/_Project/Prefabs/Tower.prefab
+++ b/Assets/_Project/Prefabs/Tower.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 2000000003}
   - component: {fileID: 2000000004}
   - component: {fileID: 2000000005}
+  - component: {fileID: 2000000006}
   m_Layer: 0
   m_Name: Tower
   m_TagString: Untagged
@@ -92,8 +93,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8ec82cd20e3b4088a853d04a374353fa, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   maxHealth: 10
   currentHealth: 10
   aimPivot: {fileID: 2000000011}
@@ -134,6 +135,28 @@ MonoBehaviour:
   returnToIdleWhenNoTarget: 1
   idleLocalAngleDegrees: 0
   idleReturnSpeedDegrees: 360
+--- !u!114 &2000000006
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2000000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fdf059d5f1f843d686491abf59e28079, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  targetingController: {fileID: 2000000004}
+  projectilePrefab: {fileID: 3000000004, guid: 2068e524b8354641b7be4e35cf537fd4, type: 3}
+  firePoint: {fileID: 2000000011}
+  damage: 1
+  cooldownSeconds: 1
+  projectileSpeed: 8
+  projectileLifetime: 3
+  targetLayerMask:
+    serializedVersion: 2
+    m_Bits: 128
 --- !u!1 &2000000010
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/_Project/Prefabs/Tower.prefab
+++ b/Assets/_Project/Prefabs/Tower.prefab
@@ -149,11 +149,12 @@ MonoBehaviour:
   m_EditorClassIdentifier:
   targetingController: {fileID: 2000000004}
   projectilePrefab: {fileID: 3000000004, guid: 2068e524b8354641b7be4e35cf537fd4, type: 3}
-  firePoint: {fileID: 2000000011}
+  firePoint: {fileID: 2000000041}
   damage: 1
   cooldownSeconds: 1
   projectileSpeed: 8
   projectileLifetime: 3
+  projectileVisualAngleOffsetDegrees: -45
   targetLayerMask:
     serializedVersion: 2
     m_Bits: 128
@@ -186,8 +187,40 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 2000000041}
   - {fileID: 2000000021}
   m_Father: {fileID: 2000000001}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2000000040
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2000000041}
+  m_Layer: 0
+  m_Name: FirePoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2000000041
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2000000040}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.05, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2000000011}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2000000020
 GameObject:

--- a/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerAttackController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerAttackController.cs
@@ -13,6 +13,7 @@ namespace Castlebound.Gameplay.Tower
         [SerializeField] private float cooldownSeconds = 1f;
         [SerializeField] private float projectileSpeed = 8f;
         [SerializeField] private float projectileLifetime = 3f;
+        [SerializeField] private float projectileVisualAngleOffsetDegrees = -45f;
         [SerializeField] private LayerMask targetLayerMask;
 
         private float nextFireTime;
@@ -61,6 +62,12 @@ namespace Castlebound.Gameplay.Tower
             set => projectileLifetime = Mathf.Max(0f, value);
         }
 
+        public float ProjectileVisualAngleOffsetDegrees
+        {
+            get => projectileVisualAngleOffsetDegrees;
+            set => projectileVisualAngleOffsetDegrees = value;
+        }
+
         public LayerMask TargetLayerMask
         {
             get => targetLayerMask;
@@ -104,10 +111,11 @@ namespace Castlebound.Gameplay.Tower
             }
 
             var origin = firePoint != null ? (Vector2)firePoint.position : (Vector2)transform.position;
-            var projectile = Instantiate(projectilePrefab, origin, Quaternion.identity);
-            var context = ProjectileLaunchContext.TowardPoint(
+            var direction = ResolveLaunchDirection(origin, target.position);
+            var projectile = Instantiate(projectilePrefab, origin, CreateProjectileRotation(direction));
+            var context = ProjectileLaunchContext.Directional(
                 origin,
-                target.position,
+                direction,
                 transform,
                 projectileSpeed,
                 damage,
@@ -134,6 +142,23 @@ namespace Castlebound.Gameplay.Tower
             cooldownSeconds = Mathf.Max(0f, cooldownSeconds);
             projectileSpeed = Mathf.Max(0f, projectileSpeed);
             projectileLifetime = Mathf.Max(0f, projectileLifetime);
+        }
+
+        private Vector2 ResolveLaunchDirection(Vector2 origin, Vector2 targetPoint)
+        {
+            var targetDirection = targetPoint - origin;
+            if (targetDirection.sqrMagnitude > 0f)
+            {
+                return targetDirection.normalized;
+            }
+
+            return firePoint != null ? (Vector2)firePoint.up : Vector2.up;
+        }
+
+        private Quaternion CreateProjectileRotation(Vector2 launchDirection)
+        {
+            var angle = Mathf.Atan2(launchDirection.y, launchDirection.x) * Mathf.Rad2Deg;
+            return Quaternion.Euler(0f, 0f, angle + projectileVisualAngleOffsetDegrees);
         }
     }
 }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerAttackController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerAttackController.cs
@@ -1,0 +1,139 @@
+using System;
+using Castlebound.Gameplay.Projectile;
+using UnityEngine;
+
+namespace Castlebound.Gameplay.Tower
+{
+    public class TowerAttackController : MonoBehaviour
+    {
+        [SerializeField] private TowerTargetingController targetingController;
+        [SerializeField] private ProjectileRuntime projectilePrefab;
+        [SerializeField] private Transform firePoint;
+        [SerializeField] private int damage = 1;
+        [SerializeField] private float cooldownSeconds = 1f;
+        [SerializeField] private float projectileSpeed = 8f;
+        [SerializeField] private float projectileLifetime = 3f;
+        [SerializeField] private LayerMask targetLayerMask;
+
+        private float nextFireTime;
+
+        public event Action<ProjectileRuntime> Fired;
+
+        public TowerTargetingController TargetingController
+        {
+            get => targetingController;
+            set => targetingController = value;
+        }
+
+        public ProjectileRuntime ProjectilePrefab
+        {
+            get => projectilePrefab;
+            set => projectilePrefab = value;
+        }
+
+        public Transform FirePoint
+        {
+            get => firePoint;
+            set => firePoint = value;
+        }
+
+        public int Damage
+        {
+            get => damage;
+            set => damage = Mathf.Max(0, value);
+        }
+
+        public float CooldownSeconds
+        {
+            get => cooldownSeconds;
+            set => cooldownSeconds = Mathf.Max(0f, value);
+        }
+
+        public float ProjectileSpeed
+        {
+            get => projectileSpeed;
+            set => projectileSpeed = Mathf.Max(0f, value);
+        }
+
+        public float ProjectileLifetime
+        {
+            get => projectileLifetime;
+            set => projectileLifetime = Mathf.Max(0f, value);
+        }
+
+        public LayerMask TargetLayerMask
+        {
+            get => targetLayerMask;
+            set => targetLayerMask = value;
+        }
+
+        private void Reset()
+        {
+            EnsureReferences();
+            NormalizeStats();
+        }
+
+        private void Awake()
+        {
+            EnsureReferences();
+        }
+
+        private void OnValidate()
+        {
+            NormalizeStats();
+        }
+
+        private void Update()
+        {
+            TryFire(Time.time);
+        }
+
+        public ProjectileRuntime TryFire(float currentTime)
+        {
+            EnsureReferences();
+
+            if (projectilePrefab == null || targetingController == null || currentTime < nextFireTime)
+            {
+                return null;
+            }
+
+            var target = targetingController.CurrentTarget;
+            if (target == null)
+            {
+                return null;
+            }
+
+            var origin = firePoint != null ? (Vector2)firePoint.position : (Vector2)transform.position;
+            var projectile = Instantiate(projectilePrefab, origin, Quaternion.identity);
+            var context = ProjectileLaunchContext.TowardPoint(
+                origin,
+                target.position,
+                transform,
+                projectileSpeed,
+                damage,
+                projectileLifetime,
+                targetLayerMask);
+
+            projectile.Launch(context);
+            nextFireTime = currentTime + cooldownSeconds;
+            Fired?.Invoke(projectile);
+            return projectile;
+        }
+
+        private void EnsureReferences()
+        {
+            if (targetingController == null)
+            {
+                targetingController = GetComponent<TowerTargetingController>();
+            }
+        }
+
+        private void NormalizeStats()
+        {
+            damage = Mathf.Max(0, damage);
+            cooldownSeconds = Mathf.Max(0f, cooldownSeconds);
+            projectileSpeed = Mathf.Max(0f, projectileSpeed);
+            projectileLifetime = Mathf.Max(0f, projectileLifetime);
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerAttackController.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerAttackController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fdf059d5f1f843d686491abf59e28079
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/EditMode/Tower/TowerAttackControllerTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Tower/TowerAttackControllerTests.cs
@@ -1,0 +1,216 @@
+using System.Reflection;
+using Castlebound.Gameplay.Projectile;
+using Castlebound.Gameplay.Tower;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Castlebound.Tests.Tower
+{
+    public class TowerAttackControllerTests
+    {
+        [Test]
+        public void TryFire_ReturnsNull_WhenNoTarget()
+        {
+            var fixture = CreateFixture();
+
+            try
+            {
+                var projectile = fixture.AttackController.TryFire(0f);
+
+                Assert.IsNull(projectile, "Tower should not fire without an acquired target.");
+                Assert.That(fixture.FiredCount, Is.EqualTo(0), "Tower should not raise Fired without a projectile.");
+            }
+            finally
+            {
+                fixture.Destroy();
+            }
+        }
+
+        [Test]
+        public void TryFire_SpawnsProjectile_WhenTargetAvailableAndCooldownReady()
+        {
+            var fixture = CreateFixture();
+            var target = CreateTarget("Enemy", new Vector2(2f, 0f));
+
+            try
+            {
+                fixture.TargetingController.AcquireTargetNow();
+
+                var projectile = fixture.AttackController.TryFire(0f);
+
+                Assert.NotNull(projectile, "Tower should spawn a projectile when a target is available.");
+                Assert.AreSame(projectile, fixture.LastFiredProjectile, "Fired event should include the spawned projectile.");
+                Assert.That(fixture.FiredCount, Is.EqualTo(1));
+                Assert.That(projectile.transform.position, Is.EqualTo(fixture.FirePoint.position), "Projectile should launch from the fire point.");
+            }
+            finally
+            {
+                Object.DestroyImmediate(target);
+                fixture.Destroy();
+            }
+        }
+
+        [Test]
+        public void TryFire_RespectsCooldown()
+        {
+            var fixture = CreateFixture();
+            var target = CreateTarget("Enemy", new Vector2(2f, 0f));
+
+            try
+            {
+                fixture.TargetingController.AcquireTargetNow();
+
+                var first = fixture.AttackController.TryFire(0f);
+                var second = fixture.AttackController.TryFire(0.5f);
+                var third = fixture.AttackController.TryFire(1f);
+
+                Assert.NotNull(first, "Precondition: first shot should fire.");
+                Assert.IsNull(second, "Tower should not fire again before cooldown completes.");
+                Assert.NotNull(third, "Tower should fire again once cooldown completes.");
+                Assert.That(fixture.FiredCount, Is.EqualTo(2));
+            }
+            finally
+            {
+                Object.DestroyImmediate(target);
+                fixture.Destroy();
+            }
+        }
+
+        [Test]
+        public void TryFire_LaunchesProjectileWithTowerAttackStats()
+        {
+            var fixture = CreateFixture();
+            var target = CreateTarget("Enemy", new Vector2(0f, 3f));
+
+            try
+            {
+                fixture.TargetingController.AcquireTargetNow();
+
+                var projectile = fixture.AttackController.TryFire(0f);
+
+                Assert.NotNull(projectile, "Precondition: tower should fire at the acquired target.");
+                Assert.AreSame(fixture.Tower.transform, GetPrivate<Transform>(projectile, "owner"));
+                Assert.That(GetPrivate<Vector2>(projectile, "direction"), Is.EqualTo(Vector2.up));
+                Assert.That(GetPrivate<float>(projectile, "speed"), Is.EqualTo(fixture.AttackController.ProjectileSpeed));
+                Assert.That(GetPrivate<int>(projectile, "damage"), Is.EqualTo(fixture.AttackController.Damage));
+                Assert.That(GetPrivate<float>(projectile, "remainingLifetime"), Is.EqualTo(fixture.AttackController.ProjectileLifetime));
+                Assert.That(GetPrivate<LayerMask>(projectile, "targetLayerMask").value, Is.EqualTo(fixture.AttackController.TargetLayerMask.value));
+            }
+            finally
+            {
+                Object.DestroyImmediate(target);
+                fixture.Destroy();
+            }
+        }
+
+        private static TowerAttackFixture CreateFixture()
+        {
+            var tower = new GameObject("Tower");
+            var firePoint = new GameObject("FirePoint").transform;
+            firePoint.SetParent(tower.transform);
+            firePoint.position = Vector3.zero;
+
+            var profile = ScriptableObject.CreateInstance<TowerTargetingProfile>();
+            profile.MinRange = 0f;
+            profile.MaxRange = 5f;
+            profile.TargetLayers = 1 << EnemyLayer();
+            profile.SelectionMode = TowerTargetSelectionMode.Nearest;
+
+            var targeting = tower.AddComponent<TowerTargetingController>();
+            targeting.TargetingProfile = profile;
+
+            var attack = tower.AddComponent<TowerAttackController>();
+            attack.TargetingController = targeting;
+            attack.ProjectilePrefab = CreateProjectilePrefab();
+            attack.FirePoint = firePoint;
+            attack.Damage = 4;
+            attack.CooldownSeconds = 1f;
+            attack.ProjectileSpeed = 7f;
+            attack.ProjectileLifetime = 2.5f;
+            attack.TargetLayerMask = 1 << EnemyLayer();
+
+            var fixture = new TowerAttackFixture(tower, firePoint, profile, attack.ProjectilePrefab, targeting, attack);
+            attack.Fired += projectile =>
+            {
+                fixture.FiredCount++;
+                fixture.LastFiredProjectile = projectile;
+            };
+
+            return fixture;
+        }
+
+        private static ProjectileRuntime CreateProjectilePrefab()
+        {
+            var projectileObject = new GameObject("ProjectilePrefab");
+            var collider = projectileObject.AddComponent<PolygonCollider2D>();
+            collider.isTrigger = true;
+            var body = projectileObject.AddComponent<Rigidbody2D>();
+            body.bodyType = RigidbodyType2D.Kinematic;
+            body.gravityScale = 0f;
+            return projectileObject.AddComponent<ProjectileRuntime>();
+        }
+
+        private static GameObject CreateTarget(string name, Vector2 position)
+        {
+            var target = new GameObject(name);
+            target.layer = EnemyLayer();
+            target.transform.position = position;
+            target.AddComponent<BoxCollider2D>();
+            Physics2D.SyncTransforms();
+            return target;
+        }
+
+        private static int EnemyLayer()
+        {
+            var layer = LayerMask.NameToLayer("Enemies");
+            Assert.That(layer, Is.GreaterThanOrEqualTo(0), "Project must define the Enemies layer.");
+            return layer;
+        }
+
+        private static T GetPrivate<T>(object instance, string fieldName)
+        {
+            var field = instance.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(field, $"{instance.GetType().Name} should define private field '{fieldName}'.");
+            return (T)field.GetValue(instance);
+        }
+
+        private sealed class TowerAttackFixture
+        {
+            public TowerAttackFixture(
+                GameObject tower,
+                Transform firePoint,
+                TowerTargetingProfile profile,
+                ProjectileRuntime projectilePrefab,
+                TowerTargetingController targetingController,
+                TowerAttackController attackController)
+            {
+                Tower = tower;
+                FirePoint = firePoint;
+                Profile = profile;
+                ProjectilePrefab = projectilePrefab;
+                TargetingController = targetingController;
+                AttackController = attackController;
+            }
+
+            public GameObject Tower { get; }
+            public Transform FirePoint { get; }
+            public TowerTargetingProfile Profile { get; }
+            public ProjectileRuntime ProjectilePrefab { get; }
+            public TowerTargetingController TargetingController { get; }
+            public TowerAttackController AttackController { get; }
+            public int FiredCount { get; set; }
+            public ProjectileRuntime LastFiredProjectile { get; set; }
+
+            public void Destroy()
+            {
+                foreach (var projectile in Object.FindObjectsOfType<ProjectileRuntime>())
+                {
+                    Object.DestroyImmediate(projectile.gameObject);
+                }
+
+                Object.DestroyImmediate(Tower);
+                Object.DestroyImmediate(Profile);
+            }
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Tower/TowerAttackControllerTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Tower/TowerAttackControllerTests.cs
@@ -103,6 +103,28 @@ namespace Castlebound.Tests.Tower
             }
         }
 
+        [Test]
+        public void TryFire_RotatesProjectileToLaunchDirection_WithVisualOffset()
+        {
+            var fixture = CreateFixture();
+            var target = CreateTarget("Enemy", new Vector2(0f, 3f));
+
+            try
+            {
+                fixture.TargetingController.AcquireTargetNow();
+
+                var projectile = fixture.AttackController.TryFire(0f);
+
+                Assert.NotNull(projectile, "Precondition: tower should fire at the acquired target.");
+                Assert.That(projectile.transform.eulerAngles.z, Is.EqualTo(45f).Within(0.001f));
+            }
+            finally
+            {
+                Object.DestroyImmediate(target);
+                fixture.Destroy();
+            }
+        }
+
         private static TowerAttackFixture CreateFixture()
         {
             var tower = new GameObject("Tower");
@@ -127,6 +149,7 @@ namespace Castlebound.Tests.Tower
             attack.CooldownSeconds = 1f;
             attack.ProjectileSpeed = 7f;
             attack.ProjectileLifetime = 2.5f;
+            attack.ProjectileVisualAngleOffsetDegrees = -45f;
             attack.TargetLayerMask = 1 << EnemyLayer();
 
             var fixture = new TowerAttackFixture(tower, firePoint, profile, attack.ProjectilePrefab, targeting, attack);

--- a/Assets/_Project/_Tests/EditMode/Tower/TowerAttackControllerTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Tower/TowerAttackControllerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ab263297acc9403b80ab11510a6b2277
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/EditMode/Tower/TowerRuntimeContractTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Tower/TowerRuntimeContractTests.cs
@@ -39,6 +39,10 @@ namespace Castlebound.Tests.Tower
                 var aimPivot = FindChildRecursive(prefabRoot.transform, "AimPivot");
                 Assert.NotNull(aimPivot, "Tower prefab must include an AimPivot child.");
 
+                var firePoint = FindChildRecursive(prefabRoot.transform, "FirePoint");
+                Assert.NotNull(firePoint, "Tower prefab must include a FirePoint child.");
+                Assert.IsTrue(firePoint.IsChildOf(aimPivot), "FirePoint should be parented under AimPivot so projectile spawn follows tower aim.");
+
                 var towerVisual = FindChildRecursive(prefabRoot.transform, "TowerVisual");
                 Assert.NotNull(towerVisual, "Tower prefab must include a TowerVisual child.");
                 Assert.IsTrue(towerVisual.IsChildOf(aimPivot), "TowerVisual should be parented under AimPivot for future rotation.");
@@ -146,17 +150,20 @@ namespace Castlebound.Tests.Tower
             {
                 var targetingController = prefabRoot.GetComponent<TowerTargetingController>();
                 var attackController = prefabRoot.GetComponent<TowerAttackController>();
+                var firePoint = FindChildRecursive(prefabRoot.transform, "FirePoint");
 
                 Assert.NotNull(targetingController, "Tower prefab must include TowerTargetingController.");
                 Assert.NotNull(attackController, "Base arrow tower prefab must include TowerAttackController.");
                 Assert.AreSame(targetingController, attackController.TargetingController, "TowerAttackController should read from the prefab targeting controller.");
                 Assert.NotNull(attackController.ProjectilePrefab, "TowerAttackController must reference a projectile prefab.");
                 Assert.IsInstanceOf<ProjectileRuntime>(attackController.ProjectilePrefab, "TowerAttackController projectile prefab must be a ProjectileRuntime.");
-                Assert.NotNull(attackController.FirePoint, "TowerAttackController should serialize a fire point for projectile spawn position.");
+                Assert.NotNull(firePoint, "Tower prefab must include a FirePoint child.");
+                Assert.AreSame(firePoint, attackController.FirePoint, "TowerAttackController should spawn projectiles from the FirePoint child.");
                 Assert.That(attackController.Damage, Is.GreaterThan(0), "Base arrow tower damage must be above zero.");
                 Assert.That(attackController.CooldownSeconds, Is.GreaterThan(0f), "Base arrow tower cooldown must be above zero.");
                 Assert.That(attackController.ProjectileSpeed, Is.GreaterThan(0f), "Base arrow tower projectile speed must be above zero.");
                 Assert.That(attackController.ProjectileLifetime, Is.GreaterThan(0f), "Base arrow tower projectile lifetime must be above zero.");
+                Assert.That(attackController.ProjectileVisualAngleOffsetDegrees, Is.EqualTo(-45f), "Base arrow tower should offset the diagonal arrow sprite by -45 degrees.");
 
                 var enemiesLayer = LayerMask.NameToLayer("Enemies");
                 Assert.That(enemiesLayer, Is.GreaterThanOrEqualTo(0), "Project must define the Enemies layer.");

--- a/Assets/_Project/_Tests/EditMode/Tower/TowerRuntimeContractTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Tower/TowerRuntimeContractTests.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using Castlebound.Gameplay.Projectile;
 using Castlebound.Gameplay.Tower;
 using UnityEngine;
 
@@ -129,6 +130,40 @@ namespace Castlebound.Tests.Tower
                 Assert.IsTrue(aimController.ReturnToIdleWhenNoTarget, "Base arrow tower should return to forward aim when no target is available.");
                 Assert.That(aimController.IdleLocalAngleDegrees, Is.EqualTo(0f), "Base arrow tower idle aim should match the authored forward rest angle.");
                 Assert.That(aimController.IdleReturnSpeedDegrees, Is.GreaterThan(0f), "Base arrow tower idle return speed must be above zero.");
+            }
+            finally
+            {
+                PrefabTestUtil.Unload(prefabRoot);
+            }
+        }
+
+        [Test]
+        public void TowerPrefab_SerializesAttackContract_ForBaseArrowTower()
+        {
+            var prefabRoot = PrefabTestUtil.Load(TowerPrefabPath);
+
+            try
+            {
+                var targetingController = prefabRoot.GetComponent<TowerTargetingController>();
+                var attackController = prefabRoot.GetComponent<TowerAttackController>();
+
+                Assert.NotNull(targetingController, "Tower prefab must include TowerTargetingController.");
+                Assert.NotNull(attackController, "Base arrow tower prefab must include TowerAttackController.");
+                Assert.AreSame(targetingController, attackController.TargetingController, "TowerAttackController should read from the prefab targeting controller.");
+                Assert.NotNull(attackController.ProjectilePrefab, "TowerAttackController must reference a projectile prefab.");
+                Assert.IsInstanceOf<ProjectileRuntime>(attackController.ProjectilePrefab, "TowerAttackController projectile prefab must be a ProjectileRuntime.");
+                Assert.NotNull(attackController.FirePoint, "TowerAttackController should serialize a fire point for projectile spawn position.");
+                Assert.That(attackController.Damage, Is.GreaterThan(0), "Base arrow tower damage must be above zero.");
+                Assert.That(attackController.CooldownSeconds, Is.GreaterThan(0f), "Base arrow tower cooldown must be above zero.");
+                Assert.That(attackController.ProjectileSpeed, Is.GreaterThan(0f), "Base arrow tower projectile speed must be above zero.");
+                Assert.That(attackController.ProjectileLifetime, Is.GreaterThan(0f), "Base arrow tower projectile lifetime must be above zero.");
+
+                var enemiesLayer = LayerMask.NameToLayer("Enemies");
+                Assert.That(enemiesLayer, Is.GreaterThanOrEqualTo(0), "Project must define the Enemies layer.");
+                Assert.That(
+                    attackController.TargetLayerMask.value & (1 << enemiesLayer),
+                    Is.Not.Zero,
+                    "Base arrow tower attack target mask must include the Enemies layer.");
             }
             finally
             {

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,24 @@
 
 ---
 
+## 2026-05-02 - feat(tower): wire projectile attack prefab
+
+### Summary
+- Wired the base Tower prefab with the tested tower attack controller.
+- Assigned the reusable arrow projectile prefab, AimPivot fire point, per-tower attack stats, and Enemies target mask.
+- Added prefab contract coverage for base arrow tower attack wiring.
+
+### New or Updated Tests
+**EditMode**
+- `TowerRuntimeContractTests` - verifies the Tower prefab serializes attack controller, targeting reference, projectile prefab, fire point, attack stats, and Enemies target mask.
+
+**PlayMode**
+- N/A - N/A
+
+### Notes
+- EditMode passed per user in Unity.
+- Manual play validated towers fire projectiles and damage enemies; projectile spawn/aim alignment remains a follow-up fix.
+
 ## 2026-05-02 - feat(tower): add projectile attack controller
 
 ### Summary

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,24 @@
 
 ---
 
+## 2026-05-02 - fix(tower): align projectile spawn with aim
+
+### Summary
+- Added one-shot projectile rotation so arrows visually follow their launch direction.
+- Added a FirePoint under the tower AimPivot so projectile spawn position follows tower aim.
+- Added a -45 degree projectile visual offset for the diagonal arrow sprite.
+
+### New or Updated Tests
+**EditMode**
+- `TowerAttackControllerTests` - verifies projectile rotation aligns to launch direction with visual offset.
+- `TowerRuntimeContractTests` - verifies FirePoint parenting, attack fire point assignment, and arrow visual offset.
+
+**PlayMode**
+- N/A - N/A
+
+### Notes
+- Not run locally; user will run tests manually in Unity and CI before merge.
+
 ## 2026-05-02 - feat(tower): wire projectile attack prefab
 
 ### Summary

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,23 @@
 
 ---
 
+## 2026-05-02 - feat(tower): add projectile attack controller
+
+### Summary
+- Added a tower attack controller that fires reusable projectiles at the current tower target.
+- Kept attack stats on the tower instance for per-tower damage, cooldown, projectile speed, lifetime, and target layer tuning.
+- Added a lightweight fire event for future presentation hooks.
+
+### New or Updated Tests
+**EditMode**
+- `TowerAttackControllerTests` - verifies no-target behavior, valid target firing, cooldown gating, and projectile launch values.
+
+**PlayMode**
+- N/A - N/A
+
+### Notes
+- EditMode passed per user in Unity.
+
 ## 2026-05-02 - feat(projectile): add reusable projectile runtime
 
 ### Summary


### PR DESCRIPTION

## Why
Towers can acquire targets, and projectiles now exist as reusable runtime objects. This adds the attack execution layer so built towers can fire arrows at valid enemies and deal damage.

## What changed
- Added `TowerAttackController` with per-tower damage, cooldown, projectile speed, lifetime, target mask, and projectile prefab settings.
- Wired the base `Tower.prefab` to fire `Projectile_Arrow` using its existing targeting controller.
- Added a `FirePoint` under the tower aim pivot so projectile spawn follows tower aim.
- Rotated spawned projectiles once at fire time so the diagonal arrow sprite aligns with launch direction.
- Added EditMode coverage for attack logic, prefab wiring, cooldown gating, launch values, and aim-aligned projectile rotation.

## How to test
1. Open the Unity Test Runner
2. Run EditMode tests:
   - `TowerAttackControllerTests`
   - `TowerRuntimeContractTests`
3. In Play Mode:
   - Build/place a tower
   - Spawn or start a wave with enemies
   - Verify the tower fires arrows at acquired enemies
   - Verify arrows travel from the aimed fire point and enemies take damage
4. Run CI checks before merge

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included - manual validation in Unity
- [x] Demo scene updated (if player-visible) - N/A
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched (if applicable) - `Docs/TEST_LOG.md`

## Related
- Closes #160