### PR TITLE
refactor(barrier): route tuning through balance tables

### DIFF
--- a/Assets/_Project/Balance/BarrierBalanceTable.asset
+++ b/Assets/_Project/Balance/BarrierBalanceTable.asset
@@ -9,10 +9,9 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9edabc177a4bfeb448438e60bf5d341c, type: 3}
-  m_Name: BarrierUpgradeConfig
+  m_Script: {fileID: 11500000, guid: 979638481b694a77b65c64a2c6912131, type: 3}
+  m_Name: BarrierBalanceTable
   m_EditorClassIdentifier: 
-  balanceStation: {fileID: 11400000, guid: d70caaeb4e66400f8127d62f459cae21, type: 2}
   baseMaxHealth: 25
   maxHealthPerTier: 5
   baseCost: 10

--- a/Assets/_Project/Balance/BarrierBalanceTable.asset.meta
+++ b/Assets/_Project/Balance/BarrierBalanceTable.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 64e791ca8c294529bc6393d439d743c9
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Balance/GameBalanceStation.asset
+++ b/Assets/_Project/Balance/GameBalanceStation.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: GameBalanceStation
   m_EditorClassIdentifier: 
   tower: {fileID: 11400000, guid: 1d03794e8d2c4c53a6de599e33d4f8fe, type: 2}
-  barrier: {fileID: 0}
+  barrier: {fileID: 11400000, guid: 64e791ca8c294529bc6393d439d743c9, type: 2}
   wave: {fileID: 0}
   enemy: {fileID: 0}
   player: {fileID: 0}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Balance/BarrierBalanceTable.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Balance/BarrierBalanceTable.cs
@@ -5,5 +5,53 @@ namespace Castlebound.Gameplay.Balance
     [CreateAssetMenu(menuName = "Castlebound/Balance/Barrier Balance Table")]
     public class BarrierBalanceTable : ScriptableObject
     {
+        [SerializeField] private int baseMaxHealth = 10;
+        [SerializeField] private int maxHealthPerTier = 2;
+        [SerializeField] private int baseCost = 20;
+        [SerializeField] private int costPerTier = 10;
+
+        public int BaseMaxHealth
+        {
+            get => baseMaxHealth;
+            set => baseMaxHealth = Mathf.Max(0, value);
+        }
+
+        public int MaxHealthPerTier
+        {
+            get => maxHealthPerTier;
+            set => maxHealthPerTier = Mathf.Max(0, value);
+        }
+
+        public int BaseCost
+        {
+            get => baseCost;
+            set => baseCost = Mathf.Max(0, value);
+        }
+
+        public int CostPerTier
+        {
+            get => costPerTier;
+            set => costPerTier = Mathf.Max(0, value);
+        }
+
+        public int GetMaxHealthForTier(int tier)
+        {
+            int safeTier = Mathf.Max(0, tier);
+            return BaseMaxHealth + MaxHealthPerTier * safeTier;
+        }
+
+        public int GetUpgradeCostForTier(int tier)
+        {
+            int safeTier = Mathf.Max(0, tier);
+            return BaseCost + CostPerTier * safeTier;
+        }
+
+        private void OnValidate()
+        {
+            BaseMaxHealth = baseMaxHealth;
+            MaxHealthPerTier = maxHealthPerTier;
+            BaseCost = baseCost;
+            CostPerTier = costPerTier;
+        }
     }
 }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Barrier/BarrierUpgradeConfig.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Barrier/BarrierUpgradeConfig.cs
@@ -1,3 +1,4 @@
+using Castlebound.Gameplay.Balance;
 using UnityEngine;
 
 namespace Castlebound.Gameplay.Barrier
