### PR TITLE
feat(world): add castle and defense placeable definitions

### DIFF
--- a/Assets/_Project/Placeables.meta
+++ b/Assets/_Project/Placeables.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0a91a6620765418291bd16057a285220
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Placeables/Castle.meta
+++ b/Assets/_Project/Placeables/Castle.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 49f5ba7b8e6443808ebd02c9f9f08e0c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Placeables/Castle/Placeable_Castle_BarrierGate.asset
+++ b/Assets/_Project/Placeables/Castle/Placeable_Castle_BarrierGate.asset
@@ -15,6 +15,7 @@ MonoBehaviour:
   id: castle.barrier_gate
   displayName: Barrier Gate
   category: 0
+  placementSurface: 0
   footprintWidth: 3
   footprintHeight: 3
   prefab: {fileID: 683792860472063015, guid: dc74549e32466984aa8c05b572869f89, type: 3}

--- a/Assets/_Project/Placeables/Castle/Placeable_Castle_BarrierGate.asset
+++ b/Assets/_Project/Placeables/Castle/Placeable_Castle_BarrierGate.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f71abf43f2e84e6bad3eb8e33bb40d49, type: 3}
+  m_Name: Placeable_Castle_BarrierGate
+  m_EditorClassIdentifier: 
+  id: castle.barrier_gate
+  displayName: Barrier Gate
+  category: 0
+  footprintWidth: 3
+  footprintHeight: 3
+  prefab: {fileID: 683792860472063015, guid: dc74549e32466984aa8c05b572869f89, type: 3}

--- a/Assets/_Project/Placeables/Castle/Placeable_Castle_BarrierGate.asset.meta
+++ b/Assets/_Project/Placeables/Castle/Placeable_Castle_BarrierGate.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d014f9036f434ee3ae3d70a4f52e64be
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Placeables/Defense.meta
+++ b/Assets/_Project/Placeables/Defense.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dfdc5c9b19d842eb890f10e1a7152236
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Placeables/Defense/Placeable_Defense_Tower.asset
+++ b/Assets/_Project/Placeables/Defense/Placeable_Defense_Tower.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f71abf43f2e84e6bad3eb8e33bb40d49, type: 3}
+  m_Name: Placeable_Defense_Tower
+  m_EditorClassIdentifier: 
+  id: defense.tower
+  displayName: Tower
+  category: 1
+  footprintWidth: 3
+  footprintHeight: 3
+  prefab: {fileID: 2000000000, guid: ec470124d4d042388418a66cedd418c1, type: 3}

--- a/Assets/_Project/Placeables/Defense/Placeable_Defense_Tower.asset
+++ b/Assets/_Project/Placeables/Defense/Placeable_Defense_Tower.asset
@@ -15,6 +15,7 @@ MonoBehaviour:
   id: defense.tower
   displayName: Tower
   category: 1
+  placementSurface: 0
   footprintWidth: 3
   footprintHeight: 3
   prefab: {fileID: 2000000000, guid: ec470124d4d042388418a66cedd418c1, type: 3}

