### PR TITLE
fix(loot): clarify reward item handling and enemy drops

### DIFF
--- a/Assets/_Project/Items/Definitions/Gold_1.asset
+++ b/Assets/_Project/Items/Definitions/Gold_1.asset
@@ -9,7 +9,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6b9150d0a42b48dca4c8f0a4b55cbb33, type: 3}
+  m_Script: {fileID: 11500000, guid: 8cc3f8e4d7504d79b99d0ccf5a7ae465, type: 3}
   m_Name: Gold_1
   m_EditorClassIdentifier: 
   itemId: gold_1

--- a/Assets/_Project/Scripts/_Project.Gameplay/Inventory/GoldDefinition.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Inventory/GoldDefinition.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+namespace Castlebound.Gameplay.Inventory
+{
+    [CreateAssetMenu(menuName = "Castlebound/Items/Gold Definition")]
+    public class GoldDefinition : ItemDefinition
+    {
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Inventory/GoldDefinition.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Inventory/GoldDefinition.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8cc3f8e4d7504d79b99d0ccf5a7ae465
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/_Project.Gameplay/Loot/LootSpawnPolicy.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Loot/LootSpawnPolicy.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Castlebound.Gameplay.Inventory;
 using UnityEngine;
@@ -40,6 +41,11 @@ namespace Castlebound.Gameplay.Loot
                     continue;
                 }
 
+                if (!IsGoldReward(result.Item))
+                {
+                    continue;
+                }
+
                 int spawnCap = ResolveSpawnCap(result, mappings);
                 int splitCount = spawnCap > 0 ? Mathf.Min(result.Amount, spawnCap) : result.Amount;
                 if (splitCount <= 0)
@@ -62,6 +68,16 @@ namespace Castlebound.Gameplay.Loot
             }
 
             return requests.Count == 0 ? System.Array.Empty<LootSpawnRequest>() : requests.ToArray();
+        }
+
+        private static bool IsGoldReward(ItemDefinition item)
+        {
+            if (item is GoldDefinition)
+            {
+                return true;
+            }
+
+            return item != null && item.ItemId != null && item.ItemId.StartsWith("gold_", StringComparison.Ordinal);
         }
 
         private static ItemPickupComponent ResolvePrefab(LootRollResult result, LootDropper.LootTableMapping[] mappings)

