### PR TITLE
Issue 169 tower upgrades

### DIFF
--- a/Assets/_Project/Prefabs/Tower.prefab
+++ b/Assets/_Project/Prefabs/Tower.prefab
@@ -15,6 +15,7 @@ GameObject:
   - component: {fileID: 2000000005}
   - component: {fileID: 2000000006}
   - component: {fileID: 2000000007}
+  - component: {fileID: 2000000008}
   m_Layer: 0
   m_Name: Tower
   m_TagString: Untagged
@@ -175,6 +176,25 @@ MonoBehaviour:
   m_EditorClassIdentifier:
   attackController: {fileID: 2000000006}
   animationPlayer: {fileID: 2000000023}
+--- !u!114 &2000000008
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2000000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f8f70d3d4dd1450bb26cd688a9ef0db2, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  config: {fileID: 11400000, guid: 0daf27b4fb724eff9a337b66c8ac73fa, type: 2}
+  runtime: {fileID: 2000000003}
+  attackController: {fileID: 2000000006}
+  targetingController: {fileID: 2000000004}
+  waveRunner: {fileID: 0}
+  feedbackChannel: {fileID: 0}
+  inventorySource: {fileID: 0}
 --- !u!1 &2000000010
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/_Project/Prefabs/Tower.prefab
+++ b/Assets/_Project/Prefabs/Tower.prefab
@@ -114,6 +114,8 @@ MonoBehaviour:
   m_Name:
   m_EditorClassIdentifier:
   targetingProfile: {fileID: 11400000, guid: e004816ce28b4dc0934be9cac2fe7bb8, type: 2}
+  minRange: 0
+  maxRange: 5
   targetBufferSize: 16
 --- !u!114 &2000000005
 MonoBehaviour:

--- a/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerBuildController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerBuildController.cs
@@ -22,6 +22,8 @@ namespace Castlebound.Gameplay.Tower
             set => config = value;
         }
 
+        public WavePhaseTracker PhaseTracker => phaseTracker;
+
         public Transform TowerParent
         {
             get => towerParent;

--- a/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerRuntime.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerRuntime.cs
@@ -10,8 +10,21 @@ namespace Castlebound.Gameplay.Tower
         [SerializeField] private Transform towerVisual;
         [SerializeField] private Transform platformVisual;
 
-        public int MaxHealth => maxHealth;
-        public int CurrentHealth => currentHealth;
+        public int MaxHealth
+        {
+            get => maxHealth;
+            set
+            {
+                maxHealth = Mathf.Max(1, value);
+                currentHealth = Mathf.Clamp(currentHealth, 0, maxHealth);
+            }
+        }
+
+        public int CurrentHealth
+        {
+            get => currentHealth;
+            set => currentHealth = Mathf.Clamp(value, 0, maxHealth);
+        }
         public Transform AimPivot
         {
             get
@@ -61,7 +74,7 @@ namespace Castlebound.Gameplay.Tower
         private void NormalizeState()
         {
             maxHealth = Mathf.Max(1, maxHealth);
-            currentHealth = Mathf.Clamp(currentHealth, 1, maxHealth);
+            currentHealth = Mathf.Clamp(currentHealth, 0, maxHealth);
         }
 
         private void EnsureReferences()

--- a/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerTargetingController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerTargetingController.cs
@@ -8,6 +8,8 @@ namespace Castlebound.Gameplay.Tower
         private const int MinTargetBufferSize = 1;
 
         [SerializeField] private TowerTargetingProfile targetingProfile;
+        [SerializeField] private float minRange;
+        [SerializeField] private float maxRange = 5f;
         [SerializeField] private int targetBufferSize = 16;
 
         private Collider2D[] targetBuffer;
@@ -17,6 +19,22 @@ namespace Castlebound.Gameplay.Tower
         {
             get => targetingProfile;
             set => targetingProfile = value;
+        }
+
+        public float MinRange
+        {
+            get => minRange;
+            set
+            {
+                minRange = Mathf.Max(0f, value);
+                maxRange = Mathf.Max(minRange, maxRange);
+            }
+        }
+
+        public float MaxRange
+        {
+            get => maxRange;
+            set => maxRange = Mathf.Max(minRange, value);
         }
 
         public Transform CurrentTarget { get; private set; }
@@ -33,11 +51,13 @@ namespace Castlebound.Gameplay.Tower
 
         private void Awake()
         {
+            NormalizeRanges();
             EnsureTargetBuffer();
         }
 
         private void OnValidate()
         {
+            NormalizeRanges();
             targetBufferSize = Mathf.Max(MinTargetBufferSize, targetBufferSize);
         }
 
@@ -57,7 +77,7 @@ namespace Castlebound.Gameplay.Tower
             EnsureTargetBuffer();
             CurrentTarget = null;
 
-            if (targetingProfile == null || targetingProfile.MaxRange <= 0f)
+            if (targetingProfile == null || maxRange <= 0f)
             {
                 return null;
             }
@@ -65,12 +85,12 @@ namespace Castlebound.Gameplay.Tower
             var origin = (Vector2)transform.position;
             var hitCount = Physics2D.OverlapCircleNonAlloc(
                 origin,
-                targetingProfile.MaxRange,
+                maxRange,
                 targetBuffer,
                 targetingProfile.TargetLayers);
 
-            var minRangeSqr = targetingProfile.MinRange * targetingProfile.MinRange;
-            var maxRangeSqr = targetingProfile.MaxRange * targetingProfile.MaxRange;
+            var minRangeSqr = minRange * minRange;
+            var maxRangeSqr = maxRange * maxRange;
             var bestScore = targetingProfile.SelectionMode == TowerTargetSelectionMode.Nearest
                 ? float.PositiveInfinity
                 : float.NegativeInfinity;
@@ -142,6 +162,12 @@ namespace Castlebound.Gameplay.Tower
             {
                 targetBuffer = new Collider2D[targetBufferSize];
             }
+        }
+
+        private void NormalizeRanges()
+        {
+            minRange = Mathf.Max(0f, minRange);
+            maxRange = Mathf.Max(minRange, maxRange);
         }
     }
 }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerTargetingProfile.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerTargetingProfile.cs
@@ -5,27 +5,9 @@ namespace Castlebound.Gameplay.Tower
     [CreateAssetMenu(menuName = "Castlebound/Tower/Tower Targeting Profile")]
     public class TowerTargetingProfile : ScriptableObject
     {
-        [SerializeField] private float minRange;
-        [SerializeField] private float maxRange = 5f;
         [SerializeField] private float scanInterval = 0.2f;
         [SerializeField] private LayerMask targetLayers;
         [SerializeField] private TowerTargetSelectionMode selectionMode;
-
-        public float MinRange
-        {
-            get => minRange;
-            set
-            {
-                minRange = Mathf.Max(0f, value);
-                maxRange = Mathf.Max(minRange, maxRange);
-            }
-        }
-
-        public float MaxRange
-        {
-            get => maxRange;
-            set => maxRange = Mathf.Max(minRange, value);
-        }
 
         public float ScanInterval
         {
@@ -47,8 +29,6 @@ namespace Castlebound.Gameplay.Tower
 
         private void OnValidate()
         {
-            minRange = Mathf.Max(0f, minRange);
-            maxRange = Mathf.Max(minRange, maxRange);
             scanInterval = Mathf.Max(0.02f, scanInterval);
         }
     }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerUpgradeConfig.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerUpgradeConfig.cs
@@ -33,6 +33,12 @@ namespace Castlebound.Gameplay.Tower
             return trackConfig != null && state != null && trackConfig.CanUpgrade(state.GetLevel(track));
         }
 
