### PR TITLE
refactor(tower): route tuning through balance tables

### DIFF
--- a/Assets/_Project/Balance.meta
+++ b/Assets/_Project/Balance.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e8828e7cfba34d22ba820acc09085b83
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Balance/GameBalanceStation.asset
+++ b/Assets/_Project/Balance/GameBalanceStation.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1c34a4cdb5e84223bea98f02f71a7031, type: 3}
+  m_Name: GameBalanceStation
+  m_EditorClassIdentifier: 
+  tower: {fileID: 11400000, guid: 1d03794e8d2c4c53a6de599e33d4f8fe, type: 2}
+  barrier: {fileID: 0}
+  wave: {fileID: 0}
+  enemy: {fileID: 0}
+  player: {fileID: 0}
+  economy: {fileID: 0}

--- a/Assets/_Project/Balance/GameBalanceStation.asset.meta
+++ b/Assets/_Project/Balance/GameBalanceStation.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d70caaeb4e66400f8127d62f459cae21
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Balance/TowerBalanceTable.asset
+++ b/Assets/_Project/Balance/TowerBalanceTable.asset
@@ -9,10 +9,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 682fba094b0745448d86184a775da6de, type: 3}
-  m_Name: BaseTowerUpgradeConfig
-  m_EditorClassIdentifier:
-  balanceStation: {fileID: 11400000, guid: d70caaeb4e66400f8127d62f459cae21, type: 2}
+  m_Script: {fileID: 11500000, guid: 5b4e38af7ec44ae9ac9c3ccd65e2d48e, type: 3}
+  m_Name: TowerBalanceTable
+  m_EditorClassIdentifier: 
+  towerPrefab: {fileID: 2000000000, guid: ec470124d4d042388418a66cedd418c1, type: 3}
+  buildCost: 50
+  baseMaxHealth: 10
+  baseDamage: 1
+  baseUpgradeCost: 75
+  baseCooldownSeconds: 1
+  baseMaxRange: 5
   damage:
     enabled: 1
     maxLevel: 5

--- a/Assets/_Project/Balance/TowerBalanceTable.asset.meta
+++ b/Assets/_Project/Balance/TowerBalanceTable.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1d03794e8d2c4c53a6de599e33d4f8fe
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/_Project.Gameplay/Balance/TowerBalanceTable.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Balance/TowerBalanceTable.cs
@@ -1,3 +1,4 @@
+using Castlebound.Gameplay.Tower;
 using UnityEngine;
 
 namespace Castlebound.Gameplay.Balance