--- a/Assets/_Project/_Tests/EditMode/Loot/LootDropperTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Loot/LootDropperTests.cs
@@ -134,7 +134,7 @@ namespace Castlebound.Tests.Loot
         [Test]
         public void SpawnDrops_SplitsGoldIntoMultiplePickups_WithCap()
         {
-            var goldItem = ScriptableObject.CreateInstance<ItemDefinition>();
+            var goldItem = ScriptableObject.CreateInstance<GoldDefinition>();
             goldItem.ItemId = "gold_test";
             var goldTable = ScriptableObject.CreateInstance<LootTable>();
             goldTable.Entries = new[]

--- a/Assets/_Project/_Tests/EditMode/Loot/LootSpawnPolicyTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Loot/LootSpawnPolicyTests.cs
@@ -1,0 +1,167 @@
+using Castlebound.Gameplay.Inventory;
+using Castlebound.Gameplay.Loot;
+using NUnit.Framework;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace Castlebound.Tests.Loot
+{
+    public class LootSpawnPolicyTests
+    {
+        [Test]
+        public void BuildRequests_WithWeaponEntry_CreatesWeaponPickup()
+        {
+            var context = CreateContext<WeaponDefinition>("weapon_test", amount: 3);
+
+            try
+            {
+                var requests = LootSpawnPolicy.BuildRequests(context.Results, context.Mappings);
+
+                Assert.That(requests, Has.Length.EqualTo(1));
+                Assert.That(requests[0].Kind, Is.EqualTo(ItemPickupKind.Weapon));
+                Assert.That(requests[0].Item, Is.SameAs(context.Item));
+                Assert.That(requests[0].Amount, Is.EqualTo(1));
+            }
+            finally
+            {
+                context.Destroy();
+            }
+        }
+
+        [Test]
+        public void BuildRequests_WithPotionEntry_CreatesPotionPickup()
+        {
+            var context = CreateContext<PotionDefinition>("potion_test", amount: 3);
+
+            try
+            {
+                var requests = LootSpawnPolicy.BuildRequests(context.Results, context.Mappings);
+
+                Assert.That(requests, Has.Length.EqualTo(1));
+                Assert.That(requests[0].Kind, Is.EqualTo(ItemPickupKind.Potion));
+                Assert.That(requests[0].Item, Is.SameAs(context.Item));
+                Assert.That(requests[0].Amount, Is.EqualTo(3));
+            }
+            finally
+            {
+                context.Destroy();
+            }
+        }
+
+        [Test]
+        public void BuildRequests_WithGoldEntry_CreatesGoldPickup()
+        {
+            var context = CreateContext<GoldDefinition>("gold_test", amount: 7, maxSpawns: 0);
+
+            try
+            {
+                var requests = LootSpawnPolicy.BuildRequests(context.Results, context.Mappings);
+
+                Assert.That(requests, Has.Length.EqualTo(7));
+                Assert.That(requests[0].Kind, Is.EqualTo(ItemPickupKind.Gold));
+                Assert.That(requests[0].Item, Is.SameAs(context.Item));
+                Assert.That(requests[0].Amount, Is.EqualTo(1));
+            }
+            finally
+            {
+                context.Destroy();
+            }
+        }
+
+        [Test]
+        public void BuildRequests_WithLegacyGoldId_CreatesGoldPickup()
+        {
+            var context = CreateContext<ItemDefinition>("gold_legacy", amount: 5, maxSpawns: 2);
+
+            try
+            {
+                var requests = LootSpawnPolicy.BuildRequests(context.Results, context.Mappings);
+
+                Assert.That(requests, Has.Length.EqualTo(2));
+                Assert.That(requests[0].Kind, Is.EqualTo(ItemPickupKind.Gold));
+                Assert.That(requests[0].Amount, Is.EqualTo(3));
+                Assert.That(requests[1].Amount, Is.EqualTo(2));
+            }
+            finally
+            {
+                context.Destroy();
+            }
+        }
+
+        [Test]
+        public void BuildRequests_WithUnsupportedGenericItem_DoesNotCreatePickup()
+        {
+            var context = CreateContext<ItemDefinition>("ore_test", amount: 4);
+
+            try
+            {
+                var requests = LootSpawnPolicy.BuildRequests(context.Results, context.Mappings);
+
+                Assert.That(requests, Is.Empty);
+            }
+            finally
+            {
+                context.Destroy();
+            }
+        }
+
+        private static TestContext<T> CreateContext<T>(string itemId, int amount, int maxSpawns = 0)
+            where T : ItemDefinition
+        {
+            var item = ScriptableObject.CreateInstance<T>();
+            item.ItemId = itemId;
+
+            var table = ScriptableObject.CreateInstance<LootTable>();
+            table.Entries = new[]
+            {
+                new LootEntry(item, amount, amount, 1f)
+            };
+
+            var pickupGo = new GameObject("PickupPrefab");
+            var pickup = pickupGo.AddComponent<ItemPickupComponent>();
+
+            var mappings = new[]
+            {
+                new LootDropper.LootTableMapping(table, pickup, 1, maxSpawns)
+            };
+            var results = new[]
+            {
+                new LootRollResult(item, amount)
+            };
+
+            return new TestContext<T>(item, table, pickupGo, mappings, results);
+        }
+
+        private readonly struct TestContext<T>
+            where T : ItemDefinition
+        {
+            private readonly LootTable table;
+            private readonly GameObject pickupGo;
+
+            public TestContext(
+                T item,
+                LootTable table,
+                GameObject pickupGo,
+                LootDropper.LootTableMapping[] mappings,
+                LootRollResult[] results)
+            {
+                Item = item;
+                this.table = table;
+                this.pickupGo = pickupGo;
+                Mappings = mappings;
+                Results = results;
+            }
+
+            public T Item { get; }
+            public LootDropper.LootTableMapping[] Mappings { get; }
+            public LootRollResult[] Results { get; }
+
+            public void Destroy()
+            {
+                Object.DestroyImmediate(pickupGo);
+                Object.DestroyImmediate(table);
+                Object.DestroyImmediate(Item);
+            }
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Loot/LootSpawnPolicyTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Loot/LootSpawnPolicyTests.cs
@@ -1,6 +1,7 @@
 using Castlebound.Gameplay.Inventory;
 using Castlebound.Gameplay.Loot;
 using NUnit.Framework;
+using UnityEditor;
 using UnityEngine;
 using Object = UnityEngine.Object;
 
@@ -8,6 +9,17 @@ namespace Castlebound.Tests.Loot
 {
     public class LootSpawnPolicyTests
     {
+        private const string GoldDefinitionPath = "Assets/_Project/Items/Definitions/Gold_1.asset";
+
+        [Test]
+        public void AuthoredGoldAsset_LoadsAsGoldDefinition()
+        {
+            var gold = AssetDatabase.LoadAssetAtPath<GoldDefinition>(GoldDefinitionPath);
+
+            Assert.NotNull(gold, "Authored gold reward item should use the explicit GoldDefinition type.");
+            Assert.That(gold.ItemId, Is.EqualTo("gold_1"));
+        }
+
         [Test]
         public void BuildRequests_WithWeaponEntry_CreatesWeaponPickup()
         {

--- a/Assets/_Project/_Tests/EditMode/Loot/LootSpawnPolicyTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Loot/LootSpawnPolicyTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 594b6a21f193475d996bafdbb4f24d0c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,24 @@
 
 ---
 
+## 2026-05-26 - fix(loot): clarify reward item handling and enemy drops
+
+### Summary
+- Added an explicit GoldDefinition type for currency reward items.
+- Updated loot spawn classification so unsupported generic items no longer become gold pickups.
+- Migrated the authored Gold_1 reward asset to GoldDefinition while preserving existing loot table references.
+
+### New or Updated Tests
+**EditMode**
+- `LootSpawnPolicyTests` - verifies weapon, potion, gold, legacy gold, unsupported generic item, and authored gold asset classification.
+- `LootDropperTests` - verifies gold splitting uses the explicit gold reward type.
+
+**PlayMode**
+- N/A - N/A
+
+### Notes
+- EditMode tests passed in Unity editor validation on 2026-05-26.
+
 ## 2026-05-25 - refactor(barrier): route barrier tuning through balance tables
 
 ### Summary


### PR DESCRIPTION
## Why
Enemy loot handling treated unsupported generic item definitions as gold, which made future loot pool expansion risky and unclear.

## What changed
- Added an explicit `GoldDefinition` item type for currency rewards
- Updated loot spawn classification so only weapons, potions, explicit gold, or legacy `gold_` IDs become pickups
- Made unsupported generic item definitions fail safely instead of becoming gold
- Added EditMode coverage for weapon, potion, gold, legacy gold, unsupported generic item, and authored gold asset classification
- Migrated the authored `Gold_1` reward asset to `GoldDefinition`

## How to test
1. Open `Enemy.prefab` and confirm existing loot table mappings are unchanged
2. Verify `Gold_1.asset` still has item ID `gold_1`
3. Run tests:
   - EditMode
   - PlayMode (N/A; no scene or runtime flow change beyond covered loot classification)

## Checklist

- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included (N/A — EditMode coverage validates this loot classification change)
- [x] Demo scene updated (N/A — no scene layout change)
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched (Docs/TEST_LOG.md updated)

## Related
- Refs #182