### PR TITLE
refactor(waves): add pacing and difficulty tuning table

### DIFF
--- a/Assets/_Project/Balance/GameBalanceStation.asset
+++ b/Assets/_Project/Balance/GameBalanceStation.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   tower: {fileID: 11400000, guid: 1d03794e8d2c4c53a6de599e33d4f8fe, type: 2}
   barrier: {fileID: 11400000, guid: 64e791ca8c294529bc6393d439d743c9, type: 2}
-  wave: {fileID: 0}
+  wave: {fileID: 11400000, guid: 744802b4eadd4e4eae9b8cc043d6c82e, type: 2}
   enemy: {fileID: 0}
   player: {fileID: 0}
   economy: {fileID: 11400000, guid: 33e3c7ab33304f10aaff7086767de14c, type: 2}

--- a/Assets/_Project/Balance/WaveBalanceTable.asset
+++ b/Assets/_Project/Balance/WaveBalanceTable.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   defaultStrategy: 0
   useDefaultSeed: 0
   defaultSeed: 0
-  defaultGapSeconds: 5
+  defaultGapSeconds: 8
   defaultWaitForClear: 1
   defaultMaxAlive: 0
   activeBuildIndex: 0

--- a/Assets/_Project/Balance/WaveBalanceTable.asset
+++ b/Assets/_Project/Balance/WaveBalanceTable.asset
@@ -1,0 +1,31 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 791dd8b7d8ee4210a4fea8c891db1035, type: 3}
+  m_Name: WaveBalanceTable
+  m_EditorClassIdentifier: 
+  defaultStrategy: 0
+  useDefaultSeed: 0
+  defaultSeed: 0
+  defaultGapSeconds: 5
+  defaultWaitForClear: 1
+  defaultMaxAlive: 0
+  activeBuildIndex: 0
+  generatedBuilds:
+  - buildId: default
+    enabled: 1
+    baseSpawnCount: 5
+    spawnCountPerStep: 3
+    spawnCountStepSize: 1
+    spawnCountStartWave: 1
+    maxSpawnCount: 0
+    intervalSeconds: 0.5
+    initialDelaySeconds: 0

--- a/Assets/_Project/Balance/WaveBalanceTable.asset.meta
+++ b/Assets/_Project/Balance/WaveBalanceTable.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 744802b4eadd4e4eae9b8cc043d6c82e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scenes/MainPrototype.unity
+++ b/Assets/_Project/Scenes/MainPrototype.unity
@@ -2665,6 +2665,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   scheduleAsset: {fileID: 11400000, guid: b8131ce0d2d210540bc4d0b4535b89b8, type: 2}
+  balanceStation: {fileID: 11400000, guid: d70caaeb4e66400f8127d62f459cae21, type: 2}
   spawnMarkers: []
   prefabMappings:
   - enemyTypeId: grunt

--- a/Assets/_Project/Scripts/_Project.Gameplay/Balance/WaveBalanceTable.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Balance/WaveBalanceTable.cs
@@ -1,9 +1,199 @@
 using UnityEngine;
+using Castlebound.Gameplay.Spawning;
 
 namespace Castlebound.Gameplay.Balance
 {
+    [System.Serializable]
+    public class WaveGenerationBuild
+    {
+        [SerializeField] private string buildId = "default";
+        [SerializeField] private bool enabled = true;
+        [SerializeField] private int baseSpawnCount = 5;
+        [SerializeField] private int spawnCountPerStep = 10;
+        [SerializeField] private int spawnCountStepSize = 1;
+        [SerializeField] private int spawnCountStartWave = 1;
+        [Tooltip("0 means no cap")]
+        [SerializeField] private int maxSpawnCount = 0;
+        [SerializeField] private float intervalSeconds = 1f;
+        [SerializeField] private float initialDelaySeconds = 0f;
+
+        public string BuildId
+        {
+            get => buildId;
+            set => buildId = value;
+        }
+
+        public bool Enabled
+        {
+            get => enabled;
+            set => enabled = value;
+        }
+
+        public int BaseSpawnCount
+        {
+            get => baseSpawnCount;
+            set => baseSpawnCount = Mathf.Max(0, value);
+        }
+
+        public int SpawnCountPerStep
+        {
+            get => spawnCountPerStep;
+            set => spawnCountPerStep = Mathf.Max(0, value);
+        }
+
+        public int SpawnCountStepSize
+        {
+            get => spawnCountStepSize;
+            set => spawnCountStepSize = Mathf.Max(1, value);
+        }
+
+        public int SpawnCountStartWave
+        {
+            get => spawnCountStartWave;
+            set => spawnCountStartWave = Mathf.Max(1, value);
+        }
+
+        public int MaxSpawnCount
+        {
+            get => maxSpawnCount;
+            set => maxSpawnCount = Mathf.Max(0, value);
+        }
+
+        public float IntervalSeconds
+        {
+            get => intervalSeconds;
+            set => intervalSeconds = Mathf.Max(0f, value);
+        }
+
+        public float InitialDelaySeconds
+        {
+            get => initialDelaySeconds;
+            set => initialDelaySeconds = Mathf.Max(0f, value);
+        }
+
+        public int GetSpawnCountForWave(int waveIndex)
+        {
+            int safeWaveIndex = Mathf.Max(1, waveIndex);
+            int count = baseSpawnCount;
+            if (safeWaveIndex >= spawnCountStartWave && spawnCountPerStep > 0)
+            {
+                int steps = (safeWaveIndex - spawnCountStartWave) / spawnCountStepSize;
+                if (steps > 0)
+                {
+                    count += steps * spawnCountPerStep;
+                }
+            }
+
+            return maxSpawnCount > 0 && count > maxSpawnCount ? maxSpawnCount : count;
+        }
+
+        public void Normalize()
+        {
+            BaseSpawnCount = baseSpawnCount;
+            SpawnCountPerStep = spawnCountPerStep;
+            SpawnCountStepSize = spawnCountStepSize;
+            SpawnCountStartWave = spawnCountStartWave;
+            MaxSpawnCount = maxSpawnCount;
+            IntervalSeconds = intervalSeconds;
+            InitialDelaySeconds = initialDelaySeconds;
+        }
+    }
+
     [CreateAssetMenu(menuName = "Castlebound/Balance/Wave Balance Table")]
     public class WaveBalanceTable : ScriptableObject
     {
+        [SerializeField] private SpawnMarkerStrategy defaultStrategy = SpawnMarkerStrategy.RoundRobin;
+        [SerializeField] private bool useDefaultSeed = false;
+        [SerializeField] private int defaultSeed = 0;
+        [SerializeField] private float defaultGapSeconds = 5f;
+        [SerializeField] private bool defaultWaitForClear = true;
+        [SerializeField] private int defaultMaxAlive = 0;
+        [Header("Generated Wave Builds")]
+        [SerializeField] private int activeBuildIndex = 0;
+        [SerializeField] private WaveGenerationBuild[] generatedBuilds =
+        {
+            new WaveGenerationBuild()
+        };
+
+        public SpawnMarkerStrategy DefaultStrategy
+        {
+            get => defaultStrategy;
+            set => defaultStrategy = value;
+        }
+
+        public bool UseDefaultSeed
+        {
+            get => useDefaultSeed;
+            set => useDefaultSeed = value;
+        }
+
+        public int DefaultSeed
+        {
+            get => defaultSeed;
+            set => defaultSeed = value;
+        }
+
+        public float DefaultGapSeconds
+        {
+            get => defaultGapSeconds;
+            set => defaultGapSeconds = Mathf.Max(0f, value);
+        }
+
+        public bool DefaultWaitForClear
+        {
+            get => defaultWaitForClear;
+            set => defaultWaitForClear = value;
+        }
+
+        public int DefaultMaxAlive
+        {
+            get => defaultMaxAlive;
+            set => defaultMaxAlive = Mathf.Max(0, value);
+        }
+
+        public int ActiveBuildIndex
+        {
+            get => activeBuildIndex;
+            set => activeBuildIndex = Mathf.Max(0, value);
+        }
+
+        public WaveGenerationBuild[] GeneratedBuilds
+        {
+            get => generatedBuilds;
+            set => generatedBuilds = value;
+        }
+
+        public int ResolvedDefaultSeed => useDefaultSeed ? defaultSeed : 0;
+
+        public WaveGenerationBuild ActiveBuild
+        {
+            get
+            {
+                if (generatedBuilds == null || generatedBuilds.Length == 0)
+                {
+                    return null;
+                }
+
+                int index = Mathf.Clamp(activeBuildIndex, 0, generatedBuilds.Length - 1);
+                var build = generatedBuilds[index];
+                return build != null && build.Enabled ? build : null;
+            }
+        }
+
+        private void OnValidate()
+        {
+            DefaultGapSeconds = defaultGapSeconds;
+            DefaultMaxAlive = defaultMaxAlive;
+            ActiveBuildIndex = activeBuildIndex;
+            if (generatedBuilds == null)
+            {
+                return;
+            }
+
+            for (int i = 0; i < generatedBuilds.Length; i++)
+            {
+                generatedBuilds[i]?.Normalize();
+            }
+        }
     }
 }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Balance/WaveBalanceTable.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Balance/WaveBalanceTable.cs