@@ -5,45 +6,64 @@ namespace Castlebound.Gameplay.Barrier
     [CreateAssetMenu(menuName = "Castlebound/Barrier/Barrier Upgrade Config")]
     public class BarrierUpgradeConfig : ScriptableObject
     {
+        [SerializeField] private GameBalanceStation balanceStation;
         [SerializeField] private int baseMaxHealth = 10;
         [SerializeField] private int maxHealthPerTier = 2;
         [SerializeField] private int baseCost = 20;
         [SerializeField] private int costPerTier = 10;
 
+        public GameBalanceStation BalanceStation
+        {
+            get => balanceStation;
+            set => balanceStation = value;
+        }
+
         public int BaseMaxHealth
         {
-            get => baseMaxHealth;
+            get => ActiveBarrierTable != null ? ActiveBarrierTable.BaseMaxHealth : baseMaxHealth;
             set => baseMaxHealth = Mathf.Max(0, value);
         }
 
         public int MaxHealthPerTier
         {
-            get => maxHealthPerTier;
+            get => ActiveBarrierTable != null ? ActiveBarrierTable.MaxHealthPerTier : maxHealthPerTier;
             set => maxHealthPerTier = Mathf.Max(0, value);
         }
 
         public int BaseCost
         {
-            get => baseCost;
+            get => ActiveBarrierTable != null ? ActiveBarrierTable.BaseCost : baseCost;
             set => baseCost = Mathf.Max(0, value);
         }
 
         public int CostPerTier
         {
-            get => costPerTier;
+            get => ActiveBarrierTable != null ? ActiveBarrierTable.CostPerTier : costPerTier;
             set => costPerTier = Mathf.Max(0, value);
         }
 
         public int GetMaxHealthForTier(int tier)
         {
+            if (ActiveBarrierTable != null)
+            {
+                return ActiveBarrierTable.GetMaxHealthForTier(tier);
+            }
+
             int safeTier = Mathf.Max(0, tier);
             return BaseMaxHealth + MaxHealthPerTier * safeTier;
         }
 
         public int GetUpgradeCostForTier(int tier)
         {
+            if (ActiveBarrierTable != null)
+            {
+                return ActiveBarrierTable.GetUpgradeCostForTier(tier);
+            }
+
             int safeTier = Mathf.Max(0, tier);
             return BaseCost + CostPerTier * safeTier;
         }
+
+        private BarrierBalanceTable ActiveBarrierTable => balanceStation != null ? balanceStation.Barrier : null;
     }
 }