@@ -5,5 +6,163 @@ namespace Castlebound.Gameplay.Balance
     [CreateAssetMenu(menuName = "Castlebound/Balance/Tower Balance Table")]
     public class TowerBalanceTable : ScriptableObject
     {
+        [Header("Build")]
+        [SerializeField] private GameObject towerPrefab;
+        [SerializeField] private int buildCost = 50;
+        [SerializeField] private int baseMaxHealth = 10;
+        [SerializeField] private int baseDamage = 1;
+        [SerializeField] private int baseUpgradeCost = 75;
+
+        [Header("Combat")]
+        [SerializeField] private float baseCooldownSeconds = 1f;
+        [SerializeField] private float baseMaxRange = 5f;
+
+        [Header("Upgrade Tracks")]
+        [SerializeField] private TowerUpgradeTrackConfig damage = CreateDamageTrack();
+        [SerializeField] private TowerUpgradeTrackConfig fireRate = CreateFireRateTrack();
+        [SerializeField] private TowerUpgradeTrackConfig health = CreateHealthTrack();
+        [SerializeField] private TowerUpgradeTrackConfig range = CreateRangeTrack();
+
+        public GameObject TowerPrefab
+        {
+            get => towerPrefab;
+            set => towerPrefab = value;
+        }
+
+        public int BuildCost
+        {
+            get => buildCost;
+            set => buildCost = Mathf.Max(0, value);
+        }
+
+        public int BaseMaxHealth
+        {
+            get => baseMaxHealth;
+            set => baseMaxHealth = Mathf.Max(0, value);
+        }
+
+        public int BaseDamage
+        {
+            get => baseDamage;
+            set => baseDamage = Mathf.Max(0, value);
+        }
+
+        public int BaseUpgradeCost
+        {
+            get => baseUpgradeCost;
+            set => baseUpgradeCost = Mathf.Max(0, value);
+        }
+
+        public float BaseCooldownSeconds
+        {
+            get => baseCooldownSeconds;
+            set => baseCooldownSeconds = Mathf.Max(0f, value);
+        }
+
+        public float BaseMaxRange
+        {
+            get => baseMaxRange;
+            set => baseMaxRange = Mathf.Max(0f, value);
+        }
+
+        public TowerUpgradeTrackConfig Damage => damage;
+        public TowerUpgradeTrackConfig FireRate => fireRate;
+        public TowerUpgradeTrackConfig Health => health;
+        public TowerUpgradeTrackConfig Range => range;
+
+        public TowerUpgradeTrackConfig GetTrack(TowerUpgradeTrack track)
+        {
+            return track switch
+            {
+                TowerUpgradeTrack.Damage => damage,
+                TowerUpgradeTrack.FireRate => fireRate,
+                TowerUpgradeTrack.Health => health,
+                TowerUpgradeTrack.Range => range,
+                _ => null
+            };
+        }
+
+        public bool CanUpgrade(TowerUpgradeTrack track, TowerUpgradeState state)
+        {
+            var trackConfig = GetTrack(track);
+            return trackConfig != null && state != null && trackConfig.CanUpgrade(state.GetLevel(track));
+        }
+
+        public bool IsTrackEnabled(TowerUpgradeTrack track)
+        {
+            var trackConfig = GetTrack(track);
+            return trackConfig != null && trackConfig.Enabled;
+        }
+
+        public int GetCost(TowerUpgradeTrack track, TowerUpgradeState state)
+        {
+            var trackConfig = GetTrack(track);
+            return trackConfig != null && state != null ? trackConfig.GetCostForLevel(state.GetLevel(track)) : 0;
+        }
+
+        public int GetDamage(TowerUpgradeState state) => Mathf.RoundToInt(damage.GetValueForLevel(GetLevel(state, TowerUpgradeTrack.Damage)));
+        public float GetCooldownSeconds(TowerUpgradeState state) => fireRate.GetValueForLevel(GetLevel(state, TowerUpgradeTrack.FireRate));
+        public int GetMaxHealth(TowerUpgradeState state) => Mathf.RoundToInt(health.GetValueForLevel(GetLevel(state, TowerUpgradeTrack.Health)));
+        public float GetMaxRange(TowerUpgradeState state) => range.GetValueForLevel(GetLevel(state, TowerUpgradeTrack.Range));
+
+        private void OnValidate()
+        {
+            BuildCost = buildCost;
+            BaseMaxHealth = baseMaxHealth;
+            BaseDamage = baseDamage;
+            BaseUpgradeCost = baseUpgradeCost;
+            BaseCooldownSeconds = baseCooldownSeconds;
+            BaseMaxRange = baseMaxRange;
+            damage?.Normalize();
+            fireRate?.Normalize();
+            health?.Normalize();
+            range?.Normalize();
+        }
+
+        private static int GetLevel(TowerUpgradeState state, TowerUpgradeTrack track)
+        {
+            return state != null ? state.GetLevel(track) : 0;
+        }
+
+        private static TowerUpgradeTrackConfig CreateDamageTrack()
+        {
+            return CreateTrack(maxLevel: 5, baseValue: 1f, valuePerLevel: 1f, minValue: 0f, baseCost: 75, costPerLevel: 25);
+        }
+
+        private static TowerUpgradeTrackConfig CreateFireRateTrack()
+        {
+            return CreateTrack(maxLevel: 4, baseValue: 1f, valuePerLevel: -0.1f, minValue: 0.45f, baseCost: 85, costPerLevel: 30);
+        }
+
+        private static TowerUpgradeTrackConfig CreateHealthTrack()
+        {
+            return CreateTrack(maxLevel: 3, baseValue: 10f, valuePerLevel: 3f, minValue: 1f, baseCost: 60, costPerLevel: 20);
+        }
+
+        private static TowerUpgradeTrackConfig CreateRangeTrack()
+        {
+            return CreateTrack(maxLevel: 3, baseValue: 5f, valuePerLevel: 0.5f, minValue: 0f, baseCost: 80, costPerLevel: 25);
+        }
+
+        private static TowerUpgradeTrackConfig CreateTrack(
+            int maxLevel,
+            float baseValue,
+            float valuePerLevel,
+            float minValue,
+            int baseCost,
+            int costPerLevel)
+        {
+            var track = new TowerUpgradeTrackConfig
+            {
+                Enabled = true,
+                MaxLevel = maxLevel,
+                BaseValue = baseValue,
+                ValuePerLevel = valuePerLevel,
+                MinValue = minValue,
+                BaseCost = baseCost,
+                CostPerLevel = costPerLevel
+            };
+            return track;
+        }
     }
 }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerBuildConfig.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerBuildConfig.cs