@@ -9,12 +9,12 @@ namespace Castlebound.Gameplay.Balance
         [SerializeField] private string buildId = "default";
         [SerializeField] private bool enabled = true;
         [SerializeField] private int baseSpawnCount = 5;
-        [SerializeField] private int spawnCountPerStep = 10;
+        [SerializeField] private int spawnCountPerStep = 3;
         [SerializeField] private int spawnCountStepSize = 1;
         [SerializeField] private int spawnCountStartWave = 1;
         [Tooltip("0 means no cap")]
         [SerializeField] private int maxSpawnCount = 0;
-        [SerializeField] private float intervalSeconds = 1f;
+        [SerializeField] private float intervalSeconds = 0.5f;
         [SerializeField] private float initialDelaySeconds = 0f;
 
         public string BuildId

--- a/Assets/_Project/Scripts/_Project.Gameplay/Balance/WaveBalanceTable.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Balance/WaveBalanceTable.cs
@@ -105,7 +105,7 @@ namespace Castlebound.Gameplay.Balance
         [SerializeField] private SpawnMarkerStrategy defaultStrategy = SpawnMarkerStrategy.RoundRobin;
         [SerializeField] private bool useDefaultSeed = false;
         [SerializeField] private int defaultSeed = 0;
-        [SerializeField] private float defaultGapSeconds = 5f;
+        [SerializeField] private float defaultGapSeconds = 8f;
         [SerializeField] private bool defaultWaitForClear = true;
         [SerializeField] private int defaultMaxAlive = 0;
         [Header("Generated Wave Builds")]

--- a/Assets/_Project/Scripts/_Project.Gameplay/Spawning/EnemySpawnScheduleAsset.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Spawning/EnemySpawnScheduleAsset.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Castlebound.Gameplay.Balance;
 using UnityEngine;
 
 namespace Castlebound.Gameplay.Spawning
@@ -73,11 +74,15 @@ namespace Castlebound.Gameplay.Spawning
     public class EnemySpawnScheduleAsset : ScriptableObject
     {
         [Header("Defaults")]
+        [SerializeField] private GameBalanceStation balanceStation;
         [SerializeField] private SpawnMarkerStrategy defaultStrategy = SpawnMarkerStrategy.RoundRobin;
 
         [Tooltip("Set true to use defaultSeed value")]
         [SerializeField] private bool useDefaultSeed;
         [SerializeField] private int defaultSeed;
+        [SerializeField] private float defaultGapSeconds = 5f;
+        [SerializeField] private bool defaultWaitForClear = true;
+        [SerializeField] private int defaultMaxAlive = 0;
 
         [Header("Authored Waves")]
         [SerializeField] private List<WaveConfig> waves = new List<WaveConfig>();
@@ -87,6 +92,24 @@ namespace Castlebound.Gameplay.Spawning
 
         // Legacy sequences kept for backward compatibility; will be removed once waves/ramp are fully wired.
         [SerializeField, HideInInspector] private List<SpawnSequenceConfig> sequences = new List<SpawnSequenceConfig>();
+
+        public GameBalanceStation BalanceStation
+        {
+            get => balanceStation;
+            set => balanceStation = value;
+        }
+
+        public float DefaultGapSeconds
+        {
+            get => defaultGapSeconds;
+            set => defaultGapSeconds = Mathf.Max(0f, value);
+        }
+
+        public int DefaultMaxAlive
+        {
+            get => defaultMaxAlive;
+            set => defaultMaxAlive = Mathf.Max(0, value);
+        }
 
         public EnemySpawnSchedule ToRuntimeSchedule()
         {
@@ -101,12 +124,45 @@ namespace Castlebound.Gameplay.Spawning
 
         public WaveScheduleRuntime ToRuntimeWaveSchedule()
         {
-            var seed = useDefaultSeed ? defaultSeed : 0;
+            return ToRuntimeWaveSchedule(null);
+        }
+
+        public WaveScheduleRuntime ToRuntimeWaveSchedule(GameBalanceStation balanceStationOverride)
+        {
+            var waveTable = ResolveWaveTable(balanceStationOverride);
+            var strategy = waveTable != null ? waveTable.DefaultStrategy : defaultStrategy;
+            var seed = waveTable != null ? waveTable.ResolvedDefaultSeed : useDefaultSeed ? defaultSeed : 0;
+            var gapSeconds = waveTable != null ? waveTable.DefaultGapSeconds : defaultGapSeconds;
+            var waitForClear = waveTable != null ? waveTable.DefaultWaitForClear : defaultWaitForClear;
+            var maxAlive = waveTable != null ? waveTable.DefaultMaxAlive : defaultMaxAlive;
+
             return new WaveScheduleRuntime(
-                defaultStrategy: defaultStrategy,
+                defaultStrategy: strategy,
                 defaultSeed: seed,
                 waves: waves,
-                ramp: ramp);
+                ramp: ramp,
+                defaultGapSeconds: gapSeconds,
+                defaultWaitForClear: waitForClear,
+                defaultMaxAlive: maxAlive,
+                generationBuild: waveTable != null ? waveTable.ActiveBuild : null);
+        }
+
+        private WaveBalanceTable ActiveWaveTable => balanceStation != null ? balanceStation.Wave : null;
+
+        private WaveBalanceTable ResolveWaveTable(GameBalanceStation balanceStationOverride)
+        {
+            if (balanceStationOverride != null && balanceStationOverride.Wave != null)
+            {
+                return balanceStationOverride.Wave;
+            }
+
+            return ActiveWaveTable;
+        }
+
+        private void OnValidate()
+        {
+            DefaultGapSeconds = defaultGapSeconds;
+            DefaultMaxAlive = defaultMaxAlive;
         }
     }
 }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Spawning/EnemySpawnerRunner.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Spawning/EnemySpawnerRunner.cs