--- a/Assets/_Project/_Tests/EditMode/Balance/BarrierBalanceTableTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Balance/BarrierBalanceTableTests.cs
@@ -1,0 +1,114 @@
+using Castlebound.Gameplay.Balance;
+using Castlebound.Gameplay.Barrier;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+
+namespace Castlebound.Tests.Balance
+{
+    public class BarrierBalanceTableTests
+    {
+        private const string BalanceStationPath = "Assets/_Project/Balance/GameBalanceStation.asset";
+        private const string BarrierBalanceTablePath = "Assets/_Project/Balance/BarrierBalanceTable.asset";
+        private const string BarrierUpgradeConfigPath = "Assets/_Project/Barrier/BarrierUpgradeConfig.asset";
+
+        [Test]
+        public void Defaults_MirrorCurrentBarrierUpgradeConfigTuning()
+        {
+            var table = ScriptableObject.CreateInstance<BarrierBalanceTable>();
+
+            try
+            {
+                Assert.That(table.BaseMaxHealth, Is.EqualTo(10));
+                Assert.That(table.MaxHealthPerTier, Is.EqualTo(2));
+                Assert.That(table.BaseCost, Is.EqualTo(20));
+                Assert.That(table.CostPerTier, Is.EqualTo(10));
+            }
+            finally
+            {
+                Object.DestroyImmediate(table);
+            }
+        }
+
+        [Test]
+        public void ScalarProperties_ClampToSafeValues()
+        {
+            var table = ScriptableObject.CreateInstance<BarrierBalanceTable>();
+
+            try
+            {
+                table.BaseMaxHealth = -1;
+                table.MaxHealthPerTier = -1;
+                table.BaseCost = -1;
+                table.CostPerTier = -1;
+
+                Assert.That(table.BaseMaxHealth, Is.EqualTo(0));
+                Assert.That(table.MaxHealthPerTier, Is.EqualTo(0));
+                Assert.That(table.BaseCost, Is.EqualTo(0));
+                Assert.That(table.CostPerTier, Is.EqualTo(0));
+            }
+            finally
+            {
+                Object.DestroyImmediate(table);
+            }
+        }
+
+        [Test]
+        public void GetMaxHealthForTier_UsesLinearScalingAndClampsTier()
+        {
+            var table = ScriptableObject.CreateInstance<BarrierBalanceTable>();
+
+            try
+            {
+                table.BaseMaxHealth = 10;
+                table.MaxHealthPerTier = 2;
+
+                Assert.That(table.GetMaxHealthForTier(-1), Is.EqualTo(10));
+                Assert.That(table.GetMaxHealthForTier(0), Is.EqualTo(10));
+                Assert.That(table.GetMaxHealthForTier(3), Is.EqualTo(16));
+            }
+            finally
+            {
+                Object.DestroyImmediate(table);
+            }
+        }
+
+        [Test]
+        public void GetUpgradeCostForTier_UsesLinearScalingAndClampsTier()
+        {
+            var table = ScriptableObject.CreateInstance<BarrierBalanceTable>();
+
+            try
+            {
+                table.BaseCost = 20;
+                table.CostPerTier = 10;
+
+                Assert.That(table.GetUpgradeCostForTier(-1), Is.EqualTo(20));
+                Assert.That(table.GetUpgradeCostForTier(0), Is.EqualTo(20));
+                Assert.That(table.GetUpgradeCostForTier(3), Is.EqualTo(50));
+            }
+            finally
+            {
+                Object.DestroyImmediate(table);
+            }
+        }
+
+        [Test]
+        public void ProjectAssets_WireBarrierConfigThroughCentralBalanceStation()
+        {
+            var station = AssetDatabase.LoadAssetAtPath<GameBalanceStation>(BalanceStationPath);
+            var table = AssetDatabase.LoadAssetAtPath<BarrierBalanceTable>(BarrierBalanceTablePath);
+            var config = AssetDatabase.LoadAssetAtPath<BarrierUpgradeConfig>(BarrierUpgradeConfigPath);
+
+            Assert.NotNull(station, "Central GameBalanceStation asset must exist.");
+            Assert.NotNull(table, "BarrierBalanceTable asset must exist.");
+            Assert.NotNull(config, "BarrierUpgradeConfig asset must exist.");
+            Assert.AreSame(table, station.Barrier, "Central station should reference the authored barrier table.");
+            Assert.AreSame(station, config.BalanceStation, "Barrier config should resolve through the central station.");
+            Assert.That(table.BaseMaxHealth, Is.EqualTo(25), "Authored table should preserve current barrier config health tuning.");
+            Assert.That(table.MaxHealthPerTier, Is.EqualTo(5), "Authored table should preserve current barrier config tier health tuning.");
+            Assert.That(table.BaseCost, Is.EqualTo(10), "Authored table should preserve current barrier config cost tuning.");
+            Assert.That(table.CostPerTier, Is.EqualTo(10), "Authored table should preserve current barrier config tier cost tuning.");
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Balance/BarrierBalanceTableTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Balance/BarrierBalanceTableTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 47a1642d37f34c1786e9b05f607fdb74
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/EditMode/Barrier/BarrierUpgradeTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Barrier/BarrierUpgradeTests.cs
@@ -1,3 +1,4 @@
+using Castlebound.Gameplay.Balance;
 using Castlebound.Gameplay.Barrier;
 using Castlebound.Gameplay.Inventory;
 using NUnit.Framework;
@@ -19,6 +20,32 @@ namespace Castlebound.Tests.Barrier
         }
 
         [Test]
+        public void GetMaxHealthForTier_UsesBalanceTableWhenAssigned()
+        {
+            var station = ScriptableObject.CreateInstance<GameBalanceStation>();
+            var table = ScriptableObject.CreateInstance<BarrierBalanceTable>();
+            var config = ScriptableObject.CreateInstance<BarrierUpgradeConfig>();
+
+            try
+            {
+                table.BaseMaxHealth = 30;
+                table.MaxHealthPerTier = 7;
+                station.Barrier = table;
+                config.BalanceStation = station;
+                config.BaseMaxHealth = 10;
+                config.MaxHealthPerTier = 2;
+
+                Assert.That(config.GetMaxHealthForTier(2), Is.EqualTo(44));
+            }
+            finally
+            {
+                Object.DestroyImmediate(config);
+                Object.DestroyImmediate(table);
+                Object.DestroyImmediate(station);
+            }
+        }
+
+        [Test]
         public void GetUpgradeCost_ForHigherTier_IsGreaterThanBaseTier()
         {
             var config = ScriptableObject.CreateInstance<BarrierUpgradeConfig>();
@@ -27,6 +54,66 @@ namespace Castlebound.Tests.Barrier
 
             Assert.That(config.GetUpgradeCostForTier(0), Is.LessThan(config.GetUpgradeCostForTier(1)),
                 "Higher tiers should cost more than tier 0.");
+        }
+
+        [Test]
+        public void GetUpgradeCostForTier_UsesBalanceTableWhenAssigned()
+        {
+            var station = ScriptableObject.CreateInstance<GameBalanceStation>();
+            var table = ScriptableObject.CreateInstance<BarrierBalanceTable>();
+            var config = ScriptableObject.CreateInstance<BarrierUpgradeConfig>();
+
+            try
+            {
+                table.BaseCost = 15;
+                table.CostPerTier = 6;
+                station.Barrier = table;
+                config.BalanceStation = station;
+                config.BaseCost = 20;
+                config.CostPerTier = 10;
+
+                Assert.That(config.GetUpgradeCostForTier(3), Is.EqualTo(33));
+            }
+            finally
+            {
+                Object.DestroyImmediate(config);
+                Object.DestroyImmediate(table);
+                Object.DestroyImmediate(station);
+            }
+        }
+
+        [Test]
+        public void TryPurchaseUpgrade_UsesBalanceTableCost_WhenAssigned()
+        {
+            var station = ScriptableObject.CreateInstance<GameBalanceStation>();
+            var table = ScriptableObject.CreateInstance<BarrierBalanceTable>();
+            var config = ScriptableObject.CreateInstance<BarrierUpgradeConfig>();
+
+            try
+            {
+                table.BaseCost = 15;
+                table.CostPerTier = 5;
+                station.Barrier = table;
+                config.BalanceStation = station;
+                config.BaseCost = 100;
+                config.CostPerTier = 100;
+
+                var state = new BarrierUpgradeState();
+                var inventory = new InventoryState();
+                inventory.AddGold(15);
+
+                bool upgraded = BarrierUpgradeService.TryPurchaseUpgrade(state, config, inventory);
+
+                Assert.IsTrue(upgraded, "Upgrade should use the balance table cost when assigned.");
+                Assert.That(state.Tier, Is.EqualTo(1));
+                Assert.That(inventory.Gold, Is.EqualTo(0));
+            }
+            finally
+            {
+                Object.DestroyImmediate(config);
+                Object.DestroyImmediate(table);
+                Object.DestroyImmediate(station);
+            }
         }
 
         [Test]

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,24 @@
 
 ---
 
+## 2026-05-25 - refactor(barrier): route barrier tuning through balance tables
+
+### Summary
+- Added authored barrier health and upgrade-cost fields to BarrierBalanceTable.
+- Routed BarrierUpgradeConfig through GameBalanceStation barrier tables when assigned.
+- Added a BarrierBalanceTable asset wired through the central station while preserving current barrier asset tuning.
+
+### New or Updated Tests
+**EditMode**
+- `BarrierBalanceTableTests` — verifies default table values, clamping, tier formulas, and project asset wiring.
+- `BarrierUpgradeTests` — verifies barrier health, upgrade costs, and purchase spending resolve through the assigned balance table.
+
+**PlayMode**
+- N/A — N/A
+
+### Notes
+- EditMode tests passed in Unity editor validation on 2026-05-25.
+
 ## 2026-05-24 - refactor(tower): route tower tuning through balance tables
 
 ### Summary


### PR DESCRIPTION
## Why
Barrier health and upgrade cost tuning should be authored through the central balance table flow, matching the tower balance routing pattern.

## What changed
- Added authored barrier health and upgrade-cost tuning to `BarrierBalanceTable`
- Routed `BarrierUpgradeConfig` through `GameBalanceStation.Barrier` when assigned
- Preserved existing serialized config values as fallback behavior
- Added barrier balance asset wiring and EditMode regression coverage
- Updated the test log for the validated barrier routing work

## How to test
1. Open the barrier balance table and verify authored values are present
2. Press Play → verify barrier upgrade health/cost behavior remains correct
3. Run tests:
   - EditMode
   - PlayMode (N/A; EditMode coverage validates this routing change)

## Checklist

- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included (N/A — EditMode coverage validates this routing change)
- [x] Demo scene updated (N/A — no player-visible scene layout change)
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched 

## Related
- Closes #174