+        public bool IsTrackEnabled(TowerUpgradeTrack track)
+        {
+            var trackConfig = GetTrack(track);
+            return trackConfig != null && trackConfig.Enabled;
+        }
+
         public int GetCost(TowerUpgradeTrack track, TowerUpgradeState state)
         {
             var trackConfig = GetTrack(track);

--- a/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerUpgradeConfig.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerUpgradeConfig.cs
@@ -1,0 +1,60 @@
+using UnityEngine;
+
+namespace Castlebound.Gameplay.Tower
+{
+    [CreateAssetMenu(menuName = "Castlebound/Tower/Tower Upgrade Config")]
+    public class TowerUpgradeConfig : ScriptableObject
+    {
+        [SerializeField] private TowerUpgradeTrackConfig damage = new TowerUpgradeTrackConfig();
+        [SerializeField] private TowerUpgradeTrackConfig fireRate = new TowerUpgradeTrackConfig();
+        [SerializeField] private TowerUpgradeTrackConfig health = new TowerUpgradeTrackConfig();
+        [SerializeField] private TowerUpgradeTrackConfig range = new TowerUpgradeTrackConfig();
+
+        public TowerUpgradeTrackConfig Damage => damage;
+        public TowerUpgradeTrackConfig FireRate => fireRate;
+        public TowerUpgradeTrackConfig Health => health;
+        public TowerUpgradeTrackConfig Range => range;
+
+        public TowerUpgradeTrackConfig GetTrack(TowerUpgradeTrack track)
+        {
+            return track switch
+            {
+                TowerUpgradeTrack.Damage => damage,
+                TowerUpgradeTrack.FireRate => fireRate,
+                TowerUpgradeTrack.Health => health,
+                TowerUpgradeTrack.Range => range,
+                _ => null
+            };
+        }
+
+        public bool CanUpgrade(TowerUpgradeTrack track, TowerUpgradeState state)
+        {
+            var trackConfig = GetTrack(track);
+            return trackConfig != null && state != null && trackConfig.CanUpgrade(state.GetLevel(track));
+        }
+
+        public int GetCost(TowerUpgradeTrack track, TowerUpgradeState state)
+        {
+            var trackConfig = GetTrack(track);
+            return trackConfig != null && state != null ? trackConfig.GetCostForLevel(state.GetLevel(track)) : 0;
+        }
+
+        public int GetDamage(TowerUpgradeState state) => Mathf.RoundToInt(damage.GetValueForLevel(GetLevel(state, TowerUpgradeTrack.Damage)));
+        public float GetCooldownSeconds(TowerUpgradeState state) => fireRate.GetValueForLevel(GetLevel(state, TowerUpgradeTrack.FireRate));
+        public int GetMaxHealth(TowerUpgradeState state) => Mathf.RoundToInt(health.GetValueForLevel(GetLevel(state, TowerUpgradeTrack.Health)));
+        public float GetMaxRange(TowerUpgradeState state) => range.GetValueForLevel(GetLevel(state, TowerUpgradeTrack.Range));
+
+        private void OnValidate()
+        {
+            damage?.Normalize();
+            fireRate?.Normalize();
+            health?.Normalize();
+            range?.Normalize();
+        }
+
+        private static int GetLevel(TowerUpgradeState state, TowerUpgradeTrack track)
+        {
+            return state != null ? state.GetLevel(track) : 0;
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerUpgradeConfig.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerUpgradeConfig.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 682fba094b0745448d86184a775da6de
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerUpgradeController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerUpgradeController.cs
@@ -1,0 +1,223 @@
+using Castlebound.Gameplay.Inventory;
+using Castlebound.Gameplay.Spawning;
+using UnityEngine;
+
+namespace Castlebound.Gameplay.Tower
+{
+    public class TowerUpgradeController : MonoBehaviour
+    {
+        [SerializeField] private TowerUpgradeConfig config;
+        [SerializeField] private TowerRuntime runtime;
+        [SerializeField] private TowerAttackController attackController;
+        [SerializeField] private TowerTargetingController targetingController;
+        [SerializeField] private EnemySpawnerRunner waveRunner;
+        [SerializeField] private FeedbackEventChannel feedbackChannel;
+        [SerializeField] private InventoryStateComponent inventorySource;
+
+        private readonly TowerUpgradeState state = new TowerUpgradeState();
+        private InventoryState inventory;
+        private WavePhaseTracker phaseTracker;
+
+        public TowerUpgradeConfig Config
+        {
+            get => config;
+            set => config = value;
+        }
+
+        public TowerUpgradeState State => state;
+
+        private void Reset()
+        {
+            EnsureReferences();
+        }
+
+        private void Awake()
+        {
+            EnsureReferences();
+            ApplyCurrentUpgrades();
+        }
+
+        public bool TryUpgrade(TowerUpgradeTrack track)
+        {
+            if (!CanUpgrade(track))
+            {
+                RaiseUpgradeFeedback(FeedbackCueType.UpgradeDenied);
+                return false;
+            }
+
+            var source = GetInventory();
+            int cost = config.GetCost(track, state);
+            if (cost > 0 && (source == null || !source.TrySpendGold(cost)))
+            {
+                RaiseUpgradeFeedback(FeedbackCueType.UpgradeDenied);
+                return false;
+            }
+
+            state.Increment(track);
+            ApplyCurrentUpgrades();
+            RaiseUpgradeFeedback(FeedbackCueType.UpgradeSuccess);
+            return true;
+        }
+
+        public bool CanUpgrade(TowerUpgradeTrack track)
+        {
+            return IsInPreWave() && config != null && config.CanUpgrade(track, state) && HasRequiredTarget(track);
+        }
+
+        public int GetUpgradeCost(TowerUpgradeTrack track)
+        {
+            return config != null ? config.GetCost(track, state) : 0;
+        }
+
+        public int GetLevel(TowerUpgradeTrack track)
+        {
+            return state.GetLevel(track);
+        }
+
+        public void ApplyCurrentUpgrades()
+        {
+            if (config == null)
+            {
+                return;
+            }
+
+            EnsureReferences();
+            ApplyHealth();
+            ApplyAttack();
+            ApplyRange();
+        }
+
+        public void SetInventory(InventoryState state)
+        {
+            inventory = state;
+        }
+
+        public void SetPhaseTracker(WavePhaseTracker tracker)
+        {
+            phaseTracker = tracker;
+        }
+
+        public void SetFeedbackChannel(FeedbackEventChannel channel)
+        {
+            feedbackChannel = channel;
+        }
+
+        private void ApplyHealth()
+        {
+            if (runtime == null || !config.Health.Enabled)
+            {
+                return;
+            }
+
+            int previousMax = runtime.MaxHealth;
+            int nextMax = Mathf.Max(1, config.GetMaxHealth(state));
+            runtime.MaxHealth = nextMax;
+            int delta = Mathf.Max(0, nextMax - previousMax);
+            if (delta > 0)
+            {
+                runtime.CurrentHealth = Mathf.Min(runtime.CurrentHealth + delta, runtime.MaxHealth);
+            }
+        }
+
+        private void ApplyAttack()
+        {
+            if (attackController == null)
+            {
+                return;
+            }
+
+            if (config.Damage.Enabled)
+            {
+                attackController.Damage = config.GetDamage(state);
+            }
+
+            if (config.FireRate.Enabled)
+            {
+                attackController.CooldownSeconds = config.GetCooldownSeconds(state);
+            }
+        }
+
+        private void ApplyRange()
+        {
+            if (targetingController == null || !config.Range.Enabled)
+            {
+                return;
+            }
+
+            targetingController.MaxRange = config.GetMaxRange(state);
+        }
+
+        private bool HasRequiredTarget(TowerUpgradeTrack track)
+        {
+            return track switch
+            {
+                TowerUpgradeTrack.Damage => attackController != null,
+                TowerUpgradeTrack.FireRate => attackController != null,
+                TowerUpgradeTrack.Health => runtime != null,
+                TowerUpgradeTrack.Range => targetingController != null,
+                _ => false
+            };
+        }
+
+        private void EnsureReferences()
+        {
+            if (runtime == null)
+            {
+                runtime = GetComponent<TowerRuntime>();
+            }
+
+            if (attackController == null)
+            {
+                attackController = GetComponent<TowerAttackController>();
+            }
+
+            if (targetingController == null)
+            {
+                targetingController = GetComponent<TowerTargetingController>();
+            }
+        }
+
+        private bool IsInPreWave()
+        {
+            if (phaseTracker != null)
+            {
+                return phaseTracker.CurrentPhase == WavePhase.PreWave;
+            }
+
+            if (waveRunner == null)
+            {
+                waveRunner = FindObjectOfType<EnemySpawnerRunner>();
+            }
+
+            return waveRunner != null
+                && waveRunner.PhaseTracker != null
+                && waveRunner.PhaseTracker.CurrentPhase == WavePhase.PreWave;
+        }
+
+        private InventoryState GetInventory()
+        {
+            if (inventory != null)
+            {
+                return inventory;
+            }
+
+            if (inventorySource == null)
+            {
+                inventorySource = GetComponent<InventoryStateComponent>();
+            }
+
+            inventory = inventorySource != null ? inventorySource.State : null;
+            return inventory;
+        }
+
+        private void RaiseUpgradeFeedback(FeedbackCueType type)
+        {
+            if (feedbackChannel == null)
+            {
+                return;
+            }
+
+            feedbackChannel.Raise(new FeedbackCue(type, transform.position, GetInstanceID()));
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerUpgradeController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerUpgradeController.cs
@@ -61,6 +61,7 @@ namespace Castlebound.Gameplay.Tower
 
         public bool CanUpgrade(TowerUpgradeTrack track)
         {
+            EnsureReferences();
             return IsInPreWave() && config != null && config.CanUpgrade(track, state) && HasRequiredTarget(track);
         }
 

--- a/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerUpgradeController.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerUpgradeController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f8f70d3d4dd1450bb26cd688a9ef0db2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerUpgradeState.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerUpgradeState.cs
@@ -1,0 +1,41 @@
+namespace Castlebound.Gameplay.Tower
+{
+    public class TowerUpgradeState
+    {
+        public int DamageLevel { get; private set; }
+        public int FireRateLevel { get; private set; }
+        public int HealthLevel { get; private set; }
+        public int RangeLevel { get; private set; }
+
+        public int GetLevel(TowerUpgradeTrack track)
+        {
+            return track switch
+            {
+                TowerUpgradeTrack.Damage => DamageLevel,
+                TowerUpgradeTrack.FireRate => FireRateLevel,
+                TowerUpgradeTrack.Health => HealthLevel,
+                TowerUpgradeTrack.Range => RangeLevel,
+                _ => 0
+            };
+        }
+
+        public void Increment(TowerUpgradeTrack track)
+        {
+            switch (track)
+            {
+                case TowerUpgradeTrack.Damage:
+                    DamageLevel++;
+                    break;
+                case TowerUpgradeTrack.FireRate:
+                    FireRateLevel++;
+                    break;
+                case TowerUpgradeTrack.Health:
+                    HealthLevel++;
+                    break;
+                case TowerUpgradeTrack.Range:
+                    RangeLevel++;
+                    break;
+            }
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerUpgradeState.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerUpgradeState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 56166217237e4fd9b1e8d12d8794dedb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerUpgradeTrack.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerUpgradeTrack.cs
@@ -1,0 +1,10 @@
+namespace Castlebound.Gameplay.Tower
+{
+    public enum TowerUpgradeTrack
+    {
+        Damage = 0,
+        FireRate = 1,
+        Health = 2,
+        Range = 3
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerUpgradeTrack.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerUpgradeTrack.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 43067b1c35f849fa97b7e8685d723357
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerUpgradeTrackConfig.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerUpgradeTrackConfig.cs
@@ -1,0 +1,95 @@
+using System;
+using UnityEngine;
+
+namespace Castlebound.Gameplay.Tower
+{
+    [Serializable]
+    public class TowerUpgradeTrackConfig
+    {
+        [SerializeField] private bool enabled;
+        [SerializeField] private int maxLevel = 3;
+        [SerializeField] private float baseValue;
+        [SerializeField] private float valuePerLevel;
+        [SerializeField] private float minValue;
+        [SerializeField] private float maxValue = 9999f;
+        [SerializeField] private int baseCost = 50;
+        [SerializeField] private int costPerLevel = 25;
+
+        public bool Enabled
+        {
+            get => enabled;
+            set => enabled = value;
+        }
+
+        public int MaxLevel
+        {
+            get => maxLevel;
+            set => maxLevel = Mathf.Max(0, value);
+        }
+
+        public float BaseValue
+        {
+            get => baseValue;
+            set => baseValue = value;
+        }
+
+        public float ValuePerLevel
+        {
+            get => valuePerLevel;
+            set => valuePerLevel = value;
+        }
+
+        public float MinValue
+        {
+            get => minValue;
+            set
+            {
+                minValue = value;
+                maxValue = Mathf.Max(minValue, maxValue);
+            }
+        }
+
+        public float MaxValue
+        {
+            get => maxValue;
+            set => maxValue = Mathf.Max(minValue, value);
+        }
+
+        public int BaseCost
+        {
+            get => baseCost;
+            set => baseCost = Mathf.Max(0, value);
+        }
+
+        public int CostPerLevel
+        {
+            get => costPerLevel;
+            set => costPerLevel = Mathf.Max(0, value);
+        }
+
+        public bool CanUpgrade(int currentLevel)
+        {
+            return enabled && currentLevel >= 0 && currentLevel < maxLevel;
+        }
+
+        public int GetCostForLevel(int currentLevel)
+        {
+            int safeLevel = Mathf.Max(0, currentLevel);
+            return baseCost + costPerLevel * safeLevel;
+        }
+
+        public float GetValueForLevel(int level)
+        {
+            int safeLevel = Mathf.Clamp(level, 0, maxLevel);
+            return Mathf.Clamp(baseValue + valuePerLevel * safeLevel, minValue, maxValue);
+        }
+
+        public void Normalize()
+        {
+            maxLevel = Mathf.Max(0, maxLevel);
+            maxValue = Mathf.Max(minValue, maxValue);
+            baseCost = Mathf.Max(0, baseCost);
+            costPerLevel = Mathf.Max(0, costPerLevel);
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerUpgradeTrackConfig.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerUpgradeTrackConfig.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 22514168ece944d1ab2654c24cd17edf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/_Project.Gameplay/UI/UpgradeMenuListView.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/UI/UpgradeMenuListView.cs
@@ -452,6 +452,12 @@ namespace Castlebound.Gameplay.UI
 
             var text = CreateText("Label", go.transform, fontSize, TextAlignmentOptions.Center);
             text.text = label;
+            text.raycastTarget = false;
+            var textRect = text.GetComponent<RectTransform>();
+            textRect.anchorMin = Vector2.zero;
+            textRect.anchorMax = Vector2.one;
+            textRect.offsetMin = Vector2.zero;
+            textRect.offsetMax = Vector2.zero;
 
             var rect = go.GetComponent<RectTransform>();
             rect.sizeDelta = new Vector2(width, 28f);

--- a/Assets/_Project/Scripts/_Project.Gameplay/UI/UpgradeMenuListView.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/UI/UpgradeMenuListView.cs
@@ -28,6 +28,13 @@ namespace Castlebound.Gameplay.UI
         [SerializeField] private TowerBuildController towerBuildController;
 
         private readonly List<ActionRow> rows = new List<ActionRow>();
+        private static readonly TowerUpgradeTrack[] TowerUpgradeTracks =
+        {
+            TowerUpgradeTrack.Damage,
+            TowerUpgradeTrack.FireRate,
+            TowerUpgradeTrack.Health,
+            TowerUpgradeTrack.Range
+        };
 
         private void OnEnable()
         {
@@ -229,7 +236,9 @@ namespace Castlebound.Gameplay.UI
                     continue;
                 }
 
-                rows.Add(CreateTowerPlotRow(plot, i, i == plots.PlotCount - 1));
+                rows.Add(plot.IsOccupied
+                    ? CreateTowerUpgradeRow(plot, i, i == plots.PlotCount - 1)
+                    : CreateTowerPlotRow(plot, i, i == plots.PlotCount - 1));
             }
         }
 
@@ -269,6 +278,75 @@ namespace Castlebound.Gameplay.UI
             return row;
         }
 
+        private ActionRow CreateTowerUpgradeRow(TowerPlot plot, int plotIndex, bool endsBarrierGroup)
+        {
+            var rowObject = new GameObject("TowerUpgradeRow", typeof(RectTransform), typeof(HorizontalLayoutGroup), typeof(ContentSizeFitter));
+            rowObject.transform.SetParent(contentRoot, false);
+            if (endsBarrierGroup)
+            {
+                var groupSpacing = rowObject.AddComponent<LayoutElement>();
+                groupSpacing.minHeight = 48f;
+                groupSpacing.preferredHeight = 48f;
+            }
+
+            ConfigureRowLayout(rowObject, 42f, 10f);
+
+            var nameText = CreateText("Name", rowObject.transform, 13, TextAlignmentOptions.Left);
+            ConfigureLayoutElement(nameText.gameObject, 120f, 0f);
+
+            var detailText = CreateText("Details", rowObject.transform, 13, TextAlignmentOptions.Left);
+            ConfigureLayoutElement(detailText.gameObject, 260f, 0f);
+
+            var upgradeController = GetTowerUpgradeController(plot);
+            var bindings = new List<TowerUpgradeButtonBinding>();
+            if (upgradeController != null)
+            {
+                if (inventorySource != null)
+                {
+                    upgradeController.SetInventory(inventorySource.State);
+                }
+
+                if (feedbackChannel != null)
+                {
+                    upgradeController.SetFeedbackChannel(feedbackChannel);
+                }
+            }
+
+            foreach (var track in TowerUpgradeTracks)
+            {
+                if (upgradeController == null || upgradeController.Config == null || !upgradeController.Config.IsTrackEnabled(track))
+                {
+                    continue;
+                }
+
+                var trackButton = CreateButton($"{track}Button", rowObject.transform, GetTrackLabel(track), 68f, 13);
+                var capturedTrack = track;
+                trackButton.onClick.AddListener(() =>
+                {
+                    bool succeeded = upgradeController.TryUpgrade(capturedTrack);
+                    FlashButton(trackButton, succeeded, Refresh);
+                });
+                bindings.Add(new TowerUpgradeButtonBinding(trackButton, track));
+            }
+
+            var row = new ActionRow(
+                rowObject,
+                nameText,
+                detailText,
+                null,
+                () => $"- {GetPlotLabel(plotIndex)}",
+                () => GetTowerPlotDetails(plot),
+                null,
+                null,
+                null,
+                Refresh,
+                FlashButton,
+                bindings,
+                () => RefreshTowerUpgradeButtons(bindings, upgradeController));
+            row.Refresh();
+            return row;
+        }
+
         private static void ConfigureRowLayout(GameObject rowObject, float leftPadding, float spacing)
         {
             var layout = rowObject.GetComponent<HorizontalLayoutGroup>();
@@ -303,9 +381,14 @@ namespace Castlebound.Gameplay.UI
             if (plot != null && plot.IsOccupied)
             {
                 var runtime = plot.OccupantInstance != null ? plot.OccupantInstance.GetComponent<TowerRuntime>() : null;
+                var attack = plot.OccupantInstance != null ? plot.OccupantInstance.GetComponent<TowerAttackController>() : null;
+                var targeting = plot.OccupantInstance != null ? plot.OccupantInstance.GetComponent<TowerTargetingController>() : null;
                 int currentHealth = runtime != null ? runtime.CurrentHealth : maxHealth;
                 int occupiedMaxHealth = runtime != null ? runtime.MaxHealth : maxHealth;
-                return $"{towerName} | HP {currentHealth}/{occupiedMaxHealth} | DMG {damage} | Upg {upgradeCost} Gold";
+                int currentDamage = attack != null ? attack.Damage : damage;
+                float cooldown = attack != null ? attack.CooldownSeconds : 0f;
+                float range = targeting != null ? targeting.MaxRange : 0f;
+                return $"{towerName} | HP {currentHealth}/{occupiedMaxHealth} | DMG {currentDamage} | RATE {cooldown:0.##} | RNG {range:0.#}";
             }
 
             return $"{towerName} | HP {maxHealth} | DMG {damage} | Build {buildCost} Gold";
@@ -341,7 +424,7 @@ namespace Castlebound.Gameplay.UI
             return text;
         }
 
-        private Button CreateButton(string name, Transform parent, string label, float width)
+        private Button CreateButton(string name, Transform parent, string label, float width, int fontSize = 16)
         {
             var go = new GameObject(name, typeof(RectTransform), typeof(CanvasRenderer), typeof(Image), typeof(Button));
             go.transform.SetParent(parent, false);
@@ -362,7 +445,7 @@ namespace Castlebound.Gameplay.UI
             colors.disabledColor = disabledButtonColor;
             button.colors = colors;
 
-            var text = CreateText("Label", go.transform, 16, TextAlignmentOptions.Center);
+            var text = CreateText("Label", go.transform, fontSize, TextAlignmentOptions.Center);
             text.text = label;
 
             var rect = go.GetComponent<RectTransform>();
@@ -374,6 +457,65 @@ namespace Castlebound.Gameplay.UI
             layout.flexibleHeight = 0f;
 
             return button;
+        }
+
+        private static string GetTrackLabel(TowerUpgradeTrack track)
+        {
+            return track switch
+            {
+                TowerUpgradeTrack.Damage => "DMG",
+                TowerUpgradeTrack.FireRate => "RATE",
+                TowerUpgradeTrack.Health => "HP",
+                TowerUpgradeTrack.Range => "RNG",
+                _ => string.Empty
+            };
+        }
+
+        private static TowerUpgradeController GetTowerUpgradeController(TowerPlot plot)
+        {
+            return plot != null && plot.OccupantInstance != null
+                ? plot.OccupantInstance.GetComponent<TowerUpgradeController>()
+                : null;
+        }
+
+        private static void RefreshTowerUpgradeButtons(IReadOnlyList<TowerUpgradeButtonBinding> bindings, TowerUpgradeController upgradeController)
+        {
+            if (bindings == null || upgradeController == null)
+            {
+                return;
+            }
+
+            for (int i = 0; i < bindings.Count; i++)
+            {
+                var button = bindings[i].Button;
+                var track = bindings[i].Track;
+                if (button == null)
+                {
+                    continue;
+                }
+
+                button.interactable = upgradeController.CanUpgrade(track);
+                var label = button.GetComponentInChildren<TextMeshProUGUI>();
+                if (label != null)
+                {
+                    label.text = GetTrackButtonText(upgradeController, track);
+                }
+            }
+        }
+
+        private static string GetTrackButtonText(TowerUpgradeController upgradeController, TowerUpgradeTrack track)
+        {
+            if (upgradeController == null)
+            {
+                return GetTrackLabel(track);
+            }
+
+            if (!upgradeController.CanUpgrade(track))
+            {
+                return $"{GetTrackLabel(track)} MAX";
+            }
+
+            return $"{GetTrackLabel(track)} {upgradeController.GetUpgradeCost(track)}";
         }
 
         private void FlashButton(Button button, bool success, System.Action onComplete)
@@ -436,6 +578,18 @@ namespace Castlebound.Gameplay.UI
             rows.Clear();
         }
 
+        private readonly struct TowerUpgradeButtonBinding
+        {
+            public TowerUpgradeButtonBinding(Button button, TowerUpgradeTrack track)
+            {
+                Button = button;
+                Track = track;
+            }
+
+            public Button Button { get; }
+            public TowerUpgradeTrack Track { get; }
+        }
+
         private class ActionRow
         {
             private readonly GameObject root;
@@ -449,6 +603,8 @@ namespace Castlebound.Gameplay.UI
             private readonly System.Func<bool> invoke;
             private readonly System.Action refreshAll;
             private readonly System.Action<Button, bool, System.Action> flashButton;
+            private readonly List<TowerUpgradeButtonBinding> extraButtons;
+            private readonly System.Action refreshExtraButtons;
 
             public ActionRow(
                 GameObject root,
@@ -461,7 +617,9 @@ namespace Castlebound.Gameplay.UI
                 System.Func<bool> canInvoke,
                 System.Func<bool> invoke,
                 System.Action refreshAll,
-                System.Action<Button, bool, System.Action> flashButton)
+                System.Action<Button, bool, System.Action> flashButton,
+                List<TowerUpgradeButtonBinding> extraButtons = null,
+                System.Action refreshExtraButtons = null)
             {
                 this.root = root;
                 this.nameText = nameText;
@@ -474,21 +632,31 @@ namespace Castlebound.Gameplay.UI
                 this.invoke = invoke;
                 this.refreshAll = refreshAll;
                 this.flashButton = flashButton;
+                this.extraButtons = extraButtons;
+                this.refreshExtraButtons = refreshExtraButtons;
 
-                actionButton.onClick.AddListener(OnClicked);
+                if (actionButton != null)
+                {
+                    actionButton.onClick.AddListener(OnClicked);
+                }
             }
 
             public void Refresh()
             {
                 nameText.text = getName != null ? getName.Invoke() : string.Empty;
                 detailText.text = getDetails != null ? getDetails.Invoke() : string.Empty;
-                actionButton.interactable = canInvoke == null || canInvoke.Invoke();
-
-                var label = actionButton.GetComponentInChildren<TextMeshProUGUI>();
-                if (label != null)
+                if (actionButton != null)
                 {
-                    label.text = getButtonLabel != null ? getButtonLabel.Invoke() : string.Empty;
+                    actionButton.interactable = canInvoke == null || canInvoke.Invoke();
+
+                    var label = actionButton.GetComponentInChildren<TextMeshProUGUI>();
+                    if (label != null)
+                    {
+                        label.text = getButtonLabel != null ? getButtonLabel.Invoke() : string.Empty;
+                    }
                 }
+
+                refreshExtraButtons?.Invoke();
             }
 
             public void Dispose()
@@ -496,6 +664,14 @@ namespace Castlebound.Gameplay.UI
                 if (actionButton != null)
                 {
                     actionButton.onClick.RemoveListener(OnClicked);
+                }
+
+                if (extraButtons != null)
+                {
+                    foreach (var binding in extraButtons)
+                    {
+                        binding.Button?.onClick.RemoveAllListeners();
+                    }
                 }
 
                 if (root != null)

--- a/Assets/_Project/Scripts/_Project.Gameplay/UI/UpgradeMenuListView.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/UI/UpgradeMenuListView.cs
@@ -310,6 +310,11 @@ namespace Castlebound.Gameplay.UI
                 {
                     upgradeController.SetFeedbackChannel(feedbackChannel);
                 }
+
+                if (towerBuildController != null && towerBuildController.PhaseTracker != null)
+                {
+                    upgradeController.SetPhaseTracker(towerBuildController.PhaseTracker);
+                }
             }
 
             foreach (var track in TowerUpgradeTracks)

--- a/Assets/_Project/Tower/BaseTowerTargetingProfile.asset
+++ b/Assets/_Project/Tower/BaseTowerTargetingProfile.asset
@@ -12,8 +12,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 06d7787f81f746c0a7119dc098e046c1, type: 3}
   m_Name: BaseTowerTargetingProfile
   m_EditorClassIdentifier:
-  minRange: 0
-  maxRange: 5
   scanInterval: 0.1
   targetLayers:
     serializedVersion: 2

--- a/Assets/_Project/Tower/BaseTowerUpgradeConfig.asset
+++ b/Assets/_Project/Tower/BaseTowerUpgradeConfig.asset
@@ -1,0 +1,50 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 682fba094b0745448d86184a775da6de, type: 3}
+  m_Name: BaseTowerUpgradeConfig
+  m_EditorClassIdentifier:
+  damage:
+    enabled: 1
+    maxLevel: 5
+    baseValue: 1
+    valuePerLevel: 1
+    minValue: 0
+    maxValue: 9999
+    baseCost: 75
+    costPerLevel: 25
+  fireRate:
+    enabled: 1
+    maxLevel: 4
+    baseValue: 1
+    valuePerLevel: -0.1
+    minValue: 0.45
+    maxValue: 9999
+    baseCost: 85
+    costPerLevel: 30
+  health:
+    enabled: 1
+    maxLevel: 3
+    baseValue: 10
+    valuePerLevel: 3
+    minValue: 1
+    maxValue: 9999
+    baseCost: 60
+    costPerLevel: 20
+  range:
+    enabled: 1
+    maxLevel: 3
+    baseValue: 5
+    valuePerLevel: 0.5
+    minValue: 0
+    maxValue: 9999
+    baseCost: 80
+    costPerLevel: 25

--- a/Assets/_Project/Tower/BaseTowerUpgradeConfig.asset.meta
+++ b/Assets/_Project/Tower/BaseTowerUpgradeConfig.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0daf27b4fb724eff9a337b66c8ac73fa
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/_Tests/EditMode/Tower/TowerAimControllerTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Tower/TowerAimControllerTests.cs
@@ -23,9 +23,9 @@ namespace Castlebound.Tests.Tower
 
             targetingController = towerObject.AddComponent<TowerTargetingController>();
             targetingProfile = ScriptableObject.CreateInstance<TowerTargetingProfile>();
-            targetingProfile.MaxRange = 5f;
             targetingProfile.TargetLayers = 1 << TargetLayer;
             targetingController.TargetingProfile = targetingProfile;
+            targetingController.MaxRange = 5f;
 
             aimController = towerObject.AddComponent<TowerAimController>();
             aimController.TargetingController = targetingController;

--- a/Assets/_Project/_Tests/EditMode/Tower/TowerAttackControllerTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Tower/TowerAttackControllerTests.cs
@@ -133,13 +133,13 @@ namespace Castlebound.Tests.Tower
             firePoint.position = Vector3.zero;
 
             var profile = ScriptableObject.CreateInstance<TowerTargetingProfile>();
-            profile.MinRange = 0f;
-            profile.MaxRange = 5f;
             profile.TargetLayers = 1 << EnemyLayer();
             profile.SelectionMode = TowerTargetSelectionMode.Nearest;
 
             var targeting = tower.AddComponent<TowerTargetingController>();
             targeting.TargetingProfile = profile;
+            targeting.MinRange = 0f;
+            targeting.MaxRange = 5f;
 
             var attack = tower.AddComponent<TowerAttackController>();
             attack.TargetingController = targeting;

--- a/Assets/_Project/_Tests/EditMode/Tower/TowerRuntimeContractTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Tower/TowerRuntimeContractTests.cs
@@ -245,6 +245,38 @@ namespace Castlebound.Tests.Tower
             }
         }
 
+        [Test]
+        public void TowerPrefab_SerializesUpgradeContract_ForBaseArrowTower()
+        {
+            var prefabRoot = PrefabTestUtil.Load(TowerPrefabPath);
+
+            try
+            {
+                var runtime = prefabRoot.GetComponent<TowerRuntime>();
+                var attackController = prefabRoot.GetComponent<TowerAttackController>();
+                var targetingController = prefabRoot.GetComponent<TowerTargetingController>();
+                var upgradeController = prefabRoot.GetComponent<TowerUpgradeController>();
+
+                Assert.NotNull(upgradeController, "Tower prefab must include TowerUpgradeController.");
+                Assert.NotNull(upgradeController.Config, "TowerUpgradeController must reference a tower upgrade config.");
+                Assert.IsTrue(upgradeController.Config.Damage.Enabled, "Base arrow tower should support damage upgrades.");
+                Assert.IsTrue(upgradeController.Config.FireRate.Enabled, "Base arrow tower should support fire-rate upgrades.");
+                Assert.IsTrue(upgradeController.Config.Health.Enabled, "Base arrow tower should support health upgrades.");
+                Assert.IsTrue(upgradeController.Config.Range.Enabled, "Base arrow tower should support range upgrades.");
+
+                upgradeController.ApplyCurrentUpgrades();
+
+                Assert.That(attackController.Damage, Is.EqualTo(upgradeController.Config.GetDamage(upgradeController.State)));
+                Assert.That(attackController.CooldownSeconds, Is.EqualTo(upgradeController.Config.GetCooldownSeconds(upgradeController.State)).Within(0.001f));
+                Assert.That(runtime.MaxHealth, Is.EqualTo(upgradeController.Config.GetMaxHealth(upgradeController.State)));
+                Assert.That(targetingController.MaxRange, Is.EqualTo(upgradeController.Config.GetMaxRange(upgradeController.State)).Within(0.001f));
+            }
+            finally
+            {
+                PrefabTestUtil.Unload(prefabRoot);
+            }
+        }
+
         private static Transform FindChildRecursive(Transform root, string childName)
         {
             foreach (var child in root.GetComponentsInChildren<Transform>(true))

--- a/Assets/_Project/_Tests/EditMode/Tower/TowerRuntimeContractTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Tower/TowerRuntimeContractTests.cs
@@ -160,8 +160,8 @@ namespace Castlebound.Tests.Tower
 
                 var profile = targetingController.TargetingProfile;
                 Assert.NotNull(profile, "TowerTargetingController must reference a targeting profile.");
-                Assert.That(profile.MinRange, Is.GreaterThanOrEqualTo(0f), "Tower targeting min range must be non-negative.");
-                Assert.That(profile.MaxRange, Is.GreaterThan(profile.MinRange), "Tower targeting max range must exceed min range.");
+                Assert.That(targetingController.MinRange, Is.GreaterThanOrEqualTo(0f), "Tower targeting min range must be non-negative.");
+                Assert.That(targetingController.MaxRange, Is.GreaterThan(targetingController.MinRange), "Tower targeting max range must exceed min range.");
                 Assert.That(profile.ScanInterval, Is.GreaterThan(0f), "Tower targeting scan interval must be above zero.");
                 Assert.That(profile.ScanInterval, Is.LessThanOrEqualTo(0.1f), "Base arrow tower should acquire targets responsively.");
                 Assert.That(profile.SelectionMode, Is.EqualTo(TowerTargetSelectionMode.Nearest), "Base tower should acquire the nearest valid enemy.");

--- a/Assets/_Project/_Tests/EditMode/Tower/TowerTargetingControllerTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Tower/TowerTargetingControllerTests.cs
@@ -20,12 +20,12 @@ namespace Castlebound.Tests.Tower
             towerObject = new GameObject("Tower");
             targetingController = towerObject.AddComponent<TowerTargetingController>();
             targetingProfile = ScriptableObject.CreateInstance<TowerTargetingProfile>();
-            targetingProfile.MinRange = 0f;
-            targetingProfile.MaxRange = 5f;
             targetingProfile.ScanInterval = 0.2f;
             targetingProfile.TargetLayers = 1 << TargetLayer;
             targetingProfile.SelectionMode = TowerTargetSelectionMode.Nearest;
             targetingController.TargetingProfile = targetingProfile;
+            targetingController.MinRange = 0f;
+            targetingController.MaxRange = 5f;
         }
 
         [TearDown]
@@ -55,8 +55,8 @@ namespace Castlebound.Tests.Tower
         [Test]
         public void AcquireTargetNow_IgnoresEnemyInsideMinimumRange()
         {
-            targetingProfile.MinRange = 2f;
-            targetingProfile.MaxRange = 5f;
+            targetingController.MinRange = 2f;
+            targetingController.MaxRange = 5f;
             var closeEnemy = CreateEnemy("Enemy_Close", new Vector2(1f, 0f));
             CreateEnemy("Enemy_Valid", new Vector2(3f, 0f));
             Physics2D.SyncTransforms();
@@ -70,7 +70,7 @@ namespace Castlebound.Tests.Tower
         [Test]
         public void AcquireTargetNow_IgnoresEnemyOutsideMaximumRange()
         {
-            targetingProfile.MaxRange = 3f;
+            targetingController.MaxRange = 3f;
             CreateEnemy("Enemy_Far", new Vector2(4f, 0f));
             Physics2D.SyncTransforms();
 
@@ -138,7 +138,7 @@ namespace Castlebound.Tests.Tower
         [Test]
         public void AcquireTargetNow_ClearsCurrentTarget_WhenTargetLeavesRange()
         {
-            targetingProfile.MaxRange = 3f;
+            targetingController.MaxRange = 3f;
             var enemy = CreateEnemy("Enemy_Target", new Vector2(2f, 0f));
             Physics2D.SyncTransforms();
 
@@ -150,6 +150,37 @@ namespace Castlebound.Tests.Tower
 
             Assert.IsNull(target);
             Assert.IsNull(targetingController.CurrentTarget);
+        }
+
+        [Test]
+        public void AcquireTargetNow_UsesInstanceRange_WhenControllersShareProfile()
+        {
+            var nearTowerObject = new GameObject("Tower_NearRange");
+            var nearRangeController = nearTowerObject.AddComponent<TowerTargetingController>();
+            nearRangeController.TargetingProfile = targetingProfile;
+            nearRangeController.MaxRange = 2f;
+
+            var farTowerObject = new GameObject("Tower_FarRange");
+            var farRangeController = farTowerObject.AddComponent<TowerTargetingController>();
+            farRangeController.TargetingProfile = targetingProfile;
+            farRangeController.MaxRange = 8f;
+
+            var enemy = CreateEnemy("Enemy_SharedProfileRange", new Vector2(6f, 0f));
+            Physics2D.SyncTransforms();
+
+            try
+            {
+                var nearTarget = nearRangeController.AcquireTargetNow();
+                var farTarget = farRangeController.AcquireTargetNow();
+
+                Assert.IsNull(nearTarget, "Short-range tower should not acquire a target outside its instance range.");
+                Assert.AreSame(enemy.transform, farTarget, "Long-range tower should acquire using its own instance range.");
+            }
+            finally
+            {
+                Object.DestroyImmediate(nearTowerObject);
+                Object.DestroyImmediate(farTowerObject);
+            }
         }
 
         [Test]

--- a/Assets/_Project/_Tests/EditMode/Tower/TowerUpgradeControllerTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Tower/TowerUpgradeControllerTests.cs
@@ -1,0 +1,288 @@
+using Castlebound.Gameplay.Inventory;
+using Castlebound.Gameplay.Spawning;
+using Castlebound.Gameplay.Tower;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Castlebound.Tests.Tower
+{
+    public class TowerUpgradeControllerTests
+    {
+        [Test]
+        public void TryUpgrade_DamageTrack_SpendsGoldAndAppliesDamageOnly()
+        {
+            var fixture = CreateFixture();
+
+            try
+            {
+                Assert.IsTrue(fixture.Controller.TryUpgrade(TowerUpgradeTrack.Damage));
+
+                Assert.That(fixture.Inventory.Gold, Is.EqualTo(90));
+                Assert.That(fixture.Controller.GetLevel(TowerUpgradeTrack.Damage), Is.EqualTo(1));
+                Assert.That(fixture.Attack.Damage, Is.EqualTo(3));
+                Assert.That(fixture.Attack.CooldownSeconds, Is.EqualTo(1.2f).Within(0.001f));
+            }
+            finally
+            {
+                fixture.Destroy();
+            }
+        }
+
+        [Test]
+        public void TryUpgrade_TracksCanDiverge_PerTowerInstance()
+        {
+            var sharedConfig = CreateConfig();
+            var damageTower = CreateFixture(sharedConfig);
+            var rateTower = CreateFixture(sharedConfig);
+
+            try
+            {
+                Assert.IsTrue(damageTower.Controller.TryUpgrade(TowerUpgradeTrack.Damage));
+                Assert.IsTrue(rateTower.Controller.TryUpgrade(TowerUpgradeTrack.FireRate));
+
+                Assert.That(damageTower.Attack.Damage, Is.EqualTo(3));
+                Assert.That(damageTower.Attack.CooldownSeconds, Is.EqualTo(1.2f).Within(0.001f));
+                Assert.That(rateTower.Attack.Damage, Is.EqualTo(1));
+                Assert.That(rateTower.Attack.CooldownSeconds, Is.EqualTo(1.05f).Within(0.001f));
+            }
+            finally
+            {
+                damageTower.Destroy(destroyConfig: false);
+                rateTower.Destroy(destroyConfig: false);
+                Object.DestroyImmediate(sharedConfig);
+            }
+        }
+
+        [Test]
+        public void TryUpgrade_HealthTrack_AddsPurchasedHealthDelta()
+        {
+            var fixture = CreateFixture();
+            fixture.Runtime.MaxHealth = 10;
+            fixture.Runtime.CurrentHealth = 4;
+
+            try
+            {
+                Assert.IsTrue(fixture.Controller.TryUpgrade(TowerUpgradeTrack.Health));
+
+                Assert.That(fixture.Runtime.MaxHealth, Is.EqualTo(14));
+                Assert.That(fixture.Runtime.CurrentHealth, Is.EqualTo(8));
+            }
+            finally
+            {
+                fixture.Destroy();
+            }
+        }
+
+        [Test]
+        public void TryUpgrade_RangeTrack_AppliesInstanceRange()
+        {
+            var fixture = CreateFixture();
+
+            try
+            {
+                Assert.IsTrue(fixture.Controller.TryUpgrade(TowerUpgradeTrack.Range));
+
+                Assert.That(fixture.Targeting.MaxRange, Is.EqualTo(6f).Within(0.001f));
+            }
+            finally
+            {
+                fixture.Destroy();
+            }
+        }
+
+        [Test]
+        public void TryUpgrade_Denied_WhenTrackDisabledOrMaxed()
+        {
+            var fixture = CreateFixture();
+            fixture.Config.Range.Enabled = false;
+
+            try
+            {
+                Assert.IsFalse(fixture.Controller.TryUpgrade(TowerUpgradeTrack.Range));
+                Assert.That(fixture.Inventory.Gold, Is.EqualTo(100));
+
+                Assert.IsTrue(fixture.Controller.TryUpgrade(TowerUpgradeTrack.Damage));
+                Assert.IsTrue(fixture.Controller.TryUpgrade(TowerUpgradeTrack.Damage));
+                Assert.IsFalse(fixture.Controller.TryUpgrade(TowerUpgradeTrack.Damage));
+                Assert.That(fixture.Controller.GetLevel(TowerUpgradeTrack.Damage), Is.EqualTo(2));
+            }
+            finally
+            {
+                fixture.Destroy();
+            }
+        }
+
+        [Test]
+        public void TryUpgrade_Denied_WhenNotPreWave()
+        {
+            var fixture = CreateFixture();
+            fixture.Phase.SetPhase(WavePhase.InWave);
+
+            try
+            {
+                Assert.IsFalse(fixture.Controller.TryUpgrade(TowerUpgradeTrack.Damage));
+
+                Assert.That(fixture.Inventory.Gold, Is.EqualTo(100));
+                Assert.That(fixture.Attack.Damage, Is.EqualTo(1));
+            }
+            finally
+            {
+                fixture.Destroy();
+            }
+        }
+
+        [Test]
+        public void TryUpgrade_RaisesSuccessAndDeniedFeedback()
+        {
+            var fixture = CreateFixture(startingGold: 10);
+            var channel = ScriptableObject.CreateInstance<FeedbackEventChannel>();
+            fixture.Controller.SetFeedbackChannel(channel);
+
+            FeedbackCueType? lastType = null;
+            channel.Raised += cue => lastType = cue.Type;
+
+            try
+            {
+                Assert.IsTrue(fixture.Controller.TryUpgrade(TowerUpgradeTrack.Damage));
+                Assert.That(lastType, Is.EqualTo(FeedbackCueType.UpgradeSuccess));
+
+                Assert.IsFalse(fixture.Controller.TryUpgrade(TowerUpgradeTrack.FireRate));
+                Assert.That(lastType, Is.EqualTo(FeedbackCueType.UpgradeDenied));
+            }
+            finally
+            {
+                Object.DestroyImmediate(channel);
+                fixture.Destroy();
+            }
+        }
+
+        [Test]
+        public void TrackConfig_ClampsCostsAndResolvesLinearValues()
+        {
+            var config = new TowerUpgradeTrackConfig
+            {
+                Enabled = true,
+                MaxLevel = -1,
+                BaseCost = -5,
+                CostPerLevel = -10,
+                BaseValue = 1f,
+                ValuePerLevel = 2f,
+                MinValue = 0f,
+                MaxValue = 4f
+            };
+
+            config.Normalize();
+
+            Assert.That(config.MaxLevel, Is.EqualTo(0));
+            Assert.That(config.GetCostForLevel(2), Is.EqualTo(0));
+            config.MaxLevel = 4;
+            Assert.That(config.GetValueForLevel(3), Is.EqualTo(4f));
+        }
+
+        private static TowerUpgradeFixture CreateFixture(int startingGold = 100)
+        {
+            return CreateFixture(CreateConfig(), startingGold);
+        }
+
+        private static TowerUpgradeFixture CreateFixture(TowerUpgradeConfig config, int startingGold = 100)
+        {
+            var tower = new GameObject("Tower");
+            var runtime = tower.AddComponent<TowerRuntime>();
+            var attack = tower.AddComponent<TowerAttackController>();
+            var targeting = tower.AddComponent<TowerTargetingController>();
+            var controller = tower.AddComponent<TowerUpgradeController>();
+
+            runtime.MaxHealth = 10;
+            runtime.CurrentHealth = 10;
+            attack.Damage = 1;
+            attack.CooldownSeconds = 1.2f;
+            targeting.MaxRange = 5f;
+
+            var inventory = new InventoryState();
+            inventory.AddGold(startingGold);
+
+            var phase = new WavePhaseTracker();
+            phase.SetPhase(WavePhase.PreWave);
+
+            controller.Config = config;
+            controller.SetInventory(inventory);
+            controller.SetPhaseTracker(phase);
+            controller.ApplyCurrentUpgrades();
+
+            return new TowerUpgradeFixture(tower, runtime, attack, targeting, controller, config, inventory, phase);
+        }
+
+        private static TowerUpgradeConfig CreateConfig()
+        {
+            var config = ScriptableObject.CreateInstance<TowerUpgradeConfig>();
+
+            Configure(config.Damage, enabled: true, maxLevel: 2, baseValue: 1f, valuePerLevel: 2f, baseCost: 10, costPerLevel: 5);
+            Configure(config.FireRate, enabled: true, maxLevel: 2, baseValue: 1.2f, valuePerLevel: -0.15f, baseCost: 20, costPerLevel: 5, minValue: 0.5f);
+            Configure(config.Health, enabled: true, maxLevel: 2, baseValue: 10f, valuePerLevel: 4f, baseCost: 15, costPerLevel: 5, minValue: 1f);
+            Configure(config.Range, enabled: true, maxLevel: 2, baseValue: 5f, valuePerLevel: 1f, baseCost: 25, costPerLevel: 5);
+
+            return config;
+        }
+
+        private static void Configure(
+            TowerUpgradeTrackConfig track,
+            bool enabled,
+            int maxLevel,
+            float baseValue,
+            float valuePerLevel,
+            int baseCost,
+            int costPerLevel,
+            float minValue = 0f)
+        {
+            track.Enabled = enabled;
+            track.MaxLevel = maxLevel;
+            track.BaseValue = baseValue;
+            track.ValuePerLevel = valuePerLevel;
+            track.MinValue = minValue;
+            track.MaxValue = 9999f;
+            track.BaseCost = baseCost;
+            track.CostPerLevel = costPerLevel;
+        }
+
+        private sealed class TowerUpgradeFixture
+        {
+            public TowerUpgradeFixture(
+                GameObject tower,
+                TowerRuntime runtime,
+                TowerAttackController attack,
+                TowerTargetingController targeting,
+                TowerUpgradeController controller,
+                TowerUpgradeConfig config,
+                InventoryState inventory,
+                WavePhaseTracker phase)
+            {
+                Tower = tower;
+                Runtime = runtime;
+                Attack = attack;
+                Targeting = targeting;
+                Controller = controller;
+                Config = config;
+                Inventory = inventory;
+                Phase = phase;
+            }
+
+            public GameObject Tower { get; }
+            public TowerRuntime Runtime { get; }
+            public TowerAttackController Attack { get; }
+            public TowerTargetingController Targeting { get; }
+            public TowerUpgradeController Controller { get; }
+            public TowerUpgradeConfig Config { get; }
+            public InventoryState Inventory { get; }
+            public WavePhaseTracker Phase { get; }
+
+            public void Destroy(bool destroyConfig = true)
+            {
+                Object.DestroyImmediate(Tower);
+                if (destroyConfig)
+                {
+                    Object.DestroyImmediate(Config);
+                }
+            }
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Tower/TowerUpgradeControllerTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Tower/TowerUpgradeControllerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ac349f09e22142af8e58a9924d296677
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/_Tests/EditMode/UI/UpgradeMenuListViewTowerRowsTests.cs
+++ b/Assets/_Project/_Tests/EditMode/UI/UpgradeMenuListViewTowerRowsTests.cs
@@ -63,11 +63,10 @@ namespace Castlebound.Tests.UI
         }
 
         [Test]
-        public void Refresh_RendersOccupiedPlotAsUnavailableWithoutHidingBarrier()
+        public void Refresh_RendersOccupiedPlotUpgradeTracksWithoutHidingBarrier()
         {
             var context = CreateContext();
-            var existingTower = new GameObject("ArcherTower_Instance");
-            existingTower.AddComponent<TowerRuntime>();
+            var existingTower = CreateUpgradeableTower(context.Inventory, context.Phase, out var upgradeConfig);
             context.LeftPlot.TryAssignOccupant(existingTower);
 
             try
@@ -75,10 +74,12 @@ namespace Castlebound.Tests.UI
                 context.View.Refresh();
 
                 AssertTextExists(context.ContentRoot, "North Barrier");
-                AssertTextExists(context.ContentRoot, "ArcherTower | HP 10/10 | DMG 3 | Upg 75 Gold");
+                AssertTextExists(context.ContentRoot, "ArcherTower | HP 10/10 | DMG 3 | RATE 1 | RNG 5");
 
-                var occupiedButton = FindButtonByLabel(context.ContentRoot, "Occupied");
-                Assert.IsFalse(occupiedButton.interactable, "Occupied tower plots should render as unavailable.");
+                Assert.NotNull(FindButtonByLabel(context.ContentRoot, "DMG 10"));
+                Assert.NotNull(FindButtonByLabel(context.ContentRoot, "RATE 20"));
+                Assert.NotNull(FindButtonByLabel(context.ContentRoot, "HP 15"));
+                Assert.NotNull(FindButtonByLabel(context.ContentRoot, "RNG 25"));
 
                 var buildButtons = FindButtonsByLabel(context.ContentRoot, "Build");
                 Assert.That(buildButtons.Length, Is.EqualTo(1), "Only the remaining empty plot should expose a build action.");
@@ -86,6 +87,35 @@ namespace Castlebound.Tests.UI
             finally
             {
                 Object.DestroyImmediate(existingTower);
+                Object.DestroyImmediate(upgradeConfig);
+                context.Destroy();
+            }
+        }
+
+        [Test]
+        public void TowerUpgradeButton_UpgradesOccupiedTowerInstance()
+        {
+            var context = CreateContext();
+            var existingTower = CreateUpgradeableTower(context.Inventory, context.Phase, out var upgradeConfig);
+            context.LeftPlot.TryAssignOccupant(existingTower);
+
+            try
+            {
+                context.View.Refresh();
+                var damageButton = FindButtonByLabel(context.ContentRoot, "DMG 10");
+
+                damageButton.onClick.Invoke();
+
+                var attack = existingTower.GetComponent<TowerAttackController>();
+                var upgrade = existingTower.GetComponent<TowerUpgradeController>();
+                Assert.That(attack.Damage, Is.EqualTo(5));
+                Assert.That(upgrade.GetLevel(TowerUpgradeTrack.Damage), Is.EqualTo(1));
+                Assert.That(context.Inventory.Gold, Is.EqualTo(90));
+            }
+            finally
+            {
+                Object.DestroyImmediate(existingTower);
+                Object.DestroyImmediate(upgradeConfig);
                 context.Destroy();
             }
         }
@@ -212,7 +242,60 @@ namespace Castlebound.Tests.UI
                 towerConfig,
                 towerPrefab,
                 towerParent,
-                inventory);
+                inventory,
+                phase);
+        }
+
+        private static GameObject CreateUpgradeableTower(
+            InventoryState inventory,
+            WavePhaseTracker phase,
+            out TowerUpgradeConfig config)
+        {
+            var tower = new GameObject("ArcherTower_Instance");
+            var runtime = tower.AddComponent<TowerRuntime>();
+            runtime.MaxHealth = 10;
+            runtime.CurrentHealth = 10;
+
+            var attack = tower.AddComponent<TowerAttackController>();
+            attack.Damage = 3;
+            attack.CooldownSeconds = 1f;
+
+            var targeting = tower.AddComponent<TowerTargetingController>();
+            targeting.MaxRange = 5f;
+
+            config = ScriptableObject.CreateInstance<TowerUpgradeConfig>();
+            Configure(config.Damage, enabled: true, maxLevel: 2, baseValue: 3f, valuePerLevel: 2f, baseCost: 10, costPerLevel: 5);
+            Configure(config.FireRate, enabled: true, maxLevel: 2, baseValue: 1f, valuePerLevel: -0.1f, baseCost: 20, costPerLevel: 5, minValue: 0.5f);
+            Configure(config.Health, enabled: true, maxLevel: 2, baseValue: 10f, valuePerLevel: 4f, baseCost: 15, costPerLevel: 5, minValue: 1f);
+            Configure(config.Range, enabled: true, maxLevel: 2, baseValue: 5f, valuePerLevel: 1f, baseCost: 25, costPerLevel: 5);
+
+            var upgrade = tower.AddComponent<TowerUpgradeController>();
+            upgrade.Config = config;
+            upgrade.SetInventory(inventory);
+            upgrade.SetPhaseTracker(phase);
+            upgrade.ApplyCurrentUpgrades();
+
+            return tower;
+        }
+
+        private static void Configure(
+            TowerUpgradeTrackConfig track,
+            bool enabled,
+            int maxLevel,
+            float baseValue,
+            float valuePerLevel,
+            int baseCost,
+            int costPerLevel,
+            float minValue = 0f)
+        {
+            track.Enabled = enabled;
+            track.MaxLevel = maxLevel;
+            track.BaseValue = baseValue;
+            track.ValuePerLevel = valuePerLevel;
+            track.MinValue = minValue;
+            track.MaxValue = 9999f;
+            track.BaseCost = baseCost;
+            track.CostPerLevel = costPerLevel;
         }
 
         private static TowerPlot CreatePlot(string name, Transform parent, Vector3 position)
@@ -299,7 +382,8 @@ namespace Castlebound.Tests.UI
                 TowerBuildConfig towerConfig,
                 GameObject towerPrefab,
                 Transform towerParent,
-                InventoryState inventory)
+                InventoryState inventory,
+                WavePhaseTracker phase)
             {
                 this.viewRoot = viewRoot;
                 this.contentRoot = contentRoot;
@@ -313,6 +397,7 @@ namespace Castlebound.Tests.UI
                 this.towerPrefab = towerPrefab;
                 TowerParent = towerParent;
                 Inventory = inventory;
+                Phase = phase;
             }
 
             public UpgradeMenuListView View => viewRoot.GetComponent<UpgradeMenuListView>();
@@ -322,6 +407,7 @@ namespace Castlebound.Tests.UI
             public TowerPlot RightPlot { get; }
             public Transform TowerParent { get; }
             public InventoryState Inventory { get; }
+            public WavePhaseTracker Phase { get; }
 
             public void Destroy()
             {
@@ -366,5 +452,6 @@ namespace Castlebound.Tests.UI
                 }
             }
         }
+
     }
 }

--- a/Assets/_Project/_Tests/EditMode/UI/UpgradeMenuListViewTowerRowsTests.cs
+++ b/Assets/_Project/_Tests/EditMode/UI/UpgradeMenuListViewTowerRowsTests.cs
@@ -121,6 +121,28 @@ namespace Castlebound.Tests.UI
         }
 
         [Test]
