### PR TITLE
refactor(enemy): add balance and loot profile tuning

### DIFF
--- a/Assets/_Project/Balance/EnemyBalanceTable.asset
+++ b/Assets/_Project/Balance/EnemyBalanceTable.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 10018b6c8221409fbf9d366afc32f253, type: 3}
+  m_Name: EnemyBalanceTable
+  m_EditorClassIdentifier: ""
+  enemies:
+  - enemyTypeId: grunt
+    maxHealth: 10
+    moveSpeed: 8
+    attackDamage: 1
+    attackCooldownSeconds: 0.8
+    xpReward: 5
+    lootProfile: {fileID: 11400000, guid: f6af5ba4e3e841eab07d6af86f261ca0, type: 2}

--- a/Assets/_Project/Balance/EnemyBalanceTable.asset.meta
+++ b/Assets/_Project/Balance/EnemyBalanceTable.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b6817306e9a44d3ebfb45d61750b8f7a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Balance/GameBalanceStation.asset
+++ b/Assets/_Project/Balance/GameBalanceStation.asset
@@ -15,6 +15,6 @@ MonoBehaviour:
   tower: {fileID: 11400000, guid: 1d03794e8d2c4c53a6de599e33d4f8fe, type: 2}
   barrier: {fileID: 11400000, guid: 64e791ca8c294529bc6393d439d743c9, type: 2}
   wave: {fileID: 11400000, guid: 744802b4eadd4e4eae9b8cc043d6c82e, type: 2}
-  enemy: {fileID: 0}
+  enemy: {fileID: 11400000, guid: b6817306e9a44d3ebfb45d61750b8f7a, type: 2}
   player: {fileID: 0}
   economy: {fileID: 11400000, guid: 33e3c7ab33304f10aaff7086767de14c, type: 2}

--- a/Assets/_Project/Items/LootTables/EnemyLootProfile_Grunt.asset
+++ b/Assets/_Project/Items/LootTables/EnemyLootProfile_Grunt.asset
@@ -1,0 +1,28 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e827b1960af4d178e39f703b9c17519, type: 3}
+  m_Name: EnemyLootProfile_Grunt
+  m_EditorClassIdentifier: ""
+  lootTables:
+  - table: {fileID: 11400000, guid: ae5e77863cbe4e8098be50ce36d5847c, type: 2}
+    prefab: {fileID: 1000000005, guid: b2c3d4e5f60718293a4b5c6d7e8f90a1, type: 3}
+    maxRolls: 1
+    maxSpawns: 1
+  - table: {fileID: 11400000, guid: a791a203560d49138ee7f0d0cd5566ba, type: 2}
+    prefab: {fileID: 1000000005, guid: e5cbfd3fa273450aab6ccde3681c5ee8, type: 3}
+    maxRolls: 1
+    maxSpawns: 1
+  - table: {fileID: 11400000, guid: 2592505e3d1e48ddba18747405b6d56a, type: 2}
+    prefab: {fileID: 1000000005, guid: a1b2c3d4e5f60718293a4b5c6d7e8f90, type: 3}
+    maxRolls: 1
+    maxSpawns: 10
+  globalMaxTables: 6

--- a/Assets/_Project/Items/LootTables/EnemyLootProfile_Grunt.asset.meta
+++ b/Assets/_Project/Items/LootTables/EnemyLootProfile_Grunt.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f6af5ba4e3e841eab07d6af86f261ca0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Items/LootTables/LootTable_PotionBasic.asset
+++ b/Assets/_Project/Items/LootTables/LootTable_PotionBasic.asset
@@ -17,4 +17,8 @@ MonoBehaviour:
   - item: {fileID: 11400000, guid: cd2861bff7fa4d4f99ca4fe0c314a971, type: 2}
     minAmount: 1
     maxAmount: 1
-    weight: 1
+    weight: 8
+  - item: {fileID: 11400000, guid: cd2861bff7fa4d4f99ca4fe0c314a971, type: 2}
+    minAmount: 2
+    maxAmount: 2
+    weight: 2