--- a/Assets/_Project/Placeables/Defense/Placeable_Defense_Tower.asset.meta
+++ b/Assets/_Project/Placeables/Defense/Placeable_Defense_Tower.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0c6d519e55fc4b24a5337690ab2d6804
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/_Project.Gameplay/World.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/World.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bdbde1649c454e3a86cd1ecac5326c62
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/_Project.Gameplay/World/Placement.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/World/Placement.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c14e62c2ec1f4cfc9091c037968f0cbd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/_Project.Gameplay/World/Placement/PlaceableObjectCategory.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/World/Placement/PlaceableObjectCategory.cs
@@ -1,0 +1,8 @@
+namespace Castlebound.Gameplay.World.Placement
+{
+    public enum PlaceableObjectCategory
+    {
+        Castle = 0,
+        Defense = 1
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/World/Placement/PlaceableObjectCategory.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/World/Placement/PlaceableObjectCategory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8d59f39deeb84194b82b31926d3ab2c8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/_Project.Gameplay/World/Placement/PlaceableObjectDefinition.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/World/Placement/PlaceableObjectDefinition.cs
@@ -9,6 +9,7 @@ namespace Castlebound.Gameplay.World.Placement
         [SerializeField] private string id;
         [SerializeField] private string displayName;
         [SerializeField] private PlaceableObjectCategory category;
+        [SerializeField] private PlaceablePlacementSurface placementSurface;
         [SerializeField] private int footprintWidth = 3;
         [SerializeField] private int footprintHeight = 3;
         [SerializeField] private GameObject prefab;
@@ -29,6 +30,12 @@ namespace Castlebound.Gameplay.World.Placement
         {
             get => category;
             set => category = value;
+        }
+
+        public PlaceablePlacementSurface PlacementSurface
+        {
+            get => placementSurface;
+            set => placementSurface = value;
         }
 
         public int FootprintWidth

--- a/Assets/_Project/Scripts/_Project.Gameplay/World/Placement/PlaceableObjectDefinition.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/World/Placement/PlaceableObjectDefinition.cs
@@ -1,0 +1,74 @@
+using Castlebound.Gameplay.Castle;
+using UnityEngine;
+
+namespace Castlebound.Gameplay.World.Placement
+{
+    [CreateAssetMenu(menuName = "Castlebound/World/Placement/Placeable Object Definition")]
+    public class PlaceableObjectDefinition : ScriptableObject
+    {
+        [SerializeField] private string id;
+        [SerializeField] private string displayName;
+        [SerializeField] private PlaceableObjectCategory category;
+        [SerializeField] private int footprintWidth = 3;
+        [SerializeField] private int footprintHeight = 3;
+        [SerializeField] private GameObject prefab;
+
+        public string Id
+        {
+            get => id;
+            set => id = value;
+        }
+
+        public string DisplayName
+        {
+            get => displayName;
+            set => displayName = value;
+        }
+
+        public PlaceableObjectCategory Category
+        {
+            get => category;
+            set => category = value;
+        }
+
+        public int FootprintWidth
+        {
+            get => footprintWidth;
+            set => footprintWidth = value;
+        }
+
+        public int FootprintHeight
+        {
+            get => footprintHeight;
+            set => footprintHeight = value;
+        }
+
+        public GameObject Prefab
+        {
+            get => prefab;
+            set => prefab = value;
+        }
+
+        public bool HasValidFootprint => footprintWidth > 0 && footprintHeight > 0;
+
+        public GridFootprint Footprint => HasValidFootprint
+            ? new GridFootprint(footprintWidth, footprintHeight)
+            : default;
+
+        public bool IsValid => !string.IsNullOrWhiteSpace(id)
+            && !string.IsNullOrWhiteSpace(displayName)
+            && HasValidFootprint
+            && prefab != null;
+
+        public void SetFootprint(GridFootprint value)
+        {
+            if (!value.IsValid)
+            {
+                throw new System.ArgumentException("Cannot assign an invalid grid footprint.", nameof(value));
+            }
+
+            footprintWidth = value.Width;
+            footprintHeight = value.Height;
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/World/Placement/PlaceableObjectDefinition.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/World/Placement/PlaceableObjectDefinition.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f71abf43f2e84e6bad3eb8e33bb40d49
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/_Project.Gameplay/World/Placement/PlaceablePlacementSurface.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/World/Placement/PlaceablePlacementSurface.cs
@@ -1,0 +1,9 @@
+namespace Castlebound.Gameplay.World.Placement
+{
+    public enum PlaceablePlacementSurface
+    {
+        CastleWall = 0,
+        CastleFloor = 1,
+        OutsideGround = 2
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/World/Placement/PlaceablePlacementSurface.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/World/Placement/PlaceablePlacementSurface.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5fb910b8d7a84dc098590fb6d12094c4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/EditMode/World.meta
+++ b/Assets/_Project/_Tests/EditMode/World.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 66f92f944ad5414dbf10867ee51c6f25
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/EditMode/World/Placement.meta
+++ b/Assets/_Project/_Tests/EditMode/World/Placement.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7b0fe6f2571542afae8c3cc47360336f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/EditMode/World/Placement/PlaceableObjectDefinitionTests.cs
+++ b/Assets/_Project/_Tests/EditMode/World/Placement/PlaceableObjectDefinitionTests.cs
@@ -55,6 +55,25 @@ namespace Castlebound.Tests.World.Placement
             }
         }
 
+        [TestCase(PlaceablePlacementSurface.CastleWall)]
+        [TestCase(PlaceablePlacementSurface.CastleFloor)]
+        [TestCase(PlaceablePlacementSurface.OutsideGround)]
+        public void PlacementSurface_SupportsCurrentAndPlannedWorldPlacementSurfaces(PlaceablePlacementSurface surface)
+        {
+            var definition = ScriptableObject.CreateInstance<PlaceableObjectDefinition>();
+
+            try
+            {
+                definition.PlacementSurface = surface;
+
+                Assert.That(definition.PlacementSurface, Is.EqualTo(surface));
+            }
+            finally
+            {
+                Object.DestroyImmediate(definition);
+            }
+        }
+
         [Test]
         public void SetFootprint_StoresExplicitGridFootprintDimensions()
         {
@@ -117,6 +136,7 @@ namespace Castlebound.Tests.World.Placement
             Assert.That(definition.Id, Is.EqualTo(expectedId));
             Assert.That(definition.DisplayName, Is.EqualTo(expectedDisplayName));
             Assert.That(definition.Category, Is.EqualTo(expectedCategory));
+            Assert.That(definition.PlacementSurface, Is.EqualTo(PlaceablePlacementSurface.CastleWall));
             Assert.That(definition.Footprint, Is.EqualTo(GridFootprint.ThreeByThree));
             Assert.NotNull(definition.Prefab, $"{expectedId} must reference a prefab.");
         }

--- a/Assets/_Project/_Tests/EditMode/World/Placement/PlaceableObjectDefinitionTests.cs
+++ b/Assets/_Project/_Tests/EditMode/World/Placement/PlaceableObjectDefinitionTests.cs
@@ -1,0 +1,124 @@
+using Castlebound.Gameplay.Castle;
+using Castlebound.Gameplay.World.Placement;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+
+namespace Castlebound.Tests.World.Placement
+{
+    public class PlaceableObjectDefinitionTests
+    {
+        private const string CastleBarrierGatePath = "Assets/_Project/Placeables/Castle/Placeable_Castle_BarrierGate.asset";
+        private const string DefenseTowerPath = "Assets/_Project/Placeables/Defense/Placeable_Defense_Tower.asset";
+
+        [Test]
+        public void NewDefinition_IsInvalidUntilRequiredAuthoringFieldsAreAssigned()
+        {
+            var definition = ScriptableObject.CreateInstance<PlaceableObjectDefinition>();
+
+            try
+            {
+                Assert.IsFalse(definition.IsValid);
+
+                definition.Id = "castle.test_piece";
+                definition.DisplayName = "Test Piece";
+                definition.Prefab = new GameObject("TestPrefab");
+
+                Assert.IsTrue(definition.IsValid);
+            }
+            finally
+            {
+                if (definition.Prefab != null)
+                {
+                    Object.DestroyImmediate(definition.Prefab);
+                }
+
+                Object.DestroyImmediate(definition);
+            }
+        }
+
+        [TestCase(PlaceableObjectCategory.Castle)]
+        [TestCase(PlaceableObjectCategory.Defense)]
+        public void Category_SupportsCurrentCastleAndDefensePlaceableFamilies(PlaceableObjectCategory category)
+        {
+            var definition = ScriptableObject.CreateInstance<PlaceableObjectDefinition>();
+
+            try
+            {
+                definition.Category = category;
+
+                Assert.That(definition.Category, Is.EqualTo(category));
+            }
+            finally
+            {
+                Object.DestroyImmediate(definition);
+            }
+        }
+
+        [Test]
+        public void SetFootprint_StoresExplicitGridFootprintDimensions()
+        {
+            var definition = ScriptableObject.CreateInstance<PlaceableObjectDefinition>();
+
+            try
+            {
+                definition.SetFootprint(GridFootprint.ThreeByThree);
+
+                Assert.That(definition.FootprintWidth, Is.EqualTo(3));
+                Assert.That(definition.FootprintHeight, Is.EqualTo(3));
+                Assert.That(definition.Footprint, Is.EqualTo(GridFootprint.ThreeByThree));
+            }
+            finally
+            {
+                Object.DestroyImmediate(definition);
+            }
+        }
+
+        [Test]
+        public void InvalidFootprint_IsReportedWithoutCreatingAFootprint()
+        {
+            var definition = ScriptableObject.CreateInstance<PlaceableObjectDefinition>();
+
+            try
+            {
+                definition.FootprintWidth = 0;
+                definition.FootprintHeight = 3;
+
+                Assert.IsFalse(definition.HasValidFootprint);
+                Assert.IsFalse(definition.Footprint.IsValid);
+                Assert.IsFalse(definition.IsValid);
+            }
+            finally
+            {
+                Object.DestroyImmediate(definition);
+            }
+        }
+
+        [Test]
+        public void ProjectAssets_AuthorCurrentCastleAndDefensePlaceablesAsThreeByThree()
+        {
+            var castle = AssetDatabase.LoadAssetAtPath<PlaceableObjectDefinition>(CastleBarrierGatePath);
+            var defense = AssetDatabase.LoadAssetAtPath<PlaceableObjectDefinition>(DefenseTowerPath);
+
+            Assert.NotNull(castle, "Castle barrier gate placeable definition must exist.");
+            Assert.NotNull(defense, "Defense tower placeable definition must exist.");
+
+            AssertPlaceable(castle, "castle.barrier_gate", "Barrier Gate", PlaceableObjectCategory.Castle);
+            AssertPlaceable(defense, "defense.tower", "Tower", PlaceableObjectCategory.Defense);
+        }
+
+        private static void AssertPlaceable(
+            PlaceableObjectDefinition definition,
+            string expectedId,
+            string expectedDisplayName,
+            PlaceableObjectCategory expectedCategory)
+        {
+            Assert.IsTrue(definition.IsValid, $"{expectedId} should be fully authored.");
+            Assert.That(definition.Id, Is.EqualTo(expectedId));
+            Assert.That(definition.DisplayName, Is.EqualTo(expectedDisplayName));
+            Assert.That(definition.Category, Is.EqualTo(expectedCategory));
+            Assert.That(definition.Footprint, Is.EqualTo(GridFootprint.ThreeByThree));
+            Assert.NotNull(definition.Prefab, $"{expectedId} must reference a prefab.");
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/World/Placement/PlaceableObjectDefinitionTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/World/Placement/PlaceableObjectDefinitionTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9d2013b8e0fc48c298da15551c33a776
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,23 @@
 
 ---
 
+## 2026-06-08 - feat(world): add castle and defense placeable definitions
+
+### Summary
+- Added placeable object definitions for authored Castle and Defense placement data.
+- Authored current barrier gate and tower placeables as 3x3 footprints.
+- Kept placement overlap and tower wall-mount rules out of this data-only slice.
+
+### New or Updated Tests
+**EditMode**
+- `PlaceableObjectDefinitionTests` - verifies required authoring fields, current categories, explicit footprint dimensions, invalid footprints, and project asset wiring.
+
+**PlayMode**
+- N/A - N/A
+
+### Notes
+- Awaiting user-run EditMode validation.
+
 ## 2026-06-07 - feat(world): add grid footprint placement contract
 
 ### Summary

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -9,11 +9,11 @@
 ### Summary
 - Added placeable object definitions for authored Castle and Defense placement data.
 - Authored current barrier gate and tower placeables as 3x3 footprints.
-- Kept placement overlap and tower wall-mount rules out of this data-only slice.
+- Added placement surface authoring while keeping overlap and tower wall-mount rules out of this data-only slice.
 
 ### New or Updated Tests
 **EditMode**
-- `PlaceableObjectDefinitionTests` - verifies required authoring fields, current categories, explicit footprint dimensions, invalid footprints, and project asset wiring.
+- `PlaceableObjectDefinitionTests` - verifies required authoring fields, current categories, placement surfaces, explicit footprint dimensions, invalid footprints, and project asset wiring.
 
 **PlayMode**
 - N/A - N/A


### PR DESCRIPTION
## Why
Placement needs authored data for objects before runtime placement, catalogs, or build menus can consume them. This adds the first placeable definition layer for current castle and defense objects.

## What changed
- Added `PlaceableObjectDefinition` for authored placeable id, display name, category, placement surface, footprint, and prefab reference
- Added `PlaceableObjectCategory` with current categories: Castle and Defense
- Added `PlaceablePlacementSurface` with CastleWall, CastleFloor, and OutsideGround surfaces
- Authored the current barrier gate as a Castle placeable with a CastleWall surface and 3x3 footprint
- Authored the current tower as a Defense placeable with a CastleWall surface and 3x3 footprint
- Added EditMode tests for required fields, categories, placement surfaces, explicit footprints, invalid footprints, and project asset wiring
- Updated TEST_LOG with validation status

## How to test
1. Inspect `Assets/_Project/Placeables/Castle/Placeable_Castle_BarrierGate.asset`
2. Inspect `Assets/_Project/Placeables/Defense/Placeable_Defense_Tower.asset`
3. Run tests:
   - EditMode
   - PlayMode (N/A - no runtime placement behavior changed)

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated (N/A - no scene changes required)
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched (TEST_LOG updated)

## Related
- Closes #191