+        public void Refresh_UsesBuildControllerPhase_ForTowerUpgradeButtons()
+        {
+            var context = CreateContext();
+            var existingTower = CreateUpgradeableTower(context.Inventory, null, out var upgradeConfig);
+            context.LeftPlot.TryAssignOccupant(existingTower);
+
+            try
+            {
+                context.View.Refresh();
+
+                var damageButton = FindButtonByLabel(context.ContentRoot, "DMG 10");
+                Assert.IsTrue(damageButton.interactable, "Tower upgrade buttons should use the build controller pre-wave tracker.");
+            }
+            finally
+            {
+                Object.DestroyImmediate(existingTower);
+                Object.DestroyImmediate(upgradeConfig);
+                context.Destroy();
+            }
+        }
+
+        [Test]
         public void BarrierUpgradeButton_StillInvokesExistingUpgradeFlow()
         {
             var context = CreateContext();
@@ -272,7 +294,10 @@ namespace Castlebound.Tests.UI
             var upgrade = tower.AddComponent<TowerUpgradeController>();
             upgrade.Config = config;
             upgrade.SetInventory(inventory);
-            upgrade.SetPhaseTracker(phase);
+            if (phase != null)
+            {
+                upgrade.SetPhaseTracker(phase);
+            }
             upgrade.ApplyCurrentUpgrades();
 
             return tower;

--- a/Assets/_Project/_Tests/PlayMode/Tower/TowerBuildUpgradeMenuVerticalSlicePlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/Tower/TowerBuildUpgradeMenuVerticalSlicePlayTests.cs
@@ -84,10 +84,6 @@ namespace Castlebound.Tests.PlayMode.Tower
             int goldAfterBuild = inventorySource.State.Gold;
             int towerCountAfterBuild = Object.FindObjectsOfType<TowerRuntime>().Length;
 
-            var occupiedButton = FindActiveButtonWithLabel("Occupied");
-            Assert.NotNull(occupiedButton, "Occupied plot should remain visible in the menu as a blocked row.");
-            Assert.IsFalse(occupiedButton.interactable, "Occupied plot row should not allow repeat purchase.");
-
             var duplicateResult = buildController.TryBuild(occupiedPlot);
             yield return null;
 
@@ -99,6 +95,73 @@ namespace Castlebound.Tests.PlayMode.Tower
             {
                 Assert.That(inventorySource.State.Gold, Is.EqualTo(buildController.Config.BuildCost), "Test setup should leave only the second grant after one successful purchase.");
             }
+        }
+
+        [UnityTest]
+        public IEnumerator MainPrototype_UpgradeMenu_UpgradesBuiltTowerInstance()
+        {
+            yield return LoadMainPrototype();
+
+            var menu = FindInActiveScene<UpgradeMenuController>();
+            var listView = FindInActiveScene<UpgradeMenuListView>();
+            var buildController = FindInActiveScene<TowerBuildController>();
+            var inventorySource = FindInActiveScene<InventoryStateComponent>();
+            Assert.NotNull(menu, "Expected MainPrototype to include UpgradeMenuController.");
+            Assert.NotNull(listView, "Expected MainPrototype to include UpgradeMenuListView.");
+            Assert.NotNull(buildController, "Expected MainPrototype to include TowerBuildController.");
+            Assert.NotNull(buildController.Config, "TowerBuildController must have a build config.");
+            Assert.NotNull(buildController.Config.TowerPrefab, "TowerBuildConfig must reference the real tower prefab.");
+            Assert.NotNull(buildController.Config.TowerPrefab.GetComponent<TowerUpgradeController>(), "Tower prefab must include upgrade support.");
+            Assert.NotNull(inventorySource, "Expected MainPrototype to expose an inventory source for upgrade purchases.");
+
+            var tracker = new WavePhaseTracker();
+            menu.SetPhaseTracker(tracker);
+            buildController.SetPhaseTracker(tracker);
+            buildController.SetInventory(inventorySource.State);
+            listView.SetTowerBuildController(buildController);
+
+            inventorySource.State.AddGold(buildController.Config.BuildCost + 200);
+
+            var plots = FindPlots();
+            Assert.That(plots.Any(plot => !plot.IsOccupied), Is.True, "Expected at least one empty tower plot before building.");
+            menu.ToggleMenu();
+            yield return null;
+
+            var buildButton = FindActiveButtonWithLabel("Build");
+            Assert.NotNull(buildButton, "Expected the upgrade menu to expose a Build button for an empty tower plot.");
+
+            var eventSystem = EventSystem.current;
+            if (eventSystem == null)
+            {
+                eventSystem = new GameObject("TestEventSystem").AddComponent<EventSystem>();
+            }
+
+            ExecuteEvents.Execute(buildButton.gameObject, new PointerEventData(eventSystem), ExecuteEvents.pointerClickHandler);
+            yield return null;
+            yield return new WaitForSeconds(0.2f);
+
+            var occupiedPlot = FindPlots().Single(plot => plot.IsOccupied);
+            var tower = occupiedPlot.OccupantInstance;
+            var upgradeController = tower.GetComponent<TowerUpgradeController>();
+            var attackController = tower.GetComponent<TowerAttackController>();
+            Assert.NotNull(upgradeController, "Built tower should include upgrade support.");
+            Assert.NotNull(upgradeController.Config, "Built tower upgrade controller should reference upgrade config.");
+            Assert.NotNull(attackController, "Built tower should include attack controller.");
+
+            int goldBeforeUpgrade = inventorySource.State.Gold;
+            int damageBeforeUpgrade = attackController.Damage;
+            int damageUpgradeCost = upgradeController.GetUpgradeCost(TowerUpgradeTrack.Damage);
+            var damageButton = FindActiveButtonWithLabel($"DMG {damageUpgradeCost}");
+            Assert.NotNull(damageButton, "Occupied plot should expose a damage upgrade action.");
+            Assert.IsTrue(damageButton.interactable, "Damage upgrade should be interactable during pre-wave.");
+
+            ExecuteEvents.Execute(damageButton.gameObject, new PointerEventData(eventSystem), ExecuteEvents.pointerClickHandler);
+            yield return null;
+            yield return new WaitForSeconds(0.2f);
+
+            Assert.That(upgradeController.GetLevel(TowerUpgradeTrack.Damage), Is.EqualTo(1), "Menu damage upgrade should advance only the built tower instance.");
+            Assert.That(attackController.Damage, Is.GreaterThan(damageBeforeUpgrade), "Damage upgrade should apply to the tower attack controller.");
+            Assert.That(inventorySource.State.Gold, Is.EqualTo(goldBeforeUpgrade - damageUpgradeCost), "Damage upgrade should spend gold exactly once.");
         }
 
         private static IEnumerator LoadMainPrototype()