--- a/Assets/_Project/Prefabs/Enemy.prefab
+++ b/Assets/_Project/Prefabs/Enemy.prefab
@@ -102,6 +102,7 @@ GameObject:
   - component: {fileID: 4031526577869015660}
   - component: {fileID: 4347245256977356794}
   - component: {fileID: 2387932495633829988}
+  - component: {fileID: 6382125908214597412}
   m_Layer: 7
   m_Name: Enemy
   m_TagString: Enemy
@@ -197,8 +198,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9b42b7e1aae77f64e8810845a4e4cbbc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   target: {fileID: 0}
   player: {fileID: 0}
   barrier: {fileID: 0}
@@ -226,8 +227,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 2c97023e7c008dd4ea8eeca0bd2f0d2d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
 --- !u!114 &1937058686654329911
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -238,8 +239,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 12b16749d0c1c00419a79f1ded1fdd58, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name: ""
+  m_EditorClassIdentifier: ""
   regionOverride: {fileID: 0}
 --- !u!114 &3821050183671550168
 MonoBehaviour:
@@ -327,3 +328,17 @@ MonoBehaviour:
   spillConeWidth: 1
   spillDistanceMin: 0.4
   spillDistanceMax: 3.2
+--- !u!114 &6382125908214597412
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6394411849047796180}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d2f0a13b9b534d04a2de7227e5839871, type: 3}
+  m_Name: ""
+  m_EditorClassIdentifier: ""
+  enemyTypeId: grunt
+  balanceStation: {fileID: 11400000, guid: d70caaeb4e66400f8127d62f459cae21, type: 2}

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyController2D.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyController2D.cs
@@ -50,6 +50,12 @@ public class EnemyController2D : MonoBehaviour
     [SerializeField] private EnemyKnockbackReceiver knockbackReceiver;
 
     public Transform Target => target;
+    public float Speed
+    {
+        get => speed;
+        set => speed = Mathf.Max(0f, value);
+    }
+
     private EnemyTargetType _currentTargetType = EnemyTargetType.None;
     public EnemyTargetType CurrentTargetType => _currentTargetType;
 