@@ -1,3 +1,4 @@
+using Castlebound.Gameplay.Balance;
 using UnityEngine;
 
 namespace Castlebound.Gameplay.Tower
@@ -5,40 +6,52 @@ namespace Castlebound.Gameplay.Tower
     [CreateAssetMenu(menuName = "Castlebound/Tower/Tower Build Config")]
     public class TowerBuildConfig : ScriptableObject
     {
+        [SerializeField] private GameBalanceStation balanceStation;
         [SerializeField] private GameObject towerPrefab;
         [SerializeField] private int buildCost = 50;
         [SerializeField] private int baseMaxHealth = 10;
         [SerializeField] private int baseDamage = 1;
         [SerializeField] private int baseUpgradeCost = 75;
 
+        public GameBalanceStation BalanceStation
+        {
+            get => balanceStation;
+            set => balanceStation = value;
+        }
+
         public GameObject TowerPrefab
         {
-            get => towerPrefab;
+            get => ActiveTowerTable != null && ActiveTowerTable.TowerPrefab != null ? ActiveTowerTable.TowerPrefab : towerPrefab;
             set => towerPrefab = value;
         }
 
         public int BuildCost
         {
-            get => buildCost;
+            get => ActiveTowerTable != null ? ActiveTowerTable.BuildCost : buildCost;
             set => buildCost = Mathf.Max(0, value);
         }
 
         public int BaseMaxHealth
         {
-            get => baseMaxHealth;
+            get => ActiveTowerTable != null ? ActiveTowerTable.BaseMaxHealth : baseMaxHealth;
             set => baseMaxHealth = Mathf.Max(0, value);
         }
 
         public int BaseDamage
         {
-            get => baseDamage;
+            get => ActiveTowerTable != null ? ActiveTowerTable.BaseDamage : baseDamage;
             set => baseDamage = Mathf.Max(0, value);
         }
 
         public int BaseUpgradeCost
         {
-            get => baseUpgradeCost;
+            get => ActiveTowerTable != null ? ActiveTowerTable.BaseUpgradeCost : baseUpgradeCost;
             set => baseUpgradeCost = Mathf.Max(0, value);
         }
+
+        public float BaseCooldownSeconds => ActiveTowerTable != null ? ActiveTowerTable.BaseCooldownSeconds : 1f;
+        public float BaseMaxRange => ActiveTowerTable != null ? ActiveTowerTable.BaseMaxRange : 5f;
+
+        private TowerBalanceTable ActiveTowerTable => balanceStation != null ? balanceStation.Tower : null;
     }
 }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerUpgradeConfig.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerUpgradeConfig.cs
@@ -1,3 +1,4 @@
+using Castlebound.Gameplay.Balance;
 using UnityEngine;
 
 namespace Castlebound.Gameplay.Tower
