### PR TITLE
refactor(balance): introduce central tuning station

### DIFF
--- a/Assets/_Project/Scripts/_Project.Gameplay/Balance.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Balance.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 829927f562824a56a7743016156f15ed
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/_Project.Gameplay/Balance/BarrierBalanceTable.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Balance/BarrierBalanceTable.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+namespace Castlebound.Gameplay.Balance
+{
+    [CreateAssetMenu(menuName = "Castlebound/Balance/Barrier Balance Table")]
+    public class BarrierBalanceTable : ScriptableObject
+    {
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Balance/BarrierBalanceTable.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Balance/BarrierBalanceTable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 979638481b694a77b65c64a2c6912131
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/_Project.Gameplay/Balance/EconomyBalanceTable.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Balance/EconomyBalanceTable.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+namespace Castlebound.Gameplay.Balance
+{
+    [CreateAssetMenu(menuName = "Castlebound/Balance/Economy Balance Table")]
+    public class EconomyBalanceTable : ScriptableObject
+    {
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Balance/EconomyBalanceTable.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Balance/EconomyBalanceTable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6e3a684419024d5c8ebcf3f8310a2f32
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/_Project.Gameplay/Balance/EnemyBalanceTable.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Balance/EnemyBalanceTable.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+namespace Castlebound.Gameplay.Balance
+{
+    [CreateAssetMenu(menuName = "Castlebound/Balance/Enemy Balance Table")]
+    public class EnemyBalanceTable : ScriptableObject
+    {
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Balance/EnemyBalanceTable.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Balance/EnemyBalanceTable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 10018b6c8221409fbf9d366afc32f253
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/_Project.Gameplay/Balance/GameBalanceStation.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Balance/GameBalanceStation.cs
@@ -1,0 +1,51 @@
+using UnityEngine;
+
+namespace Castlebound.Gameplay.Balance
+{
+    [CreateAssetMenu(menuName = "Castlebound/Balance/Game Balance Station")]
+    public class GameBalanceStation : ScriptableObject
+    {
+        [SerializeField] private TowerBalanceTable tower;
+        [SerializeField] private BarrierBalanceTable barrier;
+        [SerializeField] private WaveBalanceTable wave;
+        [SerializeField] private EnemyBalanceTable enemy;
+        [SerializeField] private PlayerBalanceTable player;
+        [SerializeField] private EconomyBalanceTable economy;
+
+        public TowerBalanceTable Tower
+        {
+            get => tower;
+            set => tower = value;
+        }
+
+        public BarrierBalanceTable Barrier
+        {
+            get => barrier;
+            set => barrier = value;
+        }
+
+        public WaveBalanceTable Wave
+        {
+            get => wave;
+            set => wave = value;
+        }
+
+        public EnemyBalanceTable Enemy
+        {
+            get => enemy;
+            set => enemy = value;
+        }
+
+        public PlayerBalanceTable Player
+        {
+            get => player;
+            set => player = value;
+        }
+
+        public EconomyBalanceTable Economy
+        {
+            get => economy;
+            set => economy = value;
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Balance/GameBalanceStation.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Balance/GameBalanceStation.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1c34a4cdb5e84223bea98f02f71a7031
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/_Project.Gameplay/Balance/PlayerBalanceTable.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Balance/PlayerBalanceTable.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+namespace Castlebound.Gameplay.Balance
+{
+    [CreateAssetMenu(menuName = "Castlebound/Balance/Player Balance Table")]
+    public class PlayerBalanceTable : ScriptableObject
+    {
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Balance/PlayerBalanceTable.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Balance/PlayerBalanceTable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ff5156f139c14dba96d2b3d174f06830
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/_Project.Gameplay/Balance/TowerBalanceTable.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Balance/TowerBalanceTable.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+namespace Castlebound.Gameplay.Balance
+{
+    [CreateAssetMenu(menuName = "Castlebound/Balance/Tower Balance Table")]
+    public class TowerBalanceTable : ScriptableObject
+    {
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Balance/TowerBalanceTable.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Balance/TowerBalanceTable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5b4e38af7ec44ae9ac9c3ccd65e2d48e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/_Project.Gameplay/Balance/WaveBalanceTable.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Balance/WaveBalanceTable.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+namespace Castlebound.Gameplay.Balance
+{
+    [CreateAssetMenu(menuName = "Castlebound/Balance/Wave Balance Table")]
+    public class WaveBalanceTable : ScriptableObject
+    {
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Balance/WaveBalanceTable.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Balance/WaveBalanceTable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 791dd8b7d8ee4210a4fea8c891db1035
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/EditMode/Balance.meta
+++ b/Assets/_Project/_Tests/EditMode/Balance.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e00c9a9ee77b4f16b4b4b0eb710ef231
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/EditMode/Balance/GameBalanceStationTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Balance/GameBalanceStationTests.cs
@@ -1,0 +1,83 @@
+using Castlebound.Gameplay.Balance;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Castlebound.Tests.Balance
+{
+    public class GameBalanceStationTests
+    {
+        [Test]
+        public void Station_ExposesAssignedCategoryTables()
+        {
+            var station = ScriptableObject.CreateInstance<GameBalanceStation>();
+            var tower = ScriptableObject.CreateInstance<TowerBalanceTable>();
+            var barrier = ScriptableObject.CreateInstance<BarrierBalanceTable>();
+            var wave = ScriptableObject.CreateInstance<WaveBalanceTable>();
+            var enemy = ScriptableObject.CreateInstance<EnemyBalanceTable>();
+            var player = ScriptableObject.CreateInstance<PlayerBalanceTable>();
+            var economy = ScriptableObject.CreateInstance<EconomyBalanceTable>();
+
+            try
+            {
+                station.Tower = tower;
+                station.Barrier = barrier;
+                station.Wave = wave;
+                station.Enemy = enemy;
+                station.Player = player;
+                station.Economy = economy;
+
+                Assert.AreSame(tower, station.Tower);
+                Assert.AreSame(barrier, station.Barrier);
+                Assert.AreSame(wave, station.Wave);
+                Assert.AreSame(enemy, station.Enemy);
+                Assert.AreSame(player, station.Player);
+                Assert.AreSame(economy, station.Economy);
+            }
+            finally
+            {
+                Object.DestroyImmediate(economy);
+                Object.DestroyImmediate(player);
+                Object.DestroyImmediate(enemy);
+                Object.DestroyImmediate(wave);
+                Object.DestroyImmediate(barrier);
+                Object.DestroyImmediate(tower);
+                Object.DestroyImmediate(station);
+            }
+        }
+
+        [Test]
+        public void Station_AllowsPartialCategoryReferences()
+        {
+            var station = ScriptableObject.CreateInstance<GameBalanceStation>();
+            var tower = ScriptableObject.CreateInstance<TowerBalanceTable>();
+
+            try
+            {
+                station.Tower = tower;
+
+                Assert.AreSame(tower, station.Tower);
+                Assert.IsNull(station.Barrier);
+                Assert.IsNull(station.Wave);
+                Assert.IsNull(station.Enemy);
+                Assert.IsNull(station.Player);
+                Assert.IsNull(station.Economy);
+            }
+            finally
+            {
+                Object.DestroyImmediate(tower);
+                Object.DestroyImmediate(station);
+            }
+        }
+
+        [Test]
+        public void CategoryTables_AreScriptableObjectAssets()
+        {
+            Assert.IsTrue(typeof(ScriptableObject).IsAssignableFrom(typeof(TowerBalanceTable)));
+            Assert.IsTrue(typeof(ScriptableObject).IsAssignableFrom(typeof(BarrierBalanceTable)));
+            Assert.IsTrue(typeof(ScriptableObject).IsAssignableFrom(typeof(WaveBalanceTable)));
+            Assert.IsTrue(typeof(ScriptableObject).IsAssignableFrom(typeof(EnemyBalanceTable)));
+            Assert.IsTrue(typeof(ScriptableObject).IsAssignableFrom(typeof(PlayerBalanceTable)));
+            Assert.IsTrue(typeof(ScriptableObject).IsAssignableFrom(typeof(EconomyBalanceTable)));
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Balance/GameBalanceStationTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Balance/GameBalanceStationTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 419a605b10be43029dcf8eb1debca56a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,23 @@
 
 ---
 
+## 2026-05-20 - refactor(balance): introduce central tuning station
+
+### Summary
+- Added a typed GameBalanceStation ScriptableObject for category balance table references.
+- Added empty category table assets for tower, barrier, wave, enemy, player, and economy tuning.
+- Added EditMode coverage for assigned references, partial station setup, and ScriptableObject table contracts.
+
+### New or Updated Tests
+**EditMode**
+- `GameBalanceStationTests` - verifies typed category references, optional missing tables, and ScriptableObject table contracts.
+
+**PlayMode**
+- N/A - N/A
+
+### Notes
+- EditMode tests passed in Unity editor validation.
+
 ## 2026-05-15 - test(tower): cover upgrade flow and scene wiring
 
 ### Summary


### PR DESCRIPTION
## Why
Create the foundation for central balance tuning without migrating live gameplay values all at once. This keeps future tower, barrier, wave, enemy, player, and economy tuning work small and reviewable.

## What changed
- Added a `GameBalanceStation` ScriptableObject as the central hub for typed balance table references
- Added empty category table assets for tower, barrier, wave, enemy, player, and economy tuning
- Added EditMode coverage for station references, partial setup, and table asset contracts
- Updated the test log for the new balance station coverage

## How to test
1. In Unity, verify balance assets can be created from `Castlebound/Balance`
2. Create a `Game Balance Station` and assign category table assets
3. Run tests:
   - EditMode: `GameBalanceStationTests`
   - PlayMode: N/A, no runtime or scene behavior changed

## Checklist

- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included - N/A, no runtime or scene behavior changed
- [x] Demo scene updated - N/A, no player-visible scene changes
- [x] Prefab links, tags, and layers validated - N/A, no prefab/tag/layer changes
- [x] README / Docs touched - TEST_LOG.md updated

## Related
- Closes #172