@@ -66,9 +66,9 @@ namespace Castlebound.Gameplay.Spawning
             }
 
             var waveSchedule = scheduleAsset.ToRuntimeWaveSchedule(balanceStation);
-            var hasAuthoredWaves = scheduleAsset != null && waveSchedule != null && waveSchedule.HasAuthoredWaves;
+            var canProvideWaves = waveSchedule != null && waveSchedule.CanProvideWaves;
 
-            if (hasAuthoredWaves)
+            if (canProvideWaves)
             {
                 _waveSpawner = new EnemyWaveSpawner(waveSchedule, spawnPoints);
                 _waveSpawner.OnWaveStarted += HandleWaveStarted;

--- a/Assets/_Project/Scripts/_Project.Gameplay/Spawning/EnemySpawnerRunner.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Spawning/EnemySpawnerRunner.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Castlebound.Gameplay.Balance;
 using UnityEngine;
 
 namespace Castlebound.Gameplay.Spawning
@@ -17,6 +18,7 @@ namespace Castlebound.Gameplay.Spawning
         }
 
         [SerializeField] private EnemySpawnScheduleAsset scheduleAsset;
+        [SerializeField] private GameBalanceStation balanceStation;
         [SerializeField] private List<SpawnPointMarker> spawnMarkers = new List<SpawnPointMarker>();
         [SerializeField] private List<EnemyPrefabMapping> prefabMappings = new List<EnemyPrefabMapping>();
         [SerializeField] private bool autoFindMarkers = true;
@@ -29,6 +31,12 @@ namespace Castlebound.Gameplay.Spawning
         private IWaveIndexProvider waveIndexProvider;
 
         public WavePhaseTracker PhaseTracker => phaseTracker ??= new WavePhaseTracker();
+
+        public GameBalanceStation BalanceStation
+        {
+            get => balanceStation;
+            set => balanceStation = value;
+        }
 
         private void Start()
         {
@@ -57,7 +65,7 @@ namespace Castlebound.Gameplay.Spawning
                 }
             }
 
-            var waveSchedule = scheduleAsset.ToRuntimeWaveSchedule();
+            var waveSchedule = scheduleAsset.ToRuntimeWaveSchedule(balanceStation);
             var hasAuthoredWaves = scheduleAsset != null && waveSchedule != null && waveSchedule.HasAuthoredWaves;
 
             if (hasAuthoredWaves)

--- a/Assets/_Project/Scripts/_Project.Gameplay/Spawning/WaveScheduleRuntime.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Spawning/WaveScheduleRuntime.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using Castlebound.Gameplay.Balance;
 
 namespace Castlebound.Gameplay.Spawning
 {
@@ -30,14 +31,55 @@ namespace Castlebound.Gameplay.Spawning
         private readonly List<WaveConfig> _waves;
         private readonly RampConfig _ramp;
         private readonly System.Random _rng;
+        private readonly float _defaultGapSeconds;
+        private readonly bool _defaultWaitForClear;
+        private readonly int _defaultMaxAlive;
+        private readonly WaveGenerationBuild _generationBuild;
 
         public WaveScheduleRuntime(SpawnMarkerStrategy defaultStrategy, int defaultSeed, IEnumerable<WaveConfig> waves, RampConfig ramp)
+            : this(defaultStrategy, defaultSeed, waves, ramp, 5f, true, 0)
+        {
+        }
+
+        public WaveScheduleRuntime(
+            SpawnMarkerStrategy defaultStrategy,
+            int defaultSeed,
+            IEnumerable<WaveConfig> waves,
+            RampConfig ramp,
+            float defaultGapSeconds,
+            bool defaultWaitForClear,
+            int defaultMaxAlive)
+            : this(
+                defaultStrategy,
+                defaultSeed,
+                waves,
+                ramp,
+                defaultGapSeconds,
+                defaultWaitForClear,
+                defaultMaxAlive,
+                null)
+        {
+        }
+
+        public WaveScheduleRuntime(
+            SpawnMarkerStrategy defaultStrategy,
+            int defaultSeed,
+            IEnumerable<WaveConfig> waves,
+            RampConfig ramp,
+            float defaultGapSeconds,
+            bool defaultWaitForClear,
+            int defaultMaxAlive,
+            WaveGenerationBuild generationBuild)
         {
             _defaultStrategy = defaultStrategy;
             _defaultSeed = defaultSeed;
             _waves = waves?.ToList() ?? new List<WaveConfig>();
             _ramp = ramp;
             _rng = new System.Random(_defaultSeed);
+            _defaultGapSeconds = defaultGapSeconds < 0f ? 0f : defaultGapSeconds;
+            _defaultWaitForClear = defaultWaitForClear;
+            _defaultMaxAlive = defaultMaxAlive < 0 ? 0 : defaultMaxAlive;
+            _generationBuild = generationBuild != null && generationBuild.Enabled ? generationBuild : null;
         }
 
         public bool HasAuthoredWaves => _waves.Count > 0;
@@ -68,9 +110,9 @@ namespace Castlebound.Gameplay.Spawning
                 sequences: new List<SpawnSequenceConfig>(),
                 strategy: _defaultStrategy,
                 seed: _defaultSeed,
-                gapSeconds: 5f,
-                waitForClear: true,
-                maxAlive: 0);
+                gapSeconds: _defaultGapSeconds,
+                waitForClear: _defaultWaitForClear,
+                maxAlive: _defaultMaxAlive);
         }
 
         private WaveConfig GetAuthoredWaveConfig(int waveIndex)
@@ -96,20 +138,7 @@ namespace Castlebound.Gameplay.Spawning
                 return null;
             }
 
-            var count = _ramp.baseSpawnCount;
-            if (_ramp.stepSize > 0 && _ramp.countPerStep != 0)
-            {
-                var steps = (waveIndex - _ramp.startWave) / _ramp.stepSize;
-                if (steps > 0)
-                {
-                    count += steps * _ramp.countPerStep;
-                }
-            }
-
-            if (count < _ramp.baseSpawnCount)
-            {
-                count = _ramp.baseSpawnCount;
-            }
+            var count = ResolveGeneratedSpawnCount(waveIndex);
 
             var pool = BuildTierPool(waveIndex);
             if (pool.Count == 0)