@@ -5,18 +6,31 @@ namespace Castlebound.Gameplay.Tower
     [CreateAssetMenu(menuName = "Castlebound/Tower/Tower Upgrade Config")]
     public class TowerUpgradeConfig : ScriptableObject
     {
+        [SerializeField] private GameBalanceStation balanceStation;
         [SerializeField] private TowerUpgradeTrackConfig damage = new TowerUpgradeTrackConfig();
         [SerializeField] private TowerUpgradeTrackConfig fireRate = new TowerUpgradeTrackConfig();
         [SerializeField] private TowerUpgradeTrackConfig health = new TowerUpgradeTrackConfig();
         [SerializeField] private TowerUpgradeTrackConfig range = new TowerUpgradeTrackConfig();
 
-        public TowerUpgradeTrackConfig Damage => damage;
-        public TowerUpgradeTrackConfig FireRate => fireRate;
-        public TowerUpgradeTrackConfig Health => health;
-        public TowerUpgradeTrackConfig Range => range;
+        public GameBalanceStation BalanceStation
+        {
+            get => balanceStation;
+            set => balanceStation = value;
+        }
+
+        public TowerUpgradeTrackConfig Damage => GetTrack(TowerUpgradeTrack.Damage);
+        public TowerUpgradeTrackConfig FireRate => GetTrack(TowerUpgradeTrack.FireRate);
+        public TowerUpgradeTrackConfig Health => GetTrack(TowerUpgradeTrack.Health);
+        public TowerUpgradeTrackConfig Range => GetTrack(TowerUpgradeTrack.Range);
 
         public TowerUpgradeTrackConfig GetTrack(TowerUpgradeTrack track)
         {
+            var tableTrack = ActiveTowerTable != null ? ActiveTowerTable.GetTrack(track) : null;
+            if (tableTrack != null)
+            {
+                return tableTrack;
+            }
+
             return track switch
             {
                 TowerUpgradeTrack.Damage => damage,
@@ -45,10 +59,10 @@ namespace Castlebound.Gameplay.Tower
             return trackConfig != null && state != null ? trackConfig.GetCostForLevel(state.GetLevel(track)) : 0;
         }
 
-        public int GetDamage(TowerUpgradeState state) => Mathf.RoundToInt(damage.GetValueForLevel(GetLevel(state, TowerUpgradeTrack.Damage)));
-        public float GetCooldownSeconds(TowerUpgradeState state) => fireRate.GetValueForLevel(GetLevel(state, TowerUpgradeTrack.FireRate));
-        public int GetMaxHealth(TowerUpgradeState state) => Mathf.RoundToInt(health.GetValueForLevel(GetLevel(state, TowerUpgradeTrack.Health)));
-        public float GetMaxRange(TowerUpgradeState state) => range.GetValueForLevel(GetLevel(state, TowerUpgradeTrack.Range));
+        public int GetDamage(TowerUpgradeState state) => Mathf.RoundToInt(Damage.GetValueForLevel(GetLevel(state, TowerUpgradeTrack.Damage)));
+        public float GetCooldownSeconds(TowerUpgradeState state) => FireRate.GetValueForLevel(GetLevel(state, TowerUpgradeTrack.FireRate));
+        public int GetMaxHealth(TowerUpgradeState state) => Mathf.RoundToInt(Health.GetValueForLevel(GetLevel(state, TowerUpgradeTrack.Health)));
+        public float GetMaxRange(TowerUpgradeState state) => Range.GetValueForLevel(GetLevel(state, TowerUpgradeTrack.Range));
 
         private void OnValidate()
         {
@@ -62,5 +76,7 @@ namespace Castlebound.Gameplay.Tower
         {
             return state != null ? state.GetLevel(track) : 0;
         }
+
+        private TowerBalanceTable ActiveTowerTable => balanceStation != null ? balanceStation.Tower : null;
     }
 }

--- a/Assets/_Project/Tower/TowerBuildConfig.asset
+++ b/Assets/_Project/Tower/TowerBuildConfig.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 06f19e9fbfa74ba096e2a5f458d0813c, type: 3}
   m_Name: TowerBuildConfig
   m_EditorClassIdentifier:
+  balanceStation: {fileID: 11400000, guid: d70caaeb4e66400f8127d62f459cae21, type: 2}
   towerPrefab: {fileID: 2000000000, guid: ec470124d4d042388418a66cedd418c1, type: 3}
   buildCost: 50
   baseMaxHealth: 10