--- a/Assets/_Project/Scripts/_Project.Gameplay/Balance/EnemyBalanceApplier.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Balance/EnemyBalanceApplier.cs
@@ -1,0 +1,115 @@
+using Castlebound.Gameplay.Loot;
+using Castlebound.Gameplay.Spawning;
+using UnityEngine;
+
+namespace Castlebound.Gameplay.Balance
+{
+    public class EnemyBalanceApplier : MonoBehaviour
+    {
+        [SerializeField] private string enemyTypeId = "grunt";
+        [SerializeField] private GameBalanceStation balanceStation;
+        private bool hasApplied;
+
+        public string EnemyTypeId
+        {
+            get => enemyTypeId;
+            set => enemyTypeId = value;
+        }
+
+        public GameBalanceStation BalanceStation
+        {
+            get => balanceStation;
+            set => balanceStation = value;
+        }
+
+        public bool Apply(int waveIndex)
+        {
+            var table = balanceStation != null ? balanceStation.Enemy : null;
+            var entry = table != null ? table.Find(enemyTypeId) : null;
+            if (entry == null)
+            {
+                return false;
+            }
+
+            ApplyStats(entry);
+            ApplyRewards(entry, Mathf.Max(1, waveIndex));
+            hasApplied = true;
+            return true;
+        }
+
+        public void Initialize(GameBalanceStation station, string typeId, int waveIndex)
+        {
+            balanceStation = station;
+            if (!string.IsNullOrWhiteSpace(typeId))
+            {
+                enemyTypeId = typeId;
+            }
+
+            Apply(waveIndex);
+        }
+
+        private void Start()
+        {
+            if (hasApplied)
+            {
+                return;
+            }
+
+            Apply(ResolveWaveIndex());
+        }
+
+        private void ApplyStats(EnemyBalanceEntry entry)
+        {
+            var health = GetComponent<Health>();
+            if (health != null)
+            {
+                health.ConfigureMaxHealth(entry.MaxHealth, true);
+            }
+
+            var controller = GetComponent<EnemyController2D>();
+            if (controller != null)
+            {
+                controller.Speed = entry.MoveSpeed;
+            }
+
+            var attack = GetComponent<EnemyAttack>();
+            if (attack != null)
+            {
+                attack.Damage = entry.AttackDamage;
+                attack.CooldownSeconds = entry.AttackCooldownSeconds;
+            }
+        }
+
+        private void ApplyRewards(EnemyBalanceEntry entry, int waveIndex)
+        {
+            var dropper = GetComponent<LootDropper>();
+            if (dropper == null)
+            {
+                return;
+            }
+
+            dropper.SetXpAmount(entry.XpReward);
+            if (entry.LootProfile != null)
+            {
+                dropper.ConfigureLootTables(entry.LootProfile.LootTables, entry.LootProfile.GlobalMaxTables);
+            }
+
+            if (GameManager.I != null)
+            {
+                dropper.PreRoll(GameManager.I.LootRng, waveIndex);
+            }
+        }
+
+        private int ResolveWaveIndex()
+        {
+            var provider = GetComponent<IWaveIndexProvider>();
+            if (provider != null)
+            {
+                return provider.CurrentWaveIndex;
+            }
+
+            var parentProvider = GetComponentInParent<IWaveIndexProvider>();
+            return parentProvider != null ? parentProvider.CurrentWaveIndex : 1;
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Balance/EnemyBalanceApplier.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Balance/EnemyBalanceApplier.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d2f0a13b9b534d04a2de7227e5839871
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/_Project.Gameplay/Balance/EnemyBalanceEntry.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Balance/EnemyBalanceEntry.cs
@@ -1,0 +1,68 @@
+using Castlebound.Gameplay.Loot;
+using UnityEngine;
+
+namespace Castlebound.Gameplay.Balance
+{
+    [System.Serializable]
+    public class EnemyBalanceEntry
+    {
+        [SerializeField] private string enemyTypeId = "grunt";
+        [SerializeField] private int maxHealth = 10;
+        [SerializeField] private float moveSpeed = 8f;
+        [SerializeField] private int attackDamage = 1;
+        [SerializeField] private float attackCooldownSeconds = 0.8f;
+        [SerializeField] private int xpReward = 5;
+        [SerializeField] private EnemyLootProfile lootProfile;
+
+        public string EnemyTypeId
+        {
+            get => enemyTypeId;
+            set => enemyTypeId = value;
+        }
+
+        public int MaxHealth
+        {
+            get => maxHealth;
+            set => maxHealth = Mathf.Max(0, value);
+        }
+
+        public float MoveSpeed
+        {
+            get => moveSpeed;
+            set => moveSpeed = Mathf.Max(0f, value);
+        }
+
+        public int AttackDamage
+        {
+            get => attackDamage;
+            set => attackDamage = Mathf.Max(0, value);
+        }
+
+        public float AttackCooldownSeconds
+        {
+            get => attackCooldownSeconds;
+            set => attackCooldownSeconds = Mathf.Max(0f, value);
+        }
+
+        public int XpReward
+        {
+            get => xpReward;
+            set => xpReward = Mathf.Max(0, value);
+        }
+
+        public EnemyLootProfile LootProfile
+        {
+            get => lootProfile;
+            set => lootProfile = value;
+        }
+
+        public void Normalize()
+        {
+            MaxHealth = maxHealth;
+            MoveSpeed = moveSpeed;
+            AttackDamage = attackDamage;
+            AttackCooldownSeconds = attackCooldownSeconds;
+            XpReward = xpReward;
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Balance/EnemyBalanceEntry.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Balance/EnemyBalanceEntry.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 03b53e556bb54f619366ed1cd65a4a11
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/_Project.Gameplay/Balance/EnemyBalanceTable.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Balance/EnemyBalanceTable.cs
@@ -5,5 +5,47 @@ namespace Castlebound.Gameplay.Balance
     [CreateAssetMenu(menuName = "Castlebound/Balance/Enemy Balance Table")]
     public class EnemyBalanceTable : ScriptableObject
     {
+        [SerializeField] private EnemyBalanceEntry[] enemies =
+        {
+            new EnemyBalanceEntry()
+        };
+
+        public EnemyBalanceEntry[] Enemies
+        {
+            get => enemies;
+            set => enemies = value;
+        }
+
+        public EnemyBalanceEntry Find(string enemyTypeId)
+        {
+            if (string.IsNullOrWhiteSpace(enemyTypeId) || enemies == null)
+            {
+                return null;
+            }
+
+            for (int i = 0; i < enemies.Length; i++)
+            {
+                var entry = enemies[i];
+                if (entry != null && entry.EnemyTypeId == enemyTypeId)
+                {
+                    return entry;
+                }
+            }
+
+            return null;
+        }
+
+        private void OnValidate()
+        {
+            if (enemies == null)
+            {
+                return;
+            }
+
+            for (int i = 0; i < enemies.Length; i++)
+            {
+                enemies[i]?.Normalize();
+            }
+        }
     }
 }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/EnemyAttack.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/EnemyAttack.cs
@@ -15,6 +15,12 @@ public class EnemyAttack : MonoBehaviour
     [SerializeField] float attackRange = 1.2f;     // should be >= stopDistance
     [SerializeField] float windupSeconds = 0.15f;  // time before damage applies
     [SerializeField] float cooldownSeconds = 0.8f; // time between attacks
+    public float CooldownSeconds
+    {
+        get => cooldownSeconds;
+        set => cooldownSeconds = Mathf.Max(0f, value);
+    }
+
     [SerializeField] LayerMask targetMask;         // set to Player layer in Inspector
     [SerializeField] Animator animator;            // optional, can be null
     [SerializeField] FeedbackEventChannel enemyHitBarrierFeedbackChannel;

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/Health.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/Health.cs
@@ -14,6 +14,13 @@ public class Health : MonoBehaviour, IDamageable, IHealable
     public event Action<int, int> OnHealthChanged; // (current, max)
     public event Action OnDied;
 
+    public void ConfigureMaxHealth(int value, bool refill)
+    {
+        maxHealth = Mathf.Max(0, value);
+        current = refill ? maxHealth : Mathf.Clamp(current, 0, maxHealth);
+        OnHealthChanged?.Invoke(current, maxHealth);
+    }
+
     void Awake()
     {
         current = maxHealth;

--- a/Assets/_Project/Scripts/_Project.Gameplay/Loot/EnemyLootProfile.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Loot/EnemyLootProfile.cs
@@ -1,0 +1,28 @@
+using UnityEngine;
+
+namespace Castlebound.Gameplay.Loot
+{
+    [CreateAssetMenu(menuName = "Castlebound/Loot/Enemy Loot Profile")]
+    public class EnemyLootProfile : ScriptableObject
+    {
+        [SerializeField] private LootDropper.LootTableMapping[] lootTables;
+        [SerializeField] private int globalMaxTables = 10;
+
+        public LootDropper.LootTableMapping[] LootTables
+        {
+            get => lootTables;
+            set => lootTables = value;
+        }
+
+        public int GlobalMaxTables
+        {
+            get => globalMaxTables;
+            set => globalMaxTables = Mathf.Max(0, value);
+        }
+
+        private void OnValidate()
+        {
+            GlobalMaxTables = globalMaxTables;
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Loot/EnemyLootProfile.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Loot/EnemyLootProfile.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4e827b1960af4d178e39f703b9c17519
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/_Project.Gameplay/Loot/LootDropper.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Loot/LootDropper.cs
@@ -45,6 +45,7 @@ namespace Castlebound.Gameplay.Loot
 
         private LootRollResult[] cachedResults = Array.Empty<LootRollResult>();
         private Health health;
+        private bool hasPreRolled;
 
         public void SetLootTable(LootTable table)
         {
@@ -64,7 +65,15 @@ namespace Castlebound.Gameplay.Loot
 
         public void SetXpAmount(int amount)
         {
-            xpAmount = amount;
+            xpAmount = Mathf.Max(0, amount);
+        }
+
+        public void ConfigureLootTables(LootTableMapping[] mappings, int maxTables)
+        {
+            lootTables = mappings;
+            globalMaxTables = Mathf.Max(0, maxTables);
+            cachedResults = Array.Empty<LootRollResult>();
+            hasPreRolled = false;
         }
 
         private void Awake()
@@ -95,7 +104,7 @@ namespace Castlebound.Gameplay.Loot
 
         private void Start()
         {
-            if (lootTables == null || lootTables.Length == 0 || GameManager.I == null)
+            if (hasPreRolled || lootTables == null || lootTables.Length == 0 || GameManager.I == null)
             {
                 return;
             }
@@ -108,6 +117,7 @@ namespace Castlebound.Gameplay.Loot
             if (lootTables == null || lootTables.Length == 0 || rng == null)
             {
                 cachedResults = Array.Empty<LootRollResult>();
+                hasPreRolled = true;
                 return;
             }
 
@@ -138,6 +148,7 @@ namespace Castlebound.Gameplay.Loot
             if (combined.Count == 0)
             {
                 cachedResults = Array.Empty<LootRollResult>();
+                hasPreRolled = true;
                 return;
             }
 
@@ -158,10 +169,12 @@ namespace Castlebound.Gameplay.Loot
                 }
 
                 cachedResults = trimmed;
+                hasPreRolled = true;
                 return;
             }
 
             cachedResults = combined.ToArray();
+            hasPreRolled = true;
         }
 
         private void HandleDied()

--- a/Assets/_Project/Scripts/_Project.Gameplay/Spawning/EnemySpawnerRunner.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Spawning/EnemySpawnerRunner.cs
@@ -167,6 +167,13 @@ namespace Castlebound.Gameplay.Spawning
                 var instance = Instantiate(prefab, request.Position, Quaternion.identity);
                 _aliveCount++;
 
+                var balanceApplier = instance.GetComponent<EnemyBalanceApplier>();
+                if (balanceApplier != null)
+                {
+                    int waveIndex = waveIndexProvider != null ? waveIndexProvider.CurrentWaveIndex : 1;
+                    balanceApplier.Initialize(balanceStation, request.EnemyTypeId, waveIndex);
+                }
+
                 var lifetime = instance.GetComponent<SpawnedEntityLifetime>();
                 if (lifetime == null)
                 {

--- a/Assets/_Project/_Tests/EditMode/Balance/EnemyBalanceApplierTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Balance/EnemyBalanceApplierTests.cs
@@ -1,0 +1,119 @@
+using System.Reflection;
+using Castlebound.Gameplay.Balance;
+using Castlebound.Gameplay.Loot;
+using Castlebound.Gameplay.Inventory;
+using NUnit.Framework;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace Castlebound.Tests.Balance
+{
+    public class EnemyBalanceApplierTests
+    {
+        [Test]
+        public void Apply_ConfiguresEnemyStatsAndLootFromBalanceEntry()
+        {
+            var station = ScriptableObject.CreateInstance<GameBalanceStation>();
+            var table = ScriptableObject.CreateInstance<EnemyBalanceTable>();
+            var lootProfile = ScriptableObject.CreateInstance<EnemyLootProfile>();
+            var lootTable = ScriptableObject.CreateInstance<LootTable>();
+            var pickupPrefab = new GameObject("PickupPrefab").AddComponent<ItemPickupComponent>();
+            var enemy = new GameObject("Enemy");
+
+            try
+            {
+                var controller = enemy.AddComponent<EnemyController2D>();
+                var attack = enemy.AddComponent<EnemyAttack>();
+                var health = enemy.AddComponent<Health>();
+                var dropper = enemy.AddComponent<LootDropper>();
+                var applier = enemy.AddComponent<EnemyBalanceApplier>();
+
+                var mapping = new LootDropper.LootTableMapping(lootTable, pickupPrefab, 2, 3);
+                lootProfile.LootTables = new[] { mapping };
+                lootProfile.GlobalMaxTables = 4;
+
+                table.Enemies = new[]
+                {
+                    new EnemyBalanceEntry
+                    {
+                        EnemyTypeId = "grunt",
+                        MaxHealth = 23,
+                        MoveSpeed = 6.5f,
+                        AttackDamage = 4,
+                        AttackCooldownSeconds = 1.25f,
+                        XpReward = 9,
+                        LootProfile = lootProfile
+                    }
+                };
+                station.Enemy = table;
+                applier.BalanceStation = station;
+                applier.EnemyTypeId = "grunt";
+
+                Assert.IsTrue(applier.Apply(3));
+
+                Assert.That(health.Max, Is.EqualTo(23));
+                Assert.That(health.Current, Is.EqualTo(23));
+                Assert.That(controller.Speed, Is.EqualTo(6.5f).Within(0.001f));
+                Assert.That(attack.Damage, Is.EqualTo(4));
+                Assert.That(attack.CooldownSeconds, Is.EqualTo(1.25f).Within(0.001f));
+                Assert.That(GetPrivate<int>(dropper, "xpAmount"), Is.EqualTo(9));
+                Assert.That(GetPrivate<int>(dropper, "globalMaxTables"), Is.EqualTo(4));
+                Assert.AreSame(lootTable, GetPrivate<LootDropper.LootTableMapping[]>(dropper, "lootTables")[0].Table);
+            }
+            finally
+            {
+                Object.DestroyImmediate(enemy);
+                Object.DestroyImmediate(pickupPrefab.gameObject);
+                Object.DestroyImmediate(lootTable);
+                Object.DestroyImmediate(lootProfile);
+                Object.DestroyImmediate(table);
+                Object.DestroyImmediate(station);
+            }
+        }
+
+        [Test]
+        public void Apply_WhenEnemyTypeMissing_LeavesPrefabAuthoredValues()
+        {
+            var station = ScriptableObject.CreateInstance<GameBalanceStation>();
+            var table = ScriptableObject.CreateInstance<EnemyBalanceTable>();
+            var enemy = new GameObject("Enemy");
+
+            try
+            {
+                var controller = enemy.AddComponent<EnemyController2D>();
+                var attack = enemy.AddComponent<EnemyAttack>();
+                var health = enemy.AddComponent<Health>();
+                var applier = enemy.AddComponent<EnemyBalanceApplier>();
+
+                health.ConfigureMaxHealth(10, true);
+                controller.Speed = 8f;
+                attack.Damage = 1;
+                attack.CooldownSeconds = 0.8f;
+                table.Enemies = new[] { new EnemyBalanceEntry { EnemyTypeId = "grunt", MaxHealth = 99 } };
+                station.Enemy = table;
+                applier.BalanceStation = station;
+                applier.EnemyTypeId = "missing";
+
+                Assert.IsFalse(applier.Apply(1));
+
+                Assert.That(health.Max, Is.EqualTo(10));
+                Assert.That(controller.Speed, Is.EqualTo(8f).Within(0.001f));
+                Assert.That(attack.Damage, Is.EqualTo(1));
+                Assert.That(attack.CooldownSeconds, Is.EqualTo(0.8f).Within(0.001f));
+            }
+            finally
+            {
+                Object.DestroyImmediate(enemy);
+                Object.DestroyImmediate(table);
+                Object.DestroyImmediate(station);
+            }
+        }
+
+        private static T GetPrivate<T>(object target, string fieldName)
+        {
+            var field = target.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(field, $"Expected private field '{fieldName}' to exist.");
+            return (T)field.GetValue(target);
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Balance/EnemyBalanceApplierTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Balance/EnemyBalanceApplierTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8bd7e7c7e738cfe4894918582e781d37
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/_Tests/EditMode/Balance/EnemyBalanceTableTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Balance/EnemyBalanceTableTests.cs
@@ -1,0 +1,95 @@
+using Castlebound.Gameplay.Balance;
+using Castlebound.Gameplay.Loot;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace Castlebound.Tests.Balance
+{
+    public class EnemyBalanceTableTests
+    {
+        private const string BalanceStationPath = "Assets/_Project/Balance/GameBalanceStation.asset";
+        private const string EnemyBalanceTablePath = "Assets/_Project/Balance/EnemyBalanceTable.asset";
+        private const string GruntLootProfilePath = "Assets/_Project/Items/LootTables/EnemyLootProfile_Grunt.asset";
+
+        [Test]
+        public void Defaults_MirrorCurrentGruntRuntimeTuning()
+        {
+            var table = ScriptableObject.CreateInstance<EnemyBalanceTable>();
+
+            try
+            {
+                var grunt = table.Find("grunt");
+
+                Assert.NotNull(grunt);
+                Assert.That(grunt.MaxHealth, Is.EqualTo(10));
+                Assert.That(grunt.MoveSpeed, Is.EqualTo(8f).Within(0.001f));
+                Assert.That(grunt.AttackDamage, Is.EqualTo(1));
+                Assert.That(grunt.AttackCooldownSeconds, Is.EqualTo(0.8f).Within(0.001f));
+                Assert.That(grunt.XpReward, Is.EqualTo(5));
+            }
+            finally
+            {
+                Object.DestroyImmediate(table);
+            }
+        }
+
+        [Test]
+        public void EntryProperties_ClampToSafeValues()
+        {
+            var entry = new EnemyBalanceEntry();
+
+            entry.MaxHealth = -1;
+            entry.MoveSpeed = -1f;
+            entry.AttackDamage = -1;
+            entry.AttackCooldownSeconds = -1f;
+            entry.XpReward = -1;
+
+            Assert.That(entry.MaxHealth, Is.EqualTo(0));
+            Assert.That(entry.MoveSpeed, Is.EqualTo(0f));
+            Assert.That(entry.AttackDamage, Is.EqualTo(0));
+            Assert.That(entry.AttackCooldownSeconds, Is.EqualTo(0f));
+            Assert.That(entry.XpReward, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void Find_ReturnsMatchingEnemyTypeOnly()
+        {
+            var table = ScriptableObject.CreateInstance<EnemyBalanceTable>();
+            try
+            {
+                var grunt = new EnemyBalanceEntry { EnemyTypeId = "grunt", MaxHealth = 10 };
+                table.Enemies = new[] { grunt };
+
+                Assert.AreSame(grunt, table.Find("grunt"));
+                Assert.IsNull(table.Find("missing"));
+                Assert.IsNull(table.Find(""));
+            }
+            finally
+            {
+                Object.DestroyImmediate(table);
+            }
+        }
+
+        [Test]
+        public void ProjectAssets_WireGruntEnemyBalanceThroughCentralStation()
+        {
+            var station = AssetDatabase.LoadAssetAtPath<GameBalanceStation>(BalanceStationPath);
+            var table = AssetDatabase.LoadAssetAtPath<EnemyBalanceTable>(EnemyBalanceTablePath);
+            var profile = AssetDatabase.LoadAssetAtPath<EnemyLootProfile>(GruntLootProfilePath);
+
+            Assert.NotNull(station, "Central GameBalanceStation asset must exist.");
+            Assert.NotNull(table, "EnemyBalanceTable asset must exist.");
+            Assert.NotNull(profile, "Grunt loot profile asset must exist.");
+            Assert.AreSame(table, station.Enemy, "Central station should reference the authored enemy table.");
+
+            var grunt = table.Find("grunt");
+            Assert.NotNull(grunt, "The only current enemy type should be authored as grunt.");
+            Assert.AreSame(profile, grunt.LootProfile, "Grunt should use the authored grunt loot profile.");
+            Assert.That(profile.LootTables, Is.Not.Null);
+            Assert.That(profile.LootTables.Length, Is.GreaterThanOrEqualTo(1));
+            Assert.That(profile.GlobalMaxTables, Is.EqualTo(6));
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Balance/EnemyBalanceTableTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Balance/EnemyBalanceTableTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: baf62319b7985b54392083da63ddc529
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/_Tests/EditMode/Inventory/LootTableRngTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Inventory/LootTableRngTests.cs
@@ -1,5 +1,6 @@
 using System;
 using NUnit.Framework;
+using UnityEditor;
 using UnityEngine;
 using Castlebound.Gameplay.Inventory;
 using Castlebound.Gameplay.Loot;
@@ -10,6 +11,8 @@ namespace Castlebound.Tests.Inventory
 {
     public class LootTableRngTests
     {
+        private const string PotionBasicPath = "Assets/_Project/Items/LootTables/LootTable_PotionBasic.asset";
+
         [Test]
         public void Roll_SeededRng_IsDeterministic()
         {
@@ -67,6 +70,27 @@ namespace Castlebound.Tests.Inventory
             Object.DestroyImmediate(itemA);
             Object.DestroyImmediate(itemB);
             Object.DestroyImmediate(itemC);
+        }
+
+        [Test]
+        public void PotionBasicAsset_WeightsOnePotionOverTwoPotions()
+        {
+            var table = AssetDatabase.LoadAssetAtPath<LootTable>(PotionBasicPath);
+
+            Assert.NotNull(table, "Potion basic loot table must exist.");
+            Assert.That(table.Entries, Is.Not.Null);
+            Assert.That(table.Entries.Length, Is.EqualTo(2));
+            AssertPotionEntry(table.Entries[0], 1, 8f);
+            AssertPotionEntry(table.Entries[1], 2, 2f);
+        }
+
+        private static void AssertPotionEntry(LootEntry entry, int amount, float weight)
+        {
+            Assert.NotNull(entry.Item);
+            Assert.That(entry.Item.ItemId, Is.EqualTo("potion_basic"));
+            Assert.That(entry.MinAmount, Is.EqualTo(amount));
+            Assert.That(entry.MaxAmount, Is.EqualTo(amount));
+            Assert.That(entry.Weight, Is.EqualTo(weight).Within(0.001f));
         }
     }
 }

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,41 @@
 
 ---
 
+## 2026-06-05 - refactor(loot): weight basic potion drop amounts
+
+### Summary
+- Updated LootTable_PotionBasic so successful potion drops usually grant 1 potion.
+- Added a lower-weight 2-potion outcome for occasional bonus potion drops.
+- Kept enemy loot profile roll counts unchanged so potion drops remain one table result per enemy.
+
+### New or Updated Tests
+**EditMode**
+- `LootTableRngTests` - verifies PotionBasic asset weights 1 potion at 8 and 2 potions at 2.
+
+**PlayMode**
+- N/A - N/A
+
+### Notes
+- N/A
+
+## 2026-06-05 - refactor(enemy): add enemy stat and reward tuning table
+
+### Summary
+- Added authored enemy stat rows through EnemyBalanceTable with the current grunt baseline.
+- Added an EnemyLootProfile asset for the current grunt reward package while preserving existing loot table mappings.
+- Routed spawned enemies through an EnemyBalanceApplier so stats, XP, and loot mappings resolve from the central GameBalanceStation.
+
+### New or Updated Tests
+**EditMode**
+- `EnemyBalanceTableTests` - verifies defaults, clamping, lookup behavior, and project asset wiring.
+- `EnemyBalanceApplierTests` - verifies stat and reward application plus missing-row fallback behavior.
+
+**PlayMode**
+- N/A - N/A
+
+### Notes
+- Unity EditMode run attempted on 2026-06-05 but failed before tests due to Unity licensing IPC timeout; no NUnit XML was produced.
+
 ## 2026-05-26 - refactor(waves): add wave pacing and difficulty tuning table
 
 ### Summary


### PR DESCRIPTION
## Why
Enemy stats and rewards need a central authored baseline before adding more enemy types. This keeps wave pressure, enemy identity, and loot outcomes tuned in separate, readable places.

## What changed
- Added enemy balance data for the current `grunt` enemy type
- Added a grunt loot profile that preserves the existing reward package
- Routed spawned enemies through the central balance station for stats, XP, and loot mappings
- Updated basic potion drops so successful rolls usually grant 1 potion with a smaller chance for 2
- Added EditMode coverage for enemy balance, reward application, asset wiring, and potion loot weights

## How to test
1. Open `MainPrototype`
2. Press Play and verify grunts spawn, use expected baseline stats, and still drop rewards
3. Run tests:
   - EditMode
   - PlayMode

## Checklist
_All items must be checked. If not applicable, check and mark "N/A"._

- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated (N/A - balance/prefab assets only)
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched (TEST_LOG.md)

## Related
- Closes #180