### PR TITLE
refactor(player): add baseline tuning table

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,7 +188,7 @@ Examples:
 ## PR Close-Out (Only on Trigger)
 
 When the user says:
-`READY TO COMMIT: <summary>`
+`READY TO CLOSE: <summary>`
 
 Output in order:
 1. Branch name suggestion
@@ -349,7 +349,7 @@ When the user types `task refresh`, output this list — clean and scannable, no
 - `HANDOFF` — structured transition block for switching sessions
 - `sync issue tree` — scan GitHub, update Docs/LIVING_ISSUE_TREE.md in repo
 - `log issue: [title]` — create structured GitHub issue mid-session
-- `READY TO COMMIT: [summary]` — full PR close-out output
+- `READY TO CLOSE: [summary]` — full PR close-out output
 - `task refresh` — this list
 
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,6 +233,11 @@ type(scope): short description (#PR_NUMBER)
 Example:
 - `feat(inventory): add castle vault count-based storage (#47)`
 
+### Pull Request Checklist Rule (Agent Instruction — Do Not Copy Into PR Body)
+- In PR close-out output, every checklist item in the PR template MUST be checked as `[x]`.
+- If an item does not apply, keep it checked and append `(N/A - <short reason>)`.
+- Do not include this instruction text or any italic checklist note in the PR body.
+
 ### Pull Request Template (copy exactly)
 ```md
 # Title
@@ -253,13 +258,11 @@ One or two sentences describing the problem, goal, or motivation.
    - PlayMode (or note manual validation)
 
 ## Checklist
-_All items must be checked. If not applicable, check and mark "N/A"._
-
-- [ ] Unit tests (EditMode) added or updated
-- [ ] PlayMode test or manual validation included
-- [ ] Demo scene updated (if player-visible)
-- [ ] Prefab links, tags, and layers validated
-- [ ] README / Docs touched (if applicable)
+- [x] Unit tests (EditMode) added or updated
+- [x] PlayMode test or manual validation included
+- [x] Demo scene updated (if player-visible, otherwise mark N/A with reason)
+- [x] Prefab links, tags, and layers validated
+- [x] README / Docs touched (if applicable, otherwise mark N/A with reason)
 
 ## Related
 - Closes #<issue> or Refs #<issue> (if applicable)

--- a/Assets/_Project/Balance/GameBalanceStation.asset
+++ b/Assets/_Project/Balance/GameBalanceStation.asset
@@ -16,5 +16,5 @@ MonoBehaviour:
   barrier: {fileID: 11400000, guid: 64e791ca8c294529bc6393d439d743c9, type: 2}
   wave: {fileID: 11400000, guid: 744802b4eadd4e4eae9b8cc043d6c82e, type: 2}
   enemy: {fileID: 11400000, guid: b6817306e9a44d3ebfb45d61750b8f7a, type: 2}
-  player: {fileID: 0}
+  player: {fileID: 11400000, guid: 29a98cd4d01b4109b013861d9b9aa57b, type: 2}
   economy: {fileID: 11400000, guid: 33e3c7ab33304f10aaff7086767de14c, type: 2}

--- a/Assets/_Project/Balance/PlayerBalanceTable.asset
+++ b/Assets/_Project/Balance/PlayerBalanceTable.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ff5156f139c14dba96d2b3d174f06830, type: 3}
+  m_Name: PlayerBalanceTable
+  m_EditorClassIdentifier: ""
+  baseMaxHealth: 200
+  baseMoveSpeed: 12
+  baseRepairRange: 2

--- a/Assets/_Project/Balance/PlayerBalanceTable.asset.meta
+++ b/Assets/_Project/Balance/PlayerBalanceTable.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 29a98cd4d01b4109b013861d9b9aa57b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Prefabs/Player.prefab
+++ b/Assets/_Project/Prefabs/Player.prefab
@@ -121,6 +121,7 @@ GameObject:
   - component: {fileID: 9150000000000000203}
   - component: {fileID: 9150000000000000204}
   - component: {fileID: 9150000000000000205}
+  - component: {fileID: 9150000000000000301}
   m_Layer: 3
   m_Name: Player
   m_TagString: Player
@@ -599,6 +600,20 @@ MonoBehaviour:
   activeDuration: 0.02
   recoveryDuration: 0.01
   minSwingDuration: 0.03
+--- !u!114 &9150000000000000301
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8325390509751579795}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c61f73618fdb4e6b8b5f72101bedf19c, type: 3}
+  m_Name: ""
+  m_EditorClassIdentifier: ""
+  balanceStation: {fileID: 11400000, guid: d70caaeb4e66400f8127d62f459cae21, type: 2}
+  playerController: {fileID: 4369444282720785943}
 --- !u!1 &9150000000000000001
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/_Project/Scripts/_Project.Gameplay/Balance/PlayerBalanceApplier.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Balance/PlayerBalanceApplier.cs
@@ -1,0 +1,76 @@
+using UnityEngine;
+
+namespace Castlebound.Gameplay.Balance
+{
+    public class PlayerBalanceApplier : MonoBehaviour
+    {
+        [SerializeField] private GameBalanceStation balanceStation;
+        [SerializeField] private PlayerController playerController;
+
+        private bool hasApplied;
+
+        public GameBalanceStation BalanceStation
+        {
+            get => balanceStation;
+            set => balanceStation = value;
+        }
+
+        public PlayerController PlayerController
+        {
+            get => playerController;
+            set => playerController = value;
+        }
+
+        public bool Apply()
+        {
+            var table = balanceStation != null ? balanceStation.Player : null;
+            if (table == null)
+            {
+                return false;
+            }
+
+            ApplyHealth(table);
+            ApplyMovement(table);
+            ApplyRepair(table);
+            hasApplied = true;
+            return true;
+        }
+
+        private void Start()
+        {
+            if (hasApplied)
+            {
+                return;
+            }
+
+            Apply();
+        }
+
+        private void ApplyHealth(PlayerBalanceTable table)
+        {
+            var health = GetComponent<Health>();
+            if (health != null)
+            {
+                health.ConfigureMaxHealth(table.BaseMaxHealth, true);
+            }
+        }
+
+        private void ApplyMovement(PlayerBalanceTable table)
+        {
+            var mover = GetComponent<PlayerCollisionMove2D>();
+            if (mover != null)
+            {
+                mover.MoveSpeed = table.BaseMoveSpeed;
+            }
+        }
+
+        private void ApplyRepair(PlayerBalanceTable table)
+        {
+            var controller = playerController != null ? playerController : GetComponent<PlayerController>();
+            if (controller != null)
+            {
+                controller.RepairRange = table.BaseRepairRange;
+            }
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Balance/PlayerBalanceApplier.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Balance/PlayerBalanceApplier.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c61f73618fdb4e6b8b5f72101bedf19c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/_Project.Gameplay/Balance/PlayerBalanceTable.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Balance/PlayerBalanceTable.cs
@@ -5,5 +5,33 @@ namespace Castlebound.Gameplay.Balance
     [CreateAssetMenu(menuName = "Castlebound/Balance/Player Balance Table")]
     public class PlayerBalanceTable : ScriptableObject
     {
+        [SerializeField] private int baseMaxHealth = 200;
+        [SerializeField] private float baseMoveSpeed = 12f;
+        [SerializeField] private float baseRepairRange = 2f;
+
+        public int BaseMaxHealth
+        {
+            get => baseMaxHealth;
+            set => baseMaxHealth = Mathf.Max(0, value);
+        }
+
+        public float BaseMoveSpeed
+        {
+            get => baseMoveSpeed;
+            set => baseMoveSpeed = Mathf.Max(0f, value);
+        }
+
+        public float BaseRepairRange
+        {
+            get => baseRepairRange;
+            set => baseRepairRange = Mathf.Max(0f, value);
+        }
+
+        private void OnValidate()
+        {
+            BaseMaxHealth = baseMaxHealth;
+            BaseMoveSpeed = baseMoveSpeed;
+            BaseRepairRange = baseRepairRange;
+        }
     }
 }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/RepairSensor.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/RepairSensor.cs
@@ -7,6 +7,12 @@ public class RepairSensor
     [SerializeField] private float repairRadius = 2f;
     [SerializeField] private LayerMask barrierMask;
 
+    public float RepairRadius
+    {
+        get => repairRadius;
+        set => repairRadius = Mathf.Max(0f, value);
+    }
+
     /// <summary>
     /// Returns true if there is at least one broken barrier within repair range.
     /// </summary>

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Movement/PlayerCollisionMove2D.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Movement/PlayerCollisionMove2D.cs
@@ -12,6 +12,12 @@ public class PlayerCollisionMove2D : MonoBehaviour
     private Collider2D _col;
     private Vector2 _input;
 
+    public float MoveSpeed
+    {
+        get => moveSpeed;
+        set => moveSpeed = Mathf.Max(0f, value);
+    }
+
     // Reused, no per-frame allocations
     private static readonly RaycastHit2D[] sHits = new RaycastHit2D[8];
 

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/PlayerController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/PlayerController.cs
@@ -37,6 +37,20 @@ public class PlayerController : MonoBehaviour
     private InventoryState inventoryState;
     private bool inputLocked;
 
+    public float RepairRange
+    {
+        get => _repairSensor != null ? _repairSensor.RepairRadius : 0f;
+        set
+        {
+            if (_repairSensor == null)
+            {
+                _repairSensor = new RepairSensor();
+            }
+
+            _repairSensor.RepairRadius = value;
+        }
+    }
+
     void Awake()
     {
         rb = GetComponent<Rigidbody2D>();

--- a/Assets/_Project/_Tests/EditMode/Balance/PlayerBalanceApplierTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Balance/PlayerBalanceApplierTests.cs
@@ -1,0 +1,82 @@
+using Castlebound.Gameplay.Balance;
+using NUnit.Framework;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace Castlebound.Tests.Balance
+{
+    public class PlayerBalanceApplierTests
+    {
+        [Test]
+        public void Apply_ConfiguresPlayerBaselinesFromBalanceTable()
+        {
+            var station = ScriptableObject.CreateInstance<GameBalanceStation>();
+            var table = ScriptableObject.CreateInstance<PlayerBalanceTable>();
+            var player = new GameObject("Player");
+
+            try
+            {
+                player.AddComponent<Rigidbody2D>();
+                player.AddComponent<BoxCollider2D>();
+                var health = player.AddComponent<Health>();
+                var mover = player.AddComponent<PlayerCollisionMove2D>();
+                var controller = player.AddComponent<PlayerController>();
+                var applier = player.AddComponent<PlayerBalanceApplier>();
+
+                table.BaseMaxHealth = 150;
+                table.BaseMoveSpeed = 9.5f;
+                table.BaseRepairRange = 3.25f;
+                station.Player = table;
+                applier.BalanceStation = station;
+                applier.PlayerController = controller;
+
+                Assert.IsTrue(applier.Apply());
+
+                Assert.That(health.Max, Is.EqualTo(150));
+                Assert.That(health.Current, Is.EqualTo(150));
+                Assert.That(mover.MoveSpeed, Is.EqualTo(9.5f).Within(0.001f));
+                Assert.That(controller.RepairRange, Is.EqualTo(3.25f).Within(0.001f));
+            }
+            finally
+            {
+                Object.DestroyImmediate(player);
+                Object.DestroyImmediate(table);
+                Object.DestroyImmediate(station);
+            }
+        }
+
+        [Test]
+        public void Apply_WhenTableMissing_LeavesAuthoredValues()
+        {
+            var station = ScriptableObject.CreateInstance<GameBalanceStation>();
+            var player = new GameObject("Player");
+
+            try
+            {
+                player.AddComponent<Rigidbody2D>();
+                player.AddComponent<BoxCollider2D>();
+                var health = player.AddComponent<Health>();
+                var mover = player.AddComponent<PlayerCollisionMove2D>();
+                var controller = player.AddComponent<PlayerController>();
+                var applier = player.AddComponent<PlayerBalanceApplier>();
+
+                health.ConfigureMaxHealth(200, true);
+                mover.MoveSpeed = 12f;
+                controller.RepairRange = 2f;
+                applier.BalanceStation = station;
+                applier.PlayerController = controller;
+
+                Assert.IsFalse(applier.Apply());
+
+                Assert.That(health.Max, Is.EqualTo(200));
+                Assert.That(mover.MoveSpeed, Is.EqualTo(12f).Within(0.001f));
+                Assert.That(controller.RepairRange, Is.EqualTo(2f).Within(0.001f));
+            }
+            finally
+            {
+                Object.DestroyImmediate(player);
+                Object.DestroyImmediate(station);
+            }
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Balance/PlayerBalanceApplierTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Balance/PlayerBalanceApplierTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a0c9b1551b5545ec9afd256fae43803b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/_Tests/EditMode/Balance/PlayerBalanceTableTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Balance/PlayerBalanceTableTests.cs
@@ -1,0 +1,66 @@
+using Castlebound.Gameplay.Balance;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace Castlebound.Tests.Balance
+{
+    public class PlayerBalanceTableTests
+    {
+        private const string BalanceStationPath = "Assets/_Project/Balance/GameBalanceStation.asset";
+        private const string PlayerBalanceTablePath = "Assets/_Project/Balance/PlayerBalanceTable.asset";
+
+        [Test]
+        public void Defaults_MirrorCurrentPlayerRuntimeTuning()
+        {
+            var table = ScriptableObject.CreateInstance<PlayerBalanceTable>();
+
+            try
+            {
+                Assert.That(table.BaseMaxHealth, Is.EqualTo(200));
+                Assert.That(table.BaseMoveSpeed, Is.EqualTo(12f).Within(0.001f));
+                Assert.That(table.BaseRepairRange, Is.EqualTo(2f).Within(0.001f));
+            }
+            finally
+            {
+                Object.DestroyImmediate(table);
+            }
+        }
+
+        [Test]
+        public void ScalarProperties_ClampToSafeValues()
+        {
+            var table = ScriptableObject.CreateInstance<PlayerBalanceTable>();
+
+            try
+            {
+                table.BaseMaxHealth = -1;
+                table.BaseMoveSpeed = -1f;
+                table.BaseRepairRange = -1f;
+
+                Assert.That(table.BaseMaxHealth, Is.EqualTo(0));
+                Assert.That(table.BaseMoveSpeed, Is.EqualTo(0f));
+                Assert.That(table.BaseRepairRange, Is.EqualTo(0f));
+            }
+            finally
+            {
+                Object.DestroyImmediate(table);
+            }
+        }
+
+        [Test]
+        public void ProjectAssets_WirePlayerTableThroughCentralBalanceStation()
+        {
+            var station = AssetDatabase.LoadAssetAtPath<GameBalanceStation>(BalanceStationPath);
+            var table = AssetDatabase.LoadAssetAtPath<PlayerBalanceTable>(PlayerBalanceTablePath);
+
+            Assert.NotNull(station, "Central GameBalanceStation asset must exist.");
+            Assert.NotNull(table, "PlayerBalanceTable asset must exist.");
+            Assert.AreSame(table, station.Player, "Central station should reference the authored player table.");
+            Assert.That(table.BaseMaxHealth, Is.EqualTo(200));
+            Assert.That(table.BaseMoveSpeed, Is.EqualTo(12f).Within(0.001f));
+            Assert.That(table.BaseRepairRange, Is.EqualTo(2f).Within(0.001f));
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Balance/PlayerBalanceTableTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Balance/PlayerBalanceTableTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1ec1fc5d1e384cfa9f52c3403d2ac701
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,24 @@
 
 ---
 
+## 2026-06-05 - refactor(player): add player baseline tuning table
+
+### Summary
+- Added authored player baseline fields to PlayerBalanceTable.
+- Added a PlayerBalanceTable project asset and wired it through GameBalanceStation.
+- Routed player max HP, move speed, and repair range through a PlayerBalanceApplier while preserving instant full barrier repair.
+
+### New or Updated Tests
+**EditMode**
+- `PlayerBalanceTableTests` - verifies defaults, clamping, and project asset wiring.
+- `PlayerBalanceApplierTests` - verifies baseline application and missing-table fallback behavior.
+
+**PlayMode**
+- N/A - N/A
+
+### Notes
+- EditMode and PlayMode tests passed per user on 2026-06-07.
+
 ## 2026-06-05 - refactor(loot): weight basic potion drop amounts
 
 ### Summary


### PR DESCRIPTION
## Why
Player baseline stats need a central authored source before future runtime modifiers, upgrades, and movement/combat abilities are added.

## What changed
- Added player baseline tuning for max HP, move speed, and repair range
- Routed player baseline values through GameBalanceStation using PlayerBalanceApplier
- Wired PlayerBalanceTable asset and Player prefab references
- Preserved current instant full barrier repair behavior
- Renamed the PR close-out workflow trigger from READY TO COMMIT to READY TO CLOSE
- Clarified that PR checklist items must be checked before close-out output

## How to test
1. Open MainPrototype
2. Press Play → verify player HP, movement speed, and repair range match the authored baseline
3. Run tests:
   - EditMode
   - PlayMode

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated (N/A - prefab/balance asset wiring only)
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched (TEST_LOG.md, AGENTS.md)

## Related
- Closes #181