@@ -123,17 +152,42 @@ namespace Castlebound.Gameplay.Spawning
             {
                 enemyTypeId = chosenType,
                 spawnCount = count,
-                intervalSeconds = 1f,
-                initialDelaySeconds = 0f
+                intervalSeconds = _generationBuild != null ? _generationBuild.IntervalSeconds : 1f,
+                initialDelaySeconds = _generationBuild != null ? _generationBuild.InitialDelaySeconds : 0f
             };
 
             return new WaveRuntime(
                 sequences: new List<SpawnSequenceConfig> { sequence },
                 strategy: _defaultStrategy,
                 seed: _defaultSeed,
-                gapSeconds: 5f,
-                waitForClear: true,
-                maxAlive: 0);
+                gapSeconds: _defaultGapSeconds,
+                waitForClear: _defaultWaitForClear,
+                maxAlive: _defaultMaxAlive);
+        }
+
+        private int ResolveGeneratedSpawnCount(int waveIndex)
+        {
+            if (_generationBuild != null)
+            {
+                return _generationBuild.GetSpawnCountForWave(waveIndex);
+            }
+
+            var rampCount = _ramp.baseSpawnCount;
+            if (_ramp.stepSize > 0 && _ramp.countPerStep != 0)
+            {
+                var steps = (waveIndex - _ramp.startWave) / _ramp.stepSize;
+                if (steps > 0)
+                {
+                    rampCount += steps * _ramp.countPerStep;
+                }
+            }
+
+            if (rampCount < _ramp.baseSpawnCount)
+            {
+                rampCount = _ramp.baseSpawnCount;
+            }
+
+            return rampCount;
         }
 
         private List<RampTier> BuildTierPool(int waveIndex)

--- a/Assets/_Project/Scripts/_Project.Gameplay/Spawning/WaveScheduleRuntime.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Spawning/WaveScheduleRuntime.cs
@@ -83,6 +83,7 @@ namespace Castlebound.Gameplay.Spawning
         }
 
         public bool HasAuthoredWaves => _waves.Count > 0;
+        public bool CanProvideWaves => HasAuthoredWaves || HasRampGeneration;
 
         public WaveRuntime GetWave(int waveIndex)
         {
@@ -208,6 +209,36 @@ namespace Castlebound.Gameplay.Spawning
 
             // If no weights set, weights are effectively equal; we just pick the first for now.
             return pool;
+        }
+
+        private bool HasRampGeneration
+        {
+            get
+            {
+                if (_ramp == null || _ramp.unlocks == null)
+                {
+                    return false;
+                }
+
+                for (int i = 0; i < _ramp.unlocks.Count; i++)
+                {
+                    var unlock = _ramp.unlocks[i];
+                    if (unlock.tiers == null)
+                    {
+                        continue;
+                    }
+
+                    for (int j = 0; j < unlock.tiers.Count; j++)
+                    {
+                        if (!string.IsNullOrWhiteSpace(unlock.tiers[j].enemyTypeId))
+                        {
+                            return true;
+                        }
+                    }
+                }
+
+                return false;
+            }
         }
 
         private string ChooseEnemyType(List<RampTier> pool)

--- a/Assets/_Project/Spawning/BasicSpawnSchedule.asset
+++ b/Assets/_Project/Spawning/BasicSpawnSchedule.asset
@@ -18,7 +18,7 @@ MonoBehaviour:
   waves:
   - sequences:
     - enemyTypeId: grunt
-      spawnCount: 6
+      spawnCount: 5
       intervalSeconds: 1
       initialDelaySeconds: 0.5
     useStrategyOverride: 0

--- a/Assets/_Project/_Tests/EditMode/Balance/WaveBalanceTableTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Balance/WaveBalanceTableTests.cs
@@ -31,11 +31,11 @@ namespace Castlebound.Tests.Balance
                 Assert.That(table.ActiveBuild.BuildId, Is.EqualTo("default"));
                 Assert.IsTrue(table.ActiveBuild.Enabled);
                 Assert.That(table.ActiveBuild.BaseSpawnCount, Is.EqualTo(5));
-                Assert.That(table.ActiveBuild.SpawnCountPerStep, Is.EqualTo(10));
+                Assert.That(table.ActiveBuild.SpawnCountPerStep, Is.EqualTo(3));
                 Assert.That(table.ActiveBuild.SpawnCountStepSize, Is.EqualTo(1));
                 Assert.That(table.ActiveBuild.SpawnCountStartWave, Is.EqualTo(1));
                 Assert.That(table.ActiveBuild.MaxSpawnCount, Is.EqualTo(0));
-                Assert.That(table.ActiveBuild.IntervalSeconds, Is.EqualTo(1f).Within(0.001f));
+                Assert.That(table.ActiveBuild.IntervalSeconds, Is.EqualTo(0.5f).Within(0.001f));
                 Assert.That(table.ActiveBuild.InitialDelaySeconds, Is.EqualTo(0f).Within(0.001f));
             }
             finally
@@ -139,7 +139,7 @@ namespace Castlebound.Tests.Balance
             Assert.That(table.DefaultMaxAlive, Is.EqualTo(0));
             Assert.NotNull(table.ActiveBuild);
             Assert.That(table.ActiveBuild.BaseSpawnCount, Is.EqualTo(5));
-            Assert.That(table.ActiveBuild.SpawnCountPerStep, Is.EqualTo(10));
+            Assert.That(table.ActiveBuild.SpawnCountPerStep, Is.EqualTo(3));
             Assert.That(table.ActiveBuild.SpawnCountStepSize, Is.EqualTo(1));
             Assert.That(table.ActiveBuild.SpawnCountStartWave, Is.EqualTo(1));
             Assert.That(table.ActiveBuild.MaxSpawnCount, Is.EqualTo(0));

--- a/Assets/_Project/_Tests/EditMode/Balance/WaveBalanceTableTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Balance/WaveBalanceTableTests.cs
@@ -138,11 +138,13 @@ namespace Castlebound.Tests.Balance
             Assert.IsTrue(table.DefaultWaitForClear);
             Assert.That(table.DefaultMaxAlive, Is.EqualTo(0));
             Assert.NotNull(table.ActiveBuild);
-            Assert.That(table.ActiveBuild.BaseSpawnCount, Is.EqualTo(5));
-            Assert.That(table.ActiveBuild.SpawnCountPerStep, Is.EqualTo(3));
-            Assert.That(table.ActiveBuild.SpawnCountStepSize, Is.EqualTo(1));
-            Assert.That(table.ActiveBuild.SpawnCountStartWave, Is.EqualTo(1));
-            Assert.That(table.ActiveBuild.MaxSpawnCount, Is.EqualTo(0));
+            Assert.IsTrue(table.ActiveBuild.Enabled);
+            Assert.That(table.ActiveBuild.BaseSpawnCount, Is.GreaterThan(0));
+            Assert.That(table.ActiveBuild.SpawnCountStepSize, Is.GreaterThanOrEqualTo(1));
+            Assert.That(table.ActiveBuild.SpawnCountStartWave, Is.GreaterThanOrEqualTo(1));
+            Assert.That(table.ActiveBuild.MaxSpawnCount, Is.GreaterThanOrEqualTo(0));
+            Assert.That(table.ActiveBuild.IntervalSeconds, Is.GreaterThan(0f));
+            Assert.That(table.ActiveBuild.GetSpawnCountForWave(2), Is.GreaterThanOrEqualTo(table.ActiveBuild.GetSpawnCountForWave(1)));
         }
     }
 }