--- a/Assets/_Project/_Tests/EditMode/Balance/TowerBalanceTableTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Balance/TowerBalanceTableTests.cs
@@ -1,0 +1,131 @@
+using Castlebound.Gameplay.Balance;
+using Castlebound.Gameplay.Tower;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Castlebound.Tests.Balance
+{
+    public class TowerBalanceTableTests
+    {
+        [Test]
+        public void Defaults_MirrorCurrentTowerBuildAndRuntimeTuning()
+        {
+            var table = ScriptableObject.CreateInstance<TowerBalanceTable>();
+
+            try
+            {
+                Assert.That(table.BuildCost, Is.EqualTo(50));
+                Assert.That(table.BaseMaxHealth, Is.EqualTo(10));
+                Assert.That(table.BaseDamage, Is.EqualTo(1));
+                Assert.That(table.BaseUpgradeCost, Is.EqualTo(75));
+                Assert.That(table.BaseCooldownSeconds, Is.EqualTo(1f).Within(0.001f));
+                Assert.That(table.BaseMaxRange, Is.EqualTo(5f).Within(0.001f));
+            }
+            finally
+            {
+                Object.DestroyImmediate(table);
+            }
+        }
+
+        [Test]
+        public void ScalarProperties_ClampToSafeValues()
+        {
+            var table = ScriptableObject.CreateInstance<TowerBalanceTable>();
+
+            try
+            {
+                table.BuildCost = -1;
+                table.BaseMaxHealth = -1;
+                table.BaseDamage = -1;
+                table.BaseUpgradeCost = -1;
+                table.BaseCooldownSeconds = -1f;
+                table.BaseMaxRange = -1f;
+
+                Assert.That(table.BuildCost, Is.EqualTo(0));
+                Assert.That(table.BaseMaxHealth, Is.EqualTo(0));
+                Assert.That(table.BaseDamage, Is.EqualTo(0));
+                Assert.That(table.BaseUpgradeCost, Is.EqualTo(0));
+                Assert.That(table.BaseCooldownSeconds, Is.EqualTo(0f));
+                Assert.That(table.BaseMaxRange, Is.EqualTo(0f));
+            }
+            finally
+            {
+                Object.DestroyImmediate(table);
+            }
+        }
+
+        [Test]
+        public void UpgradeTracks_MirrorCurrentBaseTowerUpgradeConfig()
+        {
+            var table = ScriptableObject.CreateInstance<TowerBalanceTable>();
+
+            try
+            {
+                AssertTrack(table.Damage, maxLevel: 5, baseValue: 1f, valuePerLevel: 1f, minValue: 0f, baseCost: 75, costPerLevel: 25);
+                AssertTrack(table.FireRate, maxLevel: 4, baseValue: 1f, valuePerLevel: -0.1f, minValue: 0.45f, baseCost: 85, costPerLevel: 30);
+                AssertTrack(table.Health, maxLevel: 3, baseValue: 10f, valuePerLevel: 3f, minValue: 1f, baseCost: 60, costPerLevel: 20);
+                AssertTrack(table.Range, maxLevel: 3, baseValue: 5f, valuePerLevel: 0.5f, minValue: 0f, baseCost: 80, costPerLevel: 25);
+            }
+            finally
+            {
+                Object.DestroyImmediate(table);
+            }
+        }
+
+        [Test]
+        public void GetTrack_ReturnsMatchingTrackConfig()
+        {
+            var table = ScriptableObject.CreateInstance<TowerBalanceTable>();
+
+            try
+            {
+                Assert.AreSame(table.Damage, table.GetTrack(TowerUpgradeTrack.Damage));
+                Assert.AreSame(table.FireRate, table.GetTrack(TowerUpgradeTrack.FireRate));
+                Assert.AreSame(table.Health, table.GetTrack(TowerUpgradeTrack.Health));
+                Assert.AreSame(table.Range, table.GetTrack(TowerUpgradeTrack.Range));
+            }
+            finally
+            {
+                Object.DestroyImmediate(table);
+            }
+        }
+
+        [Test]
+        public void ResolvedValues_MirrorCurrentBaseTowerUpgradeConfigAtBaseLevel()
+        {
+            var table = ScriptableObject.CreateInstance<TowerBalanceTable>();
+            var state = new TowerUpgradeState();
+
+            try
+            {
+                Assert.That(table.GetDamage(state), Is.EqualTo(1));
+                Assert.That(table.GetCooldownSeconds(state), Is.EqualTo(1f).Within(0.001f));
+                Assert.That(table.GetMaxHealth(state), Is.EqualTo(10));
+                Assert.That(table.GetMaxRange(state), Is.EqualTo(5f).Within(0.001f));
+            }
+            finally
+            {
+                Object.DestroyImmediate(table);
+            }
+        }
+
+        private static void AssertTrack(
+            TowerUpgradeTrackConfig track,
+            int maxLevel,
+            float baseValue,
+            float valuePerLevel,
+            float minValue,
+            int baseCost,
+            int costPerLevel)
+        {
+            Assert.NotNull(track);
+            Assert.IsTrue(track.Enabled);
+            Assert.That(track.MaxLevel, Is.EqualTo(maxLevel));
+            Assert.That(track.BaseValue, Is.EqualTo(baseValue).Within(0.001f));
+            Assert.That(track.ValuePerLevel, Is.EqualTo(valuePerLevel).Within(0.001f));
+            Assert.That(track.MinValue, Is.EqualTo(minValue).Within(0.001f));
+            Assert.That(track.BaseCost, Is.EqualTo(baseCost));
+            Assert.That(track.CostPerLevel, Is.EqualTo(costPerLevel));
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Balance/TowerBalanceTableTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Balance/TowerBalanceTableTests.cs
@@ -1,12 +1,18 @@
 using Castlebound.Gameplay.Balance;
 using Castlebound.Gameplay.Tower;
 using NUnit.Framework;
+using UnityEditor;
 using UnityEngine;
 
 namespace Castlebound.Tests.Balance
 {
     public class TowerBalanceTableTests
     {
+        private const string BalanceStationPath = "Assets/_Project/Balance/GameBalanceStation.asset";
+        private const string TowerBalanceTablePath = "Assets/_Project/Balance/TowerBalanceTable.asset";
+        private const string TowerBuildConfigPath = "Assets/_Project/Tower/TowerBuildConfig.asset";
+        private const string TowerUpgradeConfigPath = "Assets/_Project/Tower/BaseTowerUpgradeConfig.asset";
+
         [Test]
         public void Defaults_MirrorCurrentTowerBuildAndRuntimeTuning()
         {
@@ -107,6 +113,24 @@ namespace Castlebound.Tests.Balance
             {
                 Object.DestroyImmediate(table);
             }
+        }
+
+        [Test]
+        public void ProjectAssets_WireTowerConfigsThroughCentralBalanceStation()
+        {
+            var station = AssetDatabase.LoadAssetAtPath<GameBalanceStation>(BalanceStationPath);
+            var table = AssetDatabase.LoadAssetAtPath<TowerBalanceTable>(TowerBalanceTablePath);
+            var buildConfig = AssetDatabase.LoadAssetAtPath<TowerBuildConfig>(TowerBuildConfigPath);
+            var upgradeConfig = AssetDatabase.LoadAssetAtPath<TowerUpgradeConfig>(TowerUpgradeConfigPath);
+
+            Assert.NotNull(station, "Central GameBalanceStation asset must exist.");
+            Assert.NotNull(table, "TowerBalanceTable asset must exist.");
+            Assert.NotNull(buildConfig, "TowerBuildConfig asset must exist.");
+            Assert.NotNull(upgradeConfig, "BaseTowerUpgradeConfig asset must exist.");
+            Assert.AreSame(table, station.Tower, "Central station should reference the authored tower table.");
+            Assert.AreSame(station, buildConfig.BalanceStation, "Tower build config should resolve through the central station.");
+            Assert.AreSame(station, upgradeConfig.BalanceStation, "Tower upgrade config should resolve through the central station.");
+            Assert.NotNull(table.TowerPrefab, "Tower table should reference the buildable tower prefab.");
         }
 
         private static void AssertTrack(

--- a/Assets/_Project/_Tests/EditMode/Balance/TowerBalanceTableTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Balance/TowerBalanceTableTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f3e1c3a931e848e98d224d8406082956
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/EditMode/Tower/TowerBuildControllerTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Tower/TowerBuildControllerTests.cs
@@ -1,3 +1,4 @@
+using Castlebound.Gameplay.Balance;
 using Castlebound.Gameplay.Castle;
 using Castlebound.Gameplay.Inventory;
 using Castlebound.Gameplay.Spawning;
@@ -184,6 +185,51 @@ namespace Castlebound.Tests.Tower
             }
             finally
             {
+                Object.DestroyImmediate(config);
+            }
+        }
+
+        [Test]
+        public void TowerBuildConfig_UsesBalanceStationTowerTable_WhenAssigned()
+        {
+            var config = ScriptableObject.CreateInstance<TowerBuildConfig>();
+            var station = ScriptableObject.CreateInstance<GameBalanceStation>();
+            var table = ScriptableObject.CreateInstance<TowerBalanceTable>();
+            var legacyPrefab = new GameObject("LegacyTower");
+            var tablePrefab = new GameObject("TableTower");
+
+            try
+            {
+                config.TowerPrefab = legacyPrefab;
+                config.BuildCost = 50;
+                config.BaseMaxHealth = 10;
+                config.BaseDamage = 1;
+                config.BaseUpgradeCost = 75;
+
+                table.TowerPrefab = tablePrefab;
+                table.BuildCost = 35;
+                table.BaseMaxHealth = 12;
+                table.BaseDamage = 4;
+                table.BaseUpgradeCost = 90;
+                table.BaseCooldownSeconds = 0.75f;
+                table.BaseMaxRange = 6.5f;
+                station.Tower = table;
+                config.BalanceStation = station;
+
+                Assert.AreSame(tablePrefab, config.TowerPrefab);
+                Assert.That(config.BuildCost, Is.EqualTo(35));
+                Assert.That(config.BaseMaxHealth, Is.EqualTo(12));
+                Assert.That(config.BaseDamage, Is.EqualTo(4));
+                Assert.That(config.BaseUpgradeCost, Is.EqualTo(90));
+                Assert.That(config.BaseCooldownSeconds, Is.EqualTo(0.75f).Within(0.001f));
+                Assert.That(config.BaseMaxRange, Is.EqualTo(6.5f).Within(0.001f));
+            }
+            finally
+            {
+                Object.DestroyImmediate(tablePrefab);
+                Object.DestroyImmediate(legacyPrefab);
+                Object.DestroyImmediate(table);
+                Object.DestroyImmediate(station);
                 Object.DestroyImmediate(config);
             }
         }

--- a/Assets/_Project/_Tests/EditMode/Tower/TowerUpgradeControllerTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Tower/TowerUpgradeControllerTests.cs
@@ -1,3 +1,4 @@
+using Castlebound.Gameplay.Balance;
 using Castlebound.Gameplay.Inventory;
 using Castlebound.Gameplay.Spawning;
 using Castlebound.Gameplay.Tower;
@@ -177,6 +178,40 @@ namespace Castlebound.Tests.Tower
             Assert.That(config.GetCostForLevel(2), Is.EqualTo(0));
             config.MaxLevel = 4;
             Assert.That(config.GetValueForLevel(3), Is.EqualTo(4f));
+        }
+
+        [Test]
+        public void TryUpgrade_UsesBalanceStationTowerTable_WhenAssigned()
+        {
+            var config = ScriptableObject.CreateInstance<TowerUpgradeConfig>();
+            var station = ScriptableObject.CreateInstance<GameBalanceStation>();
+            var table = ScriptableObject.CreateInstance<TowerBalanceTable>();
+            Configure(table.Damage, enabled: true, maxLevel: 2, baseValue: 4f, valuePerLevel: 3f, baseCost: 12, costPerLevel: 5);
+            Configure(table.FireRate, enabled: true, maxLevel: 2, baseValue: 0.8f, valuePerLevel: -0.1f, baseCost: 20, costPerLevel: 5, minValue: 0.4f);
+            Configure(table.Health, enabled: true, maxLevel: 2, baseValue: 12f, valuePerLevel: 4f, baseCost: 15, costPerLevel: 5, minValue: 1f);
+            Configure(table.Range, enabled: true, maxLevel: 2, baseValue: 6f, valuePerLevel: 1.5f, baseCost: 25, costPerLevel: 5);
+            station.Tower = table;
+            config.BalanceStation = station;
+            var fixture = CreateFixture(config);
+
+            try
+            {
+                Assert.That(fixture.Attack.Damage, Is.EqualTo(4));
+                Assert.That(fixture.Attack.CooldownSeconds, Is.EqualTo(0.8f).Within(0.001f));
+                Assert.That(fixture.Runtime.MaxHealth, Is.EqualTo(12));
+                Assert.That(fixture.Targeting.MaxRange, Is.EqualTo(6f).Within(0.001f));
+
+                Assert.IsTrue(fixture.Controller.TryUpgrade(TowerUpgradeTrack.Damage));
+
+                Assert.That(fixture.Inventory.Gold, Is.EqualTo(88));
+                Assert.That(fixture.Attack.Damage, Is.EqualTo(7));
+            }
+            finally
+            {
+                fixture.Destroy();
+                Object.DestroyImmediate(table);
+                Object.DestroyImmediate(station);
+            }
         }
 
         private static TowerUpgradeFixture CreateFixture(int startingGold = 100)

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,22 +4,26 @@
 
 ---
 
-## 2026-05-24 - refactor(tower): add tower balance table defaults
+## 2026-05-24 - refactor(tower): route tower tuning through balance tables
 
 ### Summary
 - Added authored tower build, combat, and upgrade-track tuning fields to TowerBalanceTable.
 - Mirrored current tower build cost, health, damage, cooldown, range, and base upgrade track defaults.
 - Added EditMode coverage for tower table defaults, clamping, track lookup, and resolved base values.
+- Routed tower build and upgrade configs through GameBalanceStation tower tables when assigned.
+- Added central GameBalanceStation and TowerBalanceTable assets for authored tower tuning.
 
 ### New or Updated Tests
 **EditMode**
-- `TowerBalanceTableTests` - verifies current tower defaults, scalar clamping, track contracts, and base resolved values.
+- `TowerBalanceTableTests` - verifies current tower defaults, scalar clamping, track contracts, base resolved values, and project asset wiring.
+- `TowerBuildControllerTests` - verifies build config resolves authored values from the station tower table.
+- `TowerUpgradeControllerTests` - verifies tower upgrades apply station table tracks to runtime stats and costs.
 
 **PlayMode**
 - N/A - N/A
 
 ### Notes
-- EditMode tests passed in Unity editor validation.
+- EditMode tests passed in Unity editor validation on 2026-05-25.
 
 ## 2026-05-20 - refactor(balance): introduce central tuning station
 

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,23 @@
 
 ---
 
+## 2026-05-24 - refactor(tower): add tower balance table defaults
+
+### Summary
+- Added authored tower build, combat, and upgrade-track tuning fields to TowerBalanceTable.
+- Mirrored current tower build cost, health, damage, cooldown, range, and base upgrade track defaults.
+- Added EditMode coverage for tower table defaults, clamping, track lookup, and resolved base values.
+
+### New or Updated Tests
+**EditMode**
+- `TowerBalanceTableTests` - verifies current tower defaults, scalar clamping, track contracts, and base resolved values.
+
+**PlayMode**
+- N/A - N/A
+
+### Notes
+- EditMode tests passed in Unity editor validation.
+
 ## 2026-05-20 - refactor(balance): introduce central tuning station
 
 ### Summary


### PR DESCRIPTION
## Why
Centralize tower tuning so build, combat, and upgrade values can be authored through the balance station instead of being scattered across tower-specific config assets.

## What changed
- Added real tower tuning fields and upgrade tracks to `TowerBalanceTable`
- Added central `GameBalanceStation` and `TowerBalanceTable` project assets
- Routed tower build and upgrade configs through the station tower table when assigned
- Preserved existing tower config fields as fallback when no station/table is assigned
- Added EditMode coverage for table defaults, asset wiring, build config routing, and upgrade stat application

## How to test
1. Open `Assets/_Project/Balance/GameBalanceStation.asset`
2. Verify it references `Assets/_Project/Balance/TowerBalanceTable.asset`
3. Open `Assets/_Project/Tower/TowerBuildConfig.asset` and `Assets/_Project/Tower/BaseTowerUpgradeConfig.asset`
4. Verify both reference the central balance station
5. Run tests:
   - EditMode: `TowerBalanceTableTests`
   - EditMode: `TowerBuildControllerTests`
   - EditMode: `TowerUpgradeControllerTests`
   - PlayMode: N/A, no new scene flow required

## Checklist

- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included - N/A, no new scene flow required
- [x] Demo scene updated - N/A, config asset wiring only
- [x] Prefab links, tags, and layers validated - N/A, no prefab/tag/layer changes
- [x] README / Docs touched - TEST_LOG.md updated

## Related
- Closes #173