@@ -124,7 +187,7 @@ namespace Castlebound.Tests.PlayMode.Tower
         private static Button FindActiveButtonWithLabel(string label)
         {
             return Object.FindObjectsOfType<Button>()
-                .Where(button => button.gameObject.activeInHierarchy && button.name == "BuildButton")
+                .Where(button => button.gameObject.activeInHierarchy)
                 .FirstOrDefault(button =>
                 {
                     foreach (var component in button.GetComponentsInChildren<Component>())

--- a/Assets/_Project/_Tests/PlayMode/Tower/TowerSpawnInitPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/Tower/TowerSpawnInitPlayTests.cs
@@ -46,9 +46,19 @@ namespace Castlebound.Tests.PlayMode.Tower
 
             var runtime = tower.GetComponent<TowerRuntime>();
             Assert.NotNull(runtime, "Instantiated Tower prefab must include TowerRuntime.");
+            var attack = tower.GetComponent<TowerAttackController>();
+            var targeting = tower.GetComponent<TowerTargetingController>();
+            var upgrade = tower.GetComponent<TowerUpgradeController>();
             Assert.NotNull(tower.GetComponent<Collider2D>(), "Instantiated Tower prefab must include a Collider2D on the root.");
+            Assert.NotNull(attack, "Instantiated Tower prefab must include TowerAttackController.");
+            Assert.NotNull(targeting, "Instantiated Tower prefab must include TowerTargetingController.");
+            Assert.NotNull(upgrade, "Instantiated Tower prefab must include TowerUpgradeController.");
+            Assert.NotNull(upgrade.Config, "Instantiated Tower prefab upgrade controller must reference upgrade config.");
             Assert.That(runtime.MaxHealth, Is.GreaterThan(0), "Tower runtime must initialize with positive max health.");
             Assert.That(runtime.CurrentHealth, Is.EqualTo(runtime.MaxHealth), "Tower runtime should initialize at full health.");
+            Assert.That(runtime.MaxHealth, Is.EqualTo(upgrade.Config.GetMaxHealth(upgrade.State)), "Tower runtime health should match base upgrade config.");
+            Assert.That(attack.Damage, Is.EqualTo(upgrade.Config.GetDamage(upgrade.State)), "Tower attack damage should match base upgrade config.");
+            Assert.That(targeting.MaxRange, Is.EqualTo(upgrade.Config.GetMaxRange(upgrade.State)).Within(0.001f), "Tower targeting range should match base upgrade config.");
             Assert.NotNull(runtime.AimPivot, "Tower prefab instance must expose AimPivot.");
             Assert.NotNull(runtime.TowerVisual, "Tower prefab instance must expose TowerVisual.");
             Assert.NotNull(runtime.PlatformVisual, "Tower prefab instance must expose PlatformVisual.");
@@ -57,6 +67,38 @@ namespace Castlebound.Tests.PlayMode.Tower
             Assert.AreEqual("PlatformVisual", runtime.PlatformVisual.name, "Tower runtime should bind to the prefab PlatformVisual child.");
             Assert.AreEqual(runtime.AimPivot, runtime.TowerVisual.parent, "TowerVisual should remain parented under AimPivot.");
             Assert.AreEqual(tower.transform, runtime.PlatformVisual.parent, "PlatformVisual should remain parented under the tower root.");
+
+            Object.Destroy(tower);
+#else
+            Assert.Fail("Tower prefab PlayMode smoke requires the Unity editor.");
+            yield break;
+#endif
+        }
+
+        [UnityTest]
+        public IEnumerator TowerPrefab_InstantiatesWithUpgradeSupport()
+        {
+#if UNITY_EDITOR
+            var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(TowerPrefabPath);
+            Assert.NotNull(prefab, "Expected Tower prefab asset to be loadable in PlayMode.");
+
+            var tower = Object.Instantiate(prefab);
+
+            yield return null;
+
+            var runtime = tower.GetComponent<TowerRuntime>();
+            var attack = tower.GetComponent<TowerAttackController>();
+            var targeting = tower.GetComponent<TowerTargetingController>();
+            var upgrade = tower.GetComponent<TowerUpgradeController>();
+
+            Assert.NotNull(runtime, "Instantiated Tower prefab must include TowerRuntime.");
+            Assert.NotNull(attack, "Instantiated Tower prefab must include TowerAttackController.");
+            Assert.NotNull(targeting, "Instantiated Tower prefab must include TowerTargetingController.");
+            Assert.NotNull(upgrade, "Instantiated Tower prefab must include TowerUpgradeController.");
+            Assert.NotNull(upgrade.Config, "Instantiated Tower prefab upgrade controller must reference upgrade config.");
+            Assert.That(runtime.MaxHealth, Is.EqualTo(upgrade.Config.GetMaxHealth(upgrade.State)), "Tower runtime health should match base upgrade config.");
+            Assert.That(attack.Damage, Is.EqualTo(upgrade.Config.GetDamage(upgrade.State)), "Tower attack damage should match base upgrade config.");
+            Assert.That(targeting.MaxRange, Is.EqualTo(upgrade.Config.GetMaxRange(upgrade.State)).Within(0.001f), "Tower targeting range should match base upgrade config.");
 
             Object.Destroy(tower);
 #else

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,24 @@
 
 ---
 
+## 2026-05-15 - refactor(tower): move targeting range to instances
+
+### Summary
+- Moved tower min/max targeting range onto TowerTargetingController instance state.
+- Kept TowerTargetingProfile focused on shared targeting rules.
+- Added regression coverage for towers sharing a profile while using different instance ranges.
+
+### New or Updated Tests
+**EditMode**
+- `TowerTargetingControllerTests` - verifies instance-owned range, min/max filtering, and shared-profile range independence.
+- `TowerRuntimeContractTests` - verifies the base tower prefab serializes valid instance targeting range.
+
+**PlayMode**
+- N/A - N/A
+
+### Notes
+- Not run locally; Unity batchmode could not connect to the local licensing client and produced no NUnit XML.
+
 ## 2026-05-10 - feat(ui): add wave count HUD indicator
 
 ### Summary

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,24 @@
 
 ---
 
+## 2026-05-15 - feat(tower): add per-instance upgrade tracks
+
+### Summary
+- Added per-prefab tower upgrade configs with independent damage, fire-rate, health, and range tracks.
+- Added per-instance tower upgrade state and controller purchase/application flow.
+- Wired the base tower prefab to authored upgrade rules.
+
+### New or Updated Tests
+**EditMode**
+- `TowerUpgradeControllerTests` - verifies track purchases, formulas, limits, pre-wave gating, feedback, and per-instance divergence.
+- `TowerRuntimeContractTests` - verifies the base tower prefab includes upgrade controller/config wiring.
+
+**PlayMode**
+- N/A - N/A
+
+### Notes
+- Not run locally; Unity batchmode could not connect to the local licensing client and produced no NUnit XML.
+
 ## 2026-05-15 - refactor(tower): move targeting range to instances
 
 ### Summary

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,24 @@
 
 ---
 
+## 2026-05-15 - test(tower): cover upgrade flow and scene wiring
+
+### Summary
+- Added PlayMode smoke coverage for Tower prefab upgrade controller/config runtime initialization.
+- Updated the MainPrototype tower build vertical slice to upgrade a built tower through the menu.
+- Kept duplicate-build regression coverage after tower upgrade actions are exposed.
+
+### New or Updated Tests
+**EditMode**
+- N/A
+
+**PlayMode**
+- `TowerSpawnInitPlayTests` - verifies instantiated Tower prefab includes upgrade support and base config values apply.
+- `TowerBuildUpgradeMenuVerticalSlicePlayTests` - verifies menu build flow exposes and invokes a built tower damage upgrade.
+
+### Notes
+- Not run locally; Unity batchmode could not connect to the local licensing client and produced no NUnit XML.
+
 ## 2026-05-15 - feat(ui): expose tower upgrade track actions
 
 ### Summary

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,23 @@
 
 ---
 
+## 2026-05-15 - feat(ui): expose tower upgrade track actions
+
+### Summary
+- Replaced occupied tower plot rows with per-track tower upgrade actions.
+- Added compact DMG, RATE, HP, and RNG buttons for supported tower upgrade tracks.
+- Refreshed occupied tower details from live tower runtime, attack, and targeting values.
+
+### New or Updated Tests
+**EditMode**
+- `UpgradeMenuListViewTowerRowsTests` - verifies occupied tower rows expose track buttons and invoke the tower upgrade controller.
+
+**PlayMode**
+- N/A - N/A
+
+### Notes
+- Not run locally; Unity batchmode could not connect to the local licensing client and produced no NUnit XML.
+
 ## 2026-05-15 - feat(tower): add per-instance upgrade tracks
 
 ### Summary


### PR DESCRIPTION
## Why
Built towers need per-instance upgrade choices so placed towers can specialize after construction. This also decouples tower range from shared targeting profiles so range can be upgraded safely per tower.

## What changed
- Moved tower targeting range from shared profile assets onto tower instances
- Added per-prefab tower upgrade configs with independent DMG, RATE, HP, and RNG tracks
- Added per-instance tower upgrade state and controller purchase flow
- Wired the base tower prefab to authored upgrade rules
- Updated upgrade menu occupied tower rows to expose track upgrade buttons
- Aligned runtime-generated upgrade button hit areas with their visible button visuals
- Added EditMode and PlayMode coverage for upgrade behavior, prefab wiring, menu flow, and scene smoke paths

## How to test
1. Open `MainPrototype`
2. Enter a pre-wave upgrade menu state, build a tower on a barrier plot, then verify occupied tower rows show `DMG`, `RATE`, `HP`, and `RNG` actions
3. Click a tower upgrade action and verify gold is spent and the tower value updates
4. Run tests:
   - EditMode
   - PlayMode

## Checklist
_All items must be checked. If not applicable, check and mark "N/A"._

- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated (if player-visible) — N/A
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched (if applicable) 

## Related
- Closes #169