--- a/Assets/_Project/_Tests/EditMode/Balance/WaveBalanceTableTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Balance/WaveBalanceTableTests.cs
@@ -1,0 +1,148 @@
+using Castlebound.Gameplay.Balance;
+using Castlebound.Gameplay.Spawning;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace Castlebound.Tests.Balance
+{
+    public class WaveBalanceTableTests
+    {
+        private const string BalanceStationPath = "Assets/_Project/Balance/GameBalanceStation.asset";
+        private const string WaveBalanceTablePath = "Assets/_Project/Balance/WaveBalanceTable.asset";
+
+        [Test]
+        public void Defaults_MirrorCurrentWaveRuntimeTuning()
+        {
+            var table = ScriptableObject.CreateInstance<WaveBalanceTable>();
+
+            try
+            {
+                Assert.That(table.DefaultStrategy, Is.EqualTo(SpawnMarkerStrategy.RoundRobin));
+                Assert.IsFalse(table.UseDefaultSeed);
+                Assert.That(table.DefaultSeed, Is.EqualTo(0));
+                Assert.That(table.ResolvedDefaultSeed, Is.EqualTo(0));
+                Assert.That(table.DefaultGapSeconds, Is.EqualTo(5f).Within(0.001f));
+                Assert.IsTrue(table.DefaultWaitForClear);
+                Assert.That(table.DefaultMaxAlive, Is.EqualTo(0));
+                Assert.That(table.ActiveBuildIndex, Is.EqualTo(0));
+                Assert.NotNull(table.ActiveBuild);
+                Assert.That(table.ActiveBuild.BuildId, Is.EqualTo("default"));
+                Assert.IsTrue(table.ActiveBuild.Enabled);
+                Assert.That(table.ActiveBuild.BaseSpawnCount, Is.EqualTo(5));
+                Assert.That(table.ActiveBuild.SpawnCountPerStep, Is.EqualTo(10));
+                Assert.That(table.ActiveBuild.SpawnCountStepSize, Is.EqualTo(1));
+                Assert.That(table.ActiveBuild.SpawnCountStartWave, Is.EqualTo(1));
+                Assert.That(table.ActiveBuild.MaxSpawnCount, Is.EqualTo(0));
+                Assert.That(table.ActiveBuild.IntervalSeconds, Is.EqualTo(1f).Within(0.001f));
+                Assert.That(table.ActiveBuild.InitialDelaySeconds, Is.EqualTo(0f).Within(0.001f));
+            }
+            finally
+            {
+                Object.DestroyImmediate(table);
+            }
+        }
+
+        [Test]
+        public void ScalarProperties_ClampToSafeValues()
+        {
+            var table = ScriptableObject.CreateInstance<WaveBalanceTable>();
+
+            try
+            {
+                table.DefaultGapSeconds = -1f;
+                table.DefaultMaxAlive = -1;
+                table.ActiveBuildIndex = -1;
+                var build = table.ActiveBuild;
+                build.BaseSpawnCount = -1;
+                build.SpawnCountPerStep = -1;
+                build.SpawnCountStepSize = 0;
+                build.SpawnCountStartWave = 0;
+                build.MaxSpawnCount = -1;
+                build.IntervalSeconds = -1f;
+                build.InitialDelaySeconds = -1f;
+
+                Assert.That(table.DefaultGapSeconds, Is.EqualTo(0f));
+                Assert.That(table.DefaultMaxAlive, Is.EqualTo(0));
+                Assert.That(table.ActiveBuildIndex, Is.EqualTo(0));
+                Assert.That(build.BaseSpawnCount, Is.EqualTo(0));
+                Assert.That(build.SpawnCountPerStep, Is.EqualTo(0));
+                Assert.That(build.SpawnCountStepSize, Is.EqualTo(1));
+                Assert.That(build.SpawnCountStartWave, Is.EqualTo(1));
+                Assert.That(build.MaxSpawnCount, Is.EqualTo(0));
+                Assert.That(build.IntervalSeconds, Is.EqualTo(0f));
+                Assert.That(build.InitialDelaySeconds, Is.EqualTo(0f));
+            }
+            finally
+            {
+                Object.DestroyImmediate(table);
+            }
+        }
+
+        [Test]
+        public void ActiveBuild_ResolvesSelectedEnabledBuild()
+        {
+            var table = ScriptableObject.CreateInstance<WaveBalanceTable>();
+            try
+            {
+                var slow = new WaveGenerationBuild { BuildId = "slow", BaseSpawnCount = 5 };
+                var fast = new WaveGenerationBuild { BuildId = "fast", BaseSpawnCount = 15 };
+                table.GeneratedBuilds = new[] { slow, fast };
+                table.ActiveBuildIndex = 1;
+
+                Assert.AreSame(fast, table.ActiveBuild);
+
+                fast.Enabled = false;
+
+                Assert.IsNull(table.ActiveBuild);
+            }
+            finally
+            {
+                Object.DestroyImmediate(table);
+            }
+        }
+
+        [Test]
+        public void ResolvedDefaultSeed_UsesSeedOnlyWhenEnabled()
+        {
+            var table = ScriptableObject.CreateInstance<WaveBalanceTable>();
+
+            try
+            {
+                table.DefaultSeed = 42;
+
+                Assert.That(table.ResolvedDefaultSeed, Is.EqualTo(0));
+
+                table.UseDefaultSeed = true;
+
+                Assert.That(table.ResolvedDefaultSeed, Is.EqualTo(42));
+            }
+            finally
+            {
+                Object.DestroyImmediate(table);
+            }
+        }
+
+        [Test]
+        public void ProjectAssets_WireWaveTableThroughCentralBalanceStation()
+        {
+            var station = AssetDatabase.LoadAssetAtPath<GameBalanceStation>(BalanceStationPath);
+            var table = AssetDatabase.LoadAssetAtPath<WaveBalanceTable>(WaveBalanceTablePath);
+
+            Assert.NotNull(station, "Central GameBalanceStation asset must exist.");
+            Assert.NotNull(table, "WaveBalanceTable asset must exist.");
+            Assert.AreSame(table, station.Wave, "Central station should reference the authored wave table.");
+            Assert.That(table.DefaultStrategy, Is.EqualTo(SpawnMarkerStrategy.RoundRobin));
+            Assert.That(table.DefaultGapSeconds, Is.EqualTo(5f).Within(0.001f));
+            Assert.IsTrue(table.DefaultWaitForClear);
+            Assert.That(table.DefaultMaxAlive, Is.EqualTo(0));
+            Assert.NotNull(table.ActiveBuild);
+            Assert.That(table.ActiveBuild.BaseSpawnCount, Is.EqualTo(5));
+            Assert.That(table.ActiveBuild.SpawnCountPerStep, Is.EqualTo(10));
+            Assert.That(table.ActiveBuild.SpawnCountStepSize, Is.EqualTo(1));
+            Assert.That(table.ActiveBuild.SpawnCountStartWave, Is.EqualTo(1));
+            Assert.That(table.ActiveBuild.MaxSpawnCount, Is.EqualTo(0));
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Balance/WaveBalanceTableTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Balance/WaveBalanceTableTests.cs
@@ -23,7 +23,7 @@ namespace Castlebound.Tests.Balance
                 Assert.IsFalse(table.UseDefaultSeed);
                 Assert.That(table.DefaultSeed, Is.EqualTo(0));
                 Assert.That(table.ResolvedDefaultSeed, Is.EqualTo(0));
-                Assert.That(table.DefaultGapSeconds, Is.EqualTo(5f).Within(0.001f));
+                Assert.That(table.DefaultGapSeconds, Is.EqualTo(8f).Within(0.001f));
                 Assert.IsTrue(table.DefaultWaitForClear);
                 Assert.That(table.DefaultMaxAlive, Is.EqualTo(0));
                 Assert.That(table.ActiveBuildIndex, Is.EqualTo(0));
@@ -134,7 +134,7 @@ namespace Castlebound.Tests.Balance
             Assert.NotNull(table, "WaveBalanceTable asset must exist.");
             Assert.AreSame(table, station.Wave, "Central station should reference the authored wave table.");
             Assert.That(table.DefaultStrategy, Is.EqualTo(SpawnMarkerStrategy.RoundRobin));
-            Assert.That(table.DefaultGapSeconds, Is.EqualTo(5f).Within(0.001f));
+            Assert.That(table.DefaultGapSeconds, Is.EqualTo(8f).Within(0.001f));
             Assert.IsTrue(table.DefaultWaitForClear);
             Assert.That(table.DefaultMaxAlive, Is.EqualTo(0));
             Assert.NotNull(table.ActiveBuild);

--- a/Assets/_Project/_Tests/EditMode/Balance/WaveBalanceTableTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Balance/WaveBalanceTableTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6c043d776e3441e1b3c13e19e6b96ef4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/EditMode/Spawning/EnemySpawnScheduleAssetBalanceTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Spawning/EnemySpawnScheduleAssetBalanceTests.cs
@@ -1,0 +1,169 @@
+using Castlebound.Gameplay.Balance;
+using Castlebound.Gameplay.Spawning;
+using NUnit.Framework;
+using UnityEngine;
+using Object = UnityEngine.Object;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Castlebound.Tests.Spawning
+{
+    public class EnemySpawnScheduleAssetBalanceTests
+    {
+        [Test]
+        public void ToRuntimeWaveSchedule_UsesWaveBalanceTableDefaultsWhenAssigned()
+        {
+            var station = ScriptableObject.CreateInstance<GameBalanceStation>();
+            var table = ScriptableObject.CreateInstance<WaveBalanceTable>();
+            var scheduleAsset = ScriptableObject.CreateInstance<EnemySpawnScheduleAsset>();
+
+            try
+            {
+                table.DefaultStrategy = SpawnMarkerStrategy.ShufflePrecompute;
+                table.UseDefaultSeed = true;
+                table.DefaultSeed = 99;
+                table.DefaultGapSeconds = 2f;
+                table.DefaultWaitForClear = false;
+                table.DefaultMaxAlive = 7;
+                station.Wave = table;
+                scheduleAsset.BalanceStation = station;
+
+                var wave = scheduleAsset.ToRuntimeWaveSchedule().GetWave(1);
+
+                Assert.That(wave.Strategy, Is.EqualTo(SpawnMarkerStrategy.ShufflePrecompute));
+                Assert.That(wave.Seed, Is.EqualTo(99));
+                Assert.That(wave.GapSeconds, Is.EqualTo(2f).Within(0.001f));
+                Assert.IsFalse(wave.WaitForClear);
+                Assert.That(wave.MaxAlive, Is.EqualTo(7));
+            }
+            finally
+            {
+                Object.DestroyImmediate(scheduleAsset);
+                Object.DestroyImmediate(table);
+                Object.DestroyImmediate(station);
+            }
+        }
+
+        [Test]
+        public void ToRuntimeWaveSchedule_UsesActiveWaveBuildForGeneratedCounts()
+        {
+            var station = ScriptableObject.CreateInstance<GameBalanceStation>();
+            var table = ScriptableObject.CreateInstance<WaveBalanceTable>();
+            var scheduleAsset = ScriptableObject.CreateInstance<EnemySpawnScheduleAsset>();
+
+            try
+            {
+                table.GeneratedBuilds = new[]
+                {
+                    new WaveGenerationBuild
+                    {
+                        BuildId = "default",
+                        BaseSpawnCount = 5,
+                        SpawnCountPerStep = 10,
+                        SpawnCountStepSize = 1,
+                        SpawnCountStartWave = 1
+                    }
+                };
+                station.Wave = table;
+                scheduleAsset.BalanceStation = station;
+                SetRamp(scheduleAsset);
+
+                var runtime = scheduleAsset.ToRuntimeWaveSchedule();
+
+                Assert.That(runtime.GetWave(1).Sequences[0].spawnCount, Is.EqualTo(5));
+                Assert.That(runtime.GetWave(2).Sequences[0].spawnCount, Is.EqualTo(15));
+            }
+            finally
+            {
+                Object.DestroyImmediate(scheduleAsset);
+                Object.DestroyImmediate(table);
+                Object.DestroyImmediate(station);
+            }
+        }
+
+        [Test]
+        public void ToRuntimeWaveSchedule_UsesOverrideStationBeforeScheduleStation()
+        {
+            var scheduleStation = ScriptableObject.CreateInstance<GameBalanceStation>();
+            var overrideStation = ScriptableObject.CreateInstance<GameBalanceStation>();
+            var scheduleTable = ScriptableObject.CreateInstance<WaveBalanceTable>();
+            var overrideTable = ScriptableObject.CreateInstance<WaveBalanceTable>();
+            var scheduleAsset = ScriptableObject.CreateInstance<EnemySpawnScheduleAsset>();
+
+            try
+            {
+                scheduleTable.DefaultMaxAlive = 3;
+                overrideTable.DefaultMaxAlive = 9;
+                scheduleStation.Wave = scheduleTable;
+                overrideStation.Wave = overrideTable;
+                scheduleAsset.BalanceStation = scheduleStation;
+
+                var wave = scheduleAsset.ToRuntimeWaveSchedule(overrideStation).GetWave(1);
+
+                Assert.That(wave.MaxAlive, Is.EqualTo(9));
+            }
+            finally
+            {
+                Object.DestroyImmediate(scheduleAsset);
+                Object.DestroyImmediate(overrideTable);
+                Object.DestroyImmediate(scheduleTable);
+                Object.DestroyImmediate(overrideStation);
+                Object.DestroyImmediate(scheduleStation);
+            }
+        }
+
+        [Test]
+        public void MainPrototypeSpawnerRunner_ReferencesCentralBalanceStation()
+        {
+            string sceneYaml = File.ReadAllText("Assets/_Project/Scenes/MainPrototype.unity");
+
+            StringAssert.Contains(
+                "balanceStation: {fileID: 11400000, guid: d70caaeb4e66400f8127d62f459cae21, type: 2}",
+                sceneYaml,
+                "MainPrototype EnemySpawnerRunner should pass the central station into wave generation.");
+        }
+
+        [Test]
+        public void ToRuntimeWaveSchedule_PreservesFallbackDefaultsWithoutBalanceTable()
+        {
+            var scheduleAsset = ScriptableObject.CreateInstance<EnemySpawnScheduleAsset>();
+
+            try
+            {
+                var wave = scheduleAsset.ToRuntimeWaveSchedule().GetWave(1);
+
+                Assert.That(wave.Strategy, Is.EqualTo(SpawnMarkerStrategy.RoundRobin));
+                Assert.That(wave.Seed, Is.EqualTo(0));
+                Assert.That(wave.GapSeconds, Is.EqualTo(5f).Within(0.001f));
+                Assert.IsTrue(wave.WaitForClear);
+                Assert.That(wave.MaxAlive, Is.EqualTo(0));
+            }
+            finally
+            {
+                Object.DestroyImmediate(scheduleAsset);
+            }
+        }
+
+        private static void SetRamp(EnemySpawnScheduleAsset scheduleAsset)
+        {
+            var rampField = typeof(EnemySpawnScheduleAsset).GetField(
+                "ramp",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            rampField.SetValue(scheduleAsset, new RampConfig
+            {
+                baseSpawnCount = 99,
+                countPerStep = 99,
+                stepSize = 1,
+                startWave = 1,
+                unlocks = new List<RampTierUnlock>
+                {
+                    new RampTierUnlock
+                    {
+                        waveIndex = 1,
+                        tiers = new List<RampTier> { new RampTier { enemyTypeId = "grunt", weight = 1f } }
+                    }
+                }
+            });
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Spawning/EnemySpawnScheduleAssetBalanceTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Spawning/EnemySpawnScheduleAssetBalanceTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7f085c71d5a24db193b3c24a49f14a45
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/EditMode/Spawning/WaveScheduleRuntimeTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Spawning/WaveScheduleRuntimeTests.cs
@@ -79,6 +79,41 @@ namespace Castlebound.Tests.Spawning
         }
 
         [Test]
+        public void CanProvideWaves_IsTrueForAuthoredOrGeneratedSchedules()
+        {
+            var authoredSchedule = new WaveScheduleRuntime(
+                defaultStrategy: SpawnMarkerStrategy.RoundRobin,
+                defaultSeed: 0,
+                waves: new[]
+                {
+                    new WaveConfig
+                    {
+                        sequences = new List<SpawnSequenceConfig>
+                        {
+                            new SpawnSequenceConfig { enemyTypeId = "grunt", spawnCount = 1 }
+                        }
+                    }
+                },
+                ramp: null);
+
+            var generatedSchedule = new WaveScheduleRuntime(
+                defaultStrategy: SpawnMarkerStrategy.RoundRobin,
+                defaultSeed: 0,
+                waves: null,
+                ramp: CreateSingleTierRamp(baseSpawnCount: 5, countPerStep: 1, stepSize: 1, startWave: 1));
+
+            var emptySchedule = new WaveScheduleRuntime(
+                defaultStrategy: SpawnMarkerStrategy.RoundRobin,
+                defaultSeed: 0,
+                waves: null,
+                ramp: null);
+
+            Assert.IsTrue(authoredSchedule.CanProvideWaves);
+            Assert.IsTrue(generatedSchedule.CanProvideWaves);
+            Assert.IsFalse(emptySchedule.CanProvideWaves);
+        }
+
+        [Test]
         public void GeneratedRampWave_UsesProvidedSharedPacingDefaults()
         {
             var ramp = new RampConfig

--- a/Assets/_Project/_Tests/EditMode/Spawning/WaveScheduleRuntimeTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Spawning/WaveScheduleRuntimeTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Castlebound.Gameplay.Balance;
 using Castlebound.Gameplay.Spawning;
 using NUnit.Framework;
 
@@ -54,6 +55,185 @@ namespace Castlebound.Tests.Spawning
             Assert.IsTrue(wave2.WaitForClear, "Wait-for-clear should default to true.");
             Assert.AreEqual(5f, wave2.GapSeconds, "Gap should default to 5 seconds.");
             Assert.AreEqual(0, wave2.MaxAlive, "MaxAlive should default to unset (0).");
+        }
+
+        [Test]
+        public void FallbackWave_UsesProvidedSharedDefaults()
+        {
+            var schedule = new WaveScheduleRuntime(
+                defaultStrategy: SpawnMarkerStrategy.ShufflePrecompute,
+                defaultSeed: 42,
+                waves: null,
+                ramp: null,
+                defaultGapSeconds: 2f,
+                defaultWaitForClear: false,
+                defaultMaxAlive: 6);
+
+            var wave = schedule.GetWave(1);
+
+            Assert.AreEqual(SpawnMarkerStrategy.ShufflePrecompute, wave.Strategy);
+            Assert.AreEqual(42, wave.Seed);
+            Assert.AreEqual(2f, wave.GapSeconds);
+            Assert.IsFalse(wave.WaitForClear);
+            Assert.AreEqual(6, wave.MaxAlive);
+        }
+
+        [Test]
+        public void GeneratedRampWave_UsesProvidedSharedPacingDefaults()
+        {
+            var ramp = new RampConfig
+            {
+                baseSpawnCount = 5,
+                countPerStep = 0,
+                stepSize = 1,
+                startWave = 1,
+                unlocks = new List<RampTierUnlock>
+                {
+                    new RampTierUnlock
+                    {
+                        waveIndex = 1,
+                        tiers = new List<RampTier> { new RampTier { enemyTypeId = "grunt", weight = 1f } }
+                    }
+                }
+            };
+
+            var schedule = new WaveScheduleRuntime(
+                defaultStrategy: SpawnMarkerStrategy.RoundRobin,
+                defaultSeed: 0,
+                waves: null,
+                ramp: ramp,
+                defaultGapSeconds: 3f,
+                defaultWaitForClear: false,
+                defaultMaxAlive: 4);
+
+            var wave = schedule.GetWave(1);
+
+            Assert.AreEqual(3f, wave.GapSeconds);
+            Assert.IsFalse(wave.WaitForClear);
+            Assert.AreEqual(4, wave.MaxAlive);
+        }
+
+        [Test]
+        public void GeneratedRampWave_UsesActiveBuildSpawnCountScaling()
+        {
+            var ramp = CreateSingleTierRamp(baseSpawnCount: 99, countPerStep: 99, stepSize: 1, startWave: 1);
+            var build = new WaveGenerationBuild
+            {
+                BaseSpawnCount = 4,
+                SpawnCountPerStep = 3,
+                SpawnCountStepSize = 2,
+                SpawnCountStartWave = 2
+            };
+
+            var schedule = new WaveScheduleRuntime(
+                defaultStrategy: SpawnMarkerStrategy.RoundRobin,
+                defaultSeed: 0,
+                waves: null,
+                ramp: ramp,
+                defaultGapSeconds: 5f,
+                defaultWaitForClear: true,
+                defaultMaxAlive: 0,
+                generationBuild: build);
+
+            var wave1 = schedule.GetWave(1);
+            var wave2 = schedule.GetWave(2);
+            var wave4 = schedule.GetWave(4);
+
+            Assert.AreEqual(4, wave1.Sequences[0].spawnCount);
+            Assert.AreEqual(4, wave2.Sequences[0].spawnCount);
+            Assert.AreEqual(7, wave4.Sequences[0].spawnCount);
+        }
+
+        [Test]
+        public void GeneratedRampWave_ActiveBuildHonorsMaxCap()
+        {
+            var ramp = CreateSingleTierRamp(baseSpawnCount: 5, countPerStep: 1, stepSize: 1, startWave: 1);
+            var build = new WaveGenerationBuild
+            {
+                BaseSpawnCount = 4,
+                SpawnCountPerStep = 10,
+                SpawnCountStepSize = 1,
+                SpawnCountStartWave = 1,
+                MaxSpawnCount = 12
+            };
+
+            var schedule = new WaveScheduleRuntime(
+                defaultStrategy: SpawnMarkerStrategy.RoundRobin,
+                defaultSeed: 0,
+                waves: null,
+                ramp: ramp,
+                defaultGapSeconds: 5f,
+                defaultWaitForClear: true,
+                defaultMaxAlive: 0,
+                generationBuild: build);
+
+            var wave3 = schedule.GetWave(3);
+
+            Assert.AreEqual(12, wave3.Sequences[0].spawnCount);
+        }
+
+        [Test]
+        public void GeneratedRampWave_PreservesRampSpawnCountsWithoutActiveBuild()
+        {
+            var ramp = CreateSingleTierRamp(baseSpawnCount: 5, countPerStep: 2, stepSize: 2, startWave: 1);
+            var schedule = new WaveScheduleRuntime(
+                defaultStrategy: SpawnMarkerStrategy.RoundRobin,
+                defaultSeed: 0,
+                waves: null,
+                ramp: ramp,
+                defaultGapSeconds: 5f,
+                defaultWaitForClear: true,
+                defaultMaxAlive: 0,
+                generationBuild: null);
+
+            var wave3 = schedule.GetWave(3);
+
+            Assert.AreEqual(7, wave3.Sequences[0].spawnCount);
+        }
+
+        [Test]
+        public void GeneratedRampWave_ActiveBuildCanJumpFromFiveToFifteenOnWaveTwo()
+        {
+            var ramp = CreateSingleTierRamp(baseSpawnCount: 99, countPerStep: 99, stepSize: 1, startWave: 1);
+            var build = new WaveGenerationBuild
+            {
+                BaseSpawnCount = 5,
+                SpawnCountPerStep = 10,
+                SpawnCountStepSize = 1,
+                SpawnCountStartWave = 1
+            };
+
+            var schedule = new WaveScheduleRuntime(
+                defaultStrategy: SpawnMarkerStrategy.RoundRobin,
+                defaultSeed: 0,
+                waves: null,
+                ramp: ramp,
+                defaultGapSeconds: 5f,
+                defaultWaitForClear: true,
+                defaultMaxAlive: 0,
+                generationBuild: build);
+
+            Assert.AreEqual(5, schedule.GetWave(1).Sequences[0].spawnCount);
+            Assert.AreEqual(15, schedule.GetWave(2).Sequences[0].spawnCount);
+        }
+
+        private static RampConfig CreateSingleTierRamp(int baseSpawnCount, int countPerStep, int stepSize, int startWave)
+        {
+            return new RampConfig
+            {
+                baseSpawnCount = baseSpawnCount,
+                countPerStep = countPerStep,
+                stepSize = stepSize,
+                startWave = startWave,
+                unlocks = new List<RampTierUnlock>
+                {
+                    new RampTierUnlock
+                    {
+                        waveIndex = 1,
+                        tiers = new List<RampTier> { new RampTier { enemyTypeId = "grunt", weight = 1f } }
+                    }
+                }
+            };
         }
     }
 }

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -12,11 +12,12 @@
 - Routed EnemySpawnScheduleAsset wave defaults through the balance table when assigned while preserving fallback behavior.
 - Added active generated wave builds so the wave table can define count scaling presets like 5 enemies on wave 1 and 15 on wave 2.
 - Wired MainPrototype's EnemySpawnerRunner to the central balance station so active wave builds reach runtime.
+- Updated the spawner runner gate so generated wave schedules use the wave runtime even when no authored waves exist.
 
 ### New or Updated Tests
 **EditMode**
 - `WaveBalanceTableTests` - verifies defaults, clamping, seed resolution, and project asset wiring.
-- `WaveScheduleRuntimeTests` - verifies fallback and generated ramp waves use provided shared defaults, active build enemy count scaling, max count capping, and no-build fallback behavior.
+- `WaveScheduleRuntimeTests` - verifies fallback and generated ramp waves use provided shared defaults, active build enemy count scaling, max count capping, generated-schedule availability, and no-build fallback behavior.
 - `EnemySpawnScheduleAssetBalanceTests` - verifies balance-table routing, runner station override behavior, active build count generation, MainPrototype station wiring, and no-table fallback defaults.
 
 **PlayMode**

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,27 @@
 
 ---
 
+## 2026-05-26 - refactor(waves): add wave pacing and difficulty tuning table
+
+### Summary
+- Added authored shared wave default fields to WaveBalanceTable.
+- Added the WaveBalanceTable project asset and wired it through GameBalanceStation.
+- Routed EnemySpawnScheduleAsset wave defaults through the balance table when assigned while preserving fallback behavior.
+- Added active generated wave builds so the wave table can define count scaling presets like 5 enemies on wave 1 and 15 on wave 2.
+- Wired MainPrototype's EnemySpawnerRunner to the central balance station so active wave builds reach runtime.
+
+### New or Updated Tests
+**EditMode**
+- `WaveBalanceTableTests` - verifies defaults, clamping, seed resolution, and project asset wiring.
+- `WaveScheduleRuntimeTests` - verifies fallback and generated ramp waves use provided shared defaults, active build enemy count scaling, max count capping, and no-build fallback behavior.
+- `EnemySpawnScheduleAssetBalanceTests` - verifies balance-table routing, runner station override behavior, active build count generation, MainPrototype station wiring, and no-table fallback defaults.
+
+**PlayMode**
+- N/A - N/A
+
+### Notes
+- EditMode and PlayMode tests passed per user on 2026-05-30.
+
 ## 2026-05-26 - refactor(economy): add reward and cost tuning table
 
 ### Summary

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -13,6 +13,7 @@
 - Added active generated wave builds so the wave table can define count scaling presets like 5 enemies on wave 1 and 15 on wave 2.
 - Wired MainPrototype's EnemySpawnerRunner to the central balance station so active wave builds reach runtime.
 - Updated the spawner runner gate so generated wave schedules use the wave runtime even when no authored waves exist.
+- Tuned the default generated wave gap to 8 seconds to leave time for post-wave loot collection.
 
 ### New or Updated Tests
 **EditMode**


### PR DESCRIPTION
## Why
Centralize wave pacing and generated enemy-count tuning so pressure curves can be adjusted from the balance station without editing schedule ramp internals.

## What changed
- Added WaveBalanceTable as an authored balance asset wired through GameBalanceStation.
- Added active generated wave builds for count scaling presets.
- Routed EnemySpawnerRunner through the central balance station.
- Updated the spawner runner gate so generated wave schedules use the wave runtime even without authored waves.
- Updated MainPrototype and BasicSpawnSchedule so wave 1 starts at 5 enemies and generated waves increase by 3.
- Tuned the default generated wave gap to 8 seconds for post-wave loot collection.
- Preserved authored wave overrides and old ramp behavior as fallback paths.
- Added EditMode coverage for wave table defaults, active build selection, runtime generation, scene wiring, fallback behavior, and asset health checks without pinning authored balance values.

## How to test
1. Open MainPrototype
2. Press Play → verify wave counts:
   - Wave 1: 5 enemies
   - Wave 2: 8 enemies
   - Wave 3: 11 enemies
3. Verify there is about an 8-second gap after wave clear for post-wave loot collection
4. Run tests:
   - EditMode
   - PlayMode

## Checklist

- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated
- [x] Prefab links, tags, and layers validated (N/A - no prefab, tag, or layer changes)
- [x] README / Docs touched (TEST_LOG.md updated)

## Related
- Closes #179