### PR TITLE
refactor(economy): add reward and cost tuning table

### DIFF
--- a/Assets/_Project/Balance/EconomyBalanceTable.asset
+++ b/Assets/_Project/Balance/EconomyBalanceTable.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6e3a684419024d5c8ebcf3f8310a2f32, type: 3}
+  m_Name: EconomyBalanceTable
+  m_EditorClassIdentifier: 
+  startingGold: 0
+  startingXp: 0

--- a/Assets/_Project/Balance/EconomyBalanceTable.asset.meta
+++ b/Assets/_Project/Balance/EconomyBalanceTable.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 33e3c7ab33304f10aaff7086767de14c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Balance/GameBalanceStation.asset
+++ b/Assets/_Project/Balance/GameBalanceStation.asset
@@ -17,4 +17,4 @@ MonoBehaviour:
   wave: {fileID: 0}
   enemy: {fileID: 0}
   player: {fileID: 0}
-  economy: {fileID: 0}
+  economy: {fileID: 11400000, guid: 33e3c7ab33304f10aaff7086767de14c, type: 2}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Balance/EconomyBalanceTable.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Balance/EconomyBalanceTable.cs
@@ -5,5 +5,25 @@ namespace Castlebound.Gameplay.Balance
     [CreateAssetMenu(menuName = "Castlebound/Balance/Economy Balance Table")]
     public class EconomyBalanceTable : ScriptableObject
     {
+        [SerializeField] private int startingGold = 0;
+        [SerializeField] private int startingXp = 0;
+
+        public int StartingGold
+        {
+            get => startingGold;
+            set => startingGold = Mathf.Max(0, value);
+        }
+
+        public int StartingXp
+        {
+            get => startingXp;
+            set => startingXp = Mathf.Max(0, value);
+        }
+
+        private void OnValidate()
+        {
+            StartingGold = startingGold;
+            StartingXp = startingXp;
+        }
     }
 }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Inventory/InventoryStateComponent.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Inventory/InventoryStateComponent.cs
@@ -1,11 +1,32 @@
+using Castlebound.Gameplay.Balance;
 using UnityEngine;
 
 namespace Castlebound.Gameplay.Inventory
 {
     public class InventoryStateComponent : MonoBehaviour
     {
+        [SerializeField] private GameBalanceStation balanceStation;
         [SerializeField] private int startingGold;
+        [SerializeField] private int startingXp;
         private InventoryState state;
+
+        public GameBalanceStation BalanceStation
+        {
+            get => balanceStation;
+            set => balanceStation = value;
+        }
+
+        public int StartingGold
+        {
+            get => startingGold;
+            set => startingGold = Mathf.Max(0, value);
+        }
+
+        public int StartingXp
+        {
+            get => startingXp;
+            set => startingXp = Mathf.Max(0, value);
+        }
 
         public InventoryState State
         {
@@ -14,14 +35,29 @@ namespace Castlebound.Gameplay.Inventory
                 if (state == null)
                 {
                     state = new InventoryState();
-                    if (startingGold > 0)
+                    int initialGold = ActiveEconomyTable != null ? ActiveEconomyTable.StartingGold : startingGold;
+                    int initialXp = ActiveEconomyTable != null ? ActiveEconomyTable.StartingXp : startingXp;
+                    if (initialGold > 0)
                     {
-                        state.AddGold(startingGold);
+                        state.AddGold(initialGold);
+                    }
+
+                    if (initialXp > 0)
+                    {
+                        state.AddXp(initialXp);
                     }
                 }
 
                 return state;
             }
+        }
+
+        private EconomyBalanceTable ActiveEconomyTable => balanceStation != null ? balanceStation.Economy : null;
+
+        private void OnValidate()
+        {
+            StartingGold = startingGold;
+            StartingXp = startingXp;
         }
     }
 }

--- a/Assets/_Project/_Tests/EditMode/Balance/EconomyBalanceTableTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Balance/EconomyBalanceTableTests.cs
@@ -1,0 +1,111 @@
+using Castlebound.Gameplay.Balance;
+using Castlebound.Gameplay.Inventory;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace Castlebound.Tests.Balance
+{
+    public class EconomyBalanceTableTests
+    {
+        private const string BalanceStationPath = "Assets/_Project/Balance/GameBalanceStation.asset";
+        private const string EconomyBalanceTablePath = "Assets/_Project/Balance/EconomyBalanceTable.asset";
+
+        [Test]
+        public void Defaults_MirrorCurrentInventoryStartTuning()
+        {
+            var table = ScriptableObject.CreateInstance<EconomyBalanceTable>();
+
+            try
+            {
+                Assert.That(table.StartingGold, Is.EqualTo(0));
+                Assert.That(table.StartingXp, Is.EqualTo(0));
+            }
+            finally
+            {
+                Object.DestroyImmediate(table);
+            }
+        }
+
+        [Test]
+        public void ScalarProperties_ClampToSafeValues()
+        {
+            var table = ScriptableObject.CreateInstance<EconomyBalanceTable>();
+
+            try
+            {
+                table.StartingGold = -1;
+                table.StartingXp = -1;
+
+                Assert.That(table.StartingGold, Is.EqualTo(0));
+                Assert.That(table.StartingXp, Is.EqualTo(0));
+            }
+            finally
+            {
+                Object.DestroyImmediate(table);
+            }
+        }
+
+        [Test]
+        public void InventoryStateComponent_UsesEconomyTableStartingCurrencyWhenAssigned()
+        {
+            var station = ScriptableObject.CreateInstance<GameBalanceStation>();
+            var table = ScriptableObject.CreateInstance<EconomyBalanceTable>();
+            var gameObject = new GameObject("Inventory");
+            var inventory = gameObject.AddComponent<InventoryStateComponent>();
+
+            try
+            {
+                table.StartingGold = 7;
+                table.StartingXp = 3;
+                station.Economy = table;
+                inventory.BalanceStation = station;
+                inventory.StartingGold = 99;
+                inventory.StartingXp = 99;
+
+                Assert.That(inventory.State.Gold, Is.EqualTo(7));
+                Assert.That(inventory.State.Xp, Is.EqualTo(3));
+            }
+            finally
+            {
+                Object.DestroyImmediate(gameObject);
+                Object.DestroyImmediate(table);
+                Object.DestroyImmediate(station);
+            }
+        }
+
+        [Test]
+        public void InventoryStateComponent_FallsBackToSerializedStartingCurrencyWithoutTable()
+        {
+            var gameObject = new GameObject("Inventory");
+            var inventory = gameObject.AddComponent<InventoryStateComponent>();
+
+            try
+            {
+                inventory.StartingGold = 5;
+                inventory.StartingXp = 2;
+
+                Assert.That(inventory.State.Gold, Is.EqualTo(5));
+                Assert.That(inventory.State.Xp, Is.EqualTo(2));
+            }
+            finally
+            {
+                Object.DestroyImmediate(gameObject);
+            }
+        }
+
+        [Test]
+        public void ProjectAssets_WireEconomyTableThroughCentralBalanceStation()
+        {
+            var station = AssetDatabase.LoadAssetAtPath<GameBalanceStation>(BalanceStationPath);
+            var table = AssetDatabase.LoadAssetAtPath<EconomyBalanceTable>(EconomyBalanceTablePath);
+
+            Assert.NotNull(station, "Central GameBalanceStation asset must exist.");
+            Assert.NotNull(table, "EconomyBalanceTable asset must exist.");
+            Assert.AreSame(table, station.Economy, "Central station should reference the authored economy table.");
+            Assert.That(table.StartingGold, Is.EqualTo(0), "Authored table should preserve current starting gold tuning.");
+            Assert.That(table.StartingXp, Is.EqualTo(0), "Authored table should preserve current starting XP tuning.");
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Balance/EconomyBalanceTableTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Balance/EconomyBalanceTableTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f4f6231d47dc4b8aaa87bf1809f1131b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,23 @@
 
 ---
 
+## 2026-05-26 - refactor(economy): add reward and cost tuning table
+
+### Summary
+- Added authored starting currency fields to EconomyBalanceTable.
+- Added the EconomyBalanceTable project asset and wired it through GameBalanceStation.
+- Routed InventoryStateComponent starting currency through the economy table when assigned.
+
+### New or Updated Tests
+**EditMode**
+- `EconomyBalanceTableTests` - verifies defaults, clamping, inventory starting currency routing, fallback behavior, and project asset wiring.
+
+**PlayMode**
+- N/A - N/A
+
+### Notes
+- EditMode and PlayMode tests passed per user on 2026-05-26.
+
 ## 2026-05-26 - fix(loot): clarify reward item handling and enemy drops
 
 ### Summary


### PR DESCRIPTION
## Why
Centralize shared starting economy tuning behind the balance station so currency setup can be authored consistently.

## What changed
- Added starting gold and XP fields to EconomyBalanceTable with safe clamping.
- Added an authored EconomyBalanceTable asset wired through GameBalanceStation.
- Routed InventoryStateComponent starting currency through the economy table when assigned.
- Added EditMode coverage for defaults, clamping, runtime routing, fallback behavior, and project asset wiring.

## How to test
1. Open the relevant scene or demo (if applicable)
2. Press Play → verify expected behavior
3. Run tests:
   - EditMode
   - PlayMode

## Checklist

- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated (N/A - no player-visible scene changes)
- [x] Prefab links, tags, and layers validated (N/A - no prefab, tag, or layer changes)
- [x] README / Docs touched (TEST_LOG.md updated)

## Related
- Closes #182
