### PR TITLE
feat(defense): add bear trap placement prototype

### DIFF
--- a/Assets/_Project/Placeables/Defense/Placeable_Defense_BearTrap.asset
+++ b/Assets/_Project/Placeables/Defense/Placeable_Defense_BearTrap.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f71abf43f2e84e6bad3eb8e33bb40d49, type: 3}
+  m_Name: Placeable_Defense_BearTrap
+  m_EditorClassIdentifier: 
+  id: defense.bear_trap
+  displayName: Bear Trap
+  category: 1
+  placementSurface: 2
+  footprintWidth: 1
+  footprintHeight: 1
+  prefab: {fileID: 2100000000, guid: c0df124f7e504b91b9f2b2aa4680c905, type: 3}

--- a/Assets/_Project/Placeables/Defense/Placeable_Defense_BearTrap.asset.meta
+++ b/Assets/_Project/Placeables/Defense/Placeable_Defense_BearTrap.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 793435efe6d1405aade9a797c942ea9e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Prefabs/BearTrap.prefab
+++ b/Assets/_Project/Prefabs/BearTrap.prefab
@@ -1,0 +1,182 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2100000000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2100000001}
+  - component: {fileID: 2100000002}
+  - component: {fileID: 2100000003}
+  m_Layer: 11
+  m_Name: BearTrap
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2100000001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2100000000}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2100000011}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &2100000002
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2100000000}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 0.8, y: 0.8}
+  m_EdgeRadius: 0
+--- !u!114 &2100000003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2100000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3a98ab4f8e5647088ef3b760f1b69710, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  visualRenderer: {fileID: 2100000012}
+  openSprite: {fileID: 21300000, guid: 40fce742cb865404798ef8ba7d49ebd4, type: 3}
+  closedSprite: {fileID: 0}
+  animator: {fileID: 0}
+  closeTriggerName: Close
+--- !u!1 &2100000010
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2100000011}
+  - component: {fileID: 2100000012}
+  m_Layer: 11
+  m_Name: Visual
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2100000011
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2100000010}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2100000001}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &2100000012
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2100000010}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 4
+  m_Sprite: {fileID: 21300000, guid: 40fce742cb865404798ef8ba7d49ebd4, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0

--- a/Assets/_Project/Prefabs/BearTrap.prefab.meta
+++ b/Assets/_Project/Prefabs/BearTrap.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c0df124f7e504b91b9f2b2aa4680c905
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scenes/MainPrototype.unity
+++ b/Assets/_Project/Scenes/MainPrototype.unity
@@ -5106,11 +5106,15 @@ MonoBehaviour:
   worldCamera: {fileID: 519420031}
   placedParent: {fileID: 2600000001}
   uiParent: {fileID: 977390126}
+  castleRegionCollider: {fileID: 769892621}
   previewRenderer: {fileID: 0}
   placeholderPreviewSprite: {fileID: 21300000, guid: 40fce742cb865404798ef8ba7d49ebd4, type: 3}
   confirmButton: {fileID: 0}
   cancelButton: {fileID: 0}
   currentSurface: 2
+  placementBlockingLayers:
+    serializedVersion: 2
+    m_Bits: 320
   gridCellSize: 1
   validPreviewColor: {r: 0.35, g: 1, b: 0.35, a: 0.55}
   invalidPreviewColor: {r: 1, g: 0.25, b: 0.2, a: 0.55}

--- a/Assets/_Project/Scenes/MainPrototype.unity
+++ b/Assets/_Project/Scenes/MainPrototype.unity
@@ -1385,6 +1385,9 @@ MonoBehaviour:
   feedbackChannel: {fileID: 11400000, guid: 1f9f2f0a7b2a4d0a9a2d6e11a6a0d1f6, type: 2}
   inventorySource: {fileID: 0}
   towerBuildController: {fileID: 2300000002}
+  bearTrapPlacementController: {fileID: 2600000002}
+  bearTrapDefinition: {fileID: 11400000, guid: 793435efe6d1405aade9a797c942ea9e, type: 2}
+  activeTab: 0
 --- !u!114 &676673187
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -5102,8 +5105,6 @@ MonoBehaviour:
   worldGrid: {fileID: 2200000012}
   worldCamera: {fileID: 519420031}
   placedParent: {fileID: 2600000001}
-  uiParent: {fileID: 977390126}
-  selectButton: {fileID: 0}
   previewRenderer: {fileID: 0}
   placeholderPreviewSprite: {fileID: 21300000, guid: 40fce742cb865404798ef8ba7d49ebd4, type: 3}
   currentSurface: 2

--- a/Assets/_Project/Scenes/MainPrototype.unity
+++ b/Assets/_Project/Scenes/MainPrototype.unity
@@ -5105,8 +5105,11 @@ MonoBehaviour:
   worldGrid: {fileID: 2200000012}
   worldCamera: {fileID: 519420031}
   placedParent: {fileID: 2600000001}
+  uiParent: {fileID: 977390126}
   previewRenderer: {fileID: 0}
   placeholderPreviewSprite: {fileID: 21300000, guid: 40fce742cb865404798ef8ba7d49ebd4, type: 3}
+  confirmButton: {fileID: 0}
+  cancelButton: {fileID: 0}
   currentSurface: 2
   gridCellSize: 1
   validPreviewColor: {r: 0.35, g: 1, b: 0.35, a: 0.55}

--- a/Assets/_Project/Scenes/MainPrototype.unity
+++ b/Assets/_Project/Scenes/MainPrototype.unity
@@ -4764,8 +4764,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: ffe78ccad9674bd88456656f36872899, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   waveText: {fileID: 2400000023}
   format: Wave {0}
   waveRunner: {fileID: 1166075763}
@@ -4825,8 +4825,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 0
@@ -4900,8 +4900,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 0
@@ -5034,8 +5034,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0.03, g: 0.025, b: 0.02, a: 0.45}
   m_RaycastTarget: 0
@@ -5054,6 +5054,62 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &2600000000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2600000001}
+  - component: {fileID: 2600000002}
+  m_Layer: 0
+  m_Name: BearTrapPlacementPrototype
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2600000001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2600000000}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2600000002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2600000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0c5af0a1321b4ba9844194255614a28c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  defaultPlaceable: {fileID: 11400000, guid: 793435efe6d1405aade9a797c942ea9e, type: 2}
+  worldGrid: {fileID: 2200000012}
+  worldCamera: {fileID: 519420031}
+  placedParent: {fileID: 2600000001}
+  uiParent: {fileID: 977390126}
+  selectButton: {fileID: 0}
+  previewRenderer: {fileID: 0}
+  placeholderPreviewSprite: {fileID: 21300000, guid: 40fce742cb865404798ef8ba7d49ebd4, type: 3}
+  currentSurface: 2
+  gridCellSize: 1
+  validPreviewColor: {r: 0.35, g: 1, b: 0.35, a: 0.55}
+  invalidPreviewColor: {r: 1, g: 0.25, b: 0.2, a: 0.55}
 --- !u!1 &3000000000
 GameObject:
   m_ObjectHideFlags: 0
@@ -5407,3 +5463,4 @@ SceneRoots:
   - {fileID: 2200000011}
   - {fileID: 3000000001}
   - {fileID: 2300000001}
+  - {fileID: 2600000001}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/PlayerController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/PlayerController.cs
@@ -224,10 +224,22 @@ public class PlayerController : MonoBehaviour
         inputLocked = locked;
         if (locked)
         {
-            fireInputController?.ClearHeldFire();
-            attackLoop?.ResetLoopState();
-            ApplyAttackRuntimeState();
+            ClearAttackInputState();
         }
+    }
+
+    public void ClearAttackInputState()
+    {
+        if (fireInputController == null)
+            fireInputController = GetComponent<PlayerFireInputController>();
+
+        if (attackLoop == null)
+            attackLoop = GetComponent<PlayerAttackLoop>();
+
+        fireInputController?.ClearHeldFire();
+        attackLoop?.ResetLoopState();
+        ApplyAttackRuntimeState();
+        SyncAttackAnimationSpeed();
     }
 
     private float GetEffectiveAttackRate()

--- a/Assets/_Project/Scripts/_Project.Gameplay/UI/UpgradeMenuController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/UI/UpgradeMenuController.cs
@@ -82,6 +82,11 @@ namespace Castlebound.Gameplay.UI
             phaseTracker?.SetPhase(WavePhase.InWave);
         }
 
+        public void HideMenuForPlacement()
+        {
+            ApplyMenuState(false);
+        }
+
         private void OnPhaseChanged(WavePhase phase)
         {
             if (phase != WavePhase.PreWave)

--- a/Assets/_Project/Scripts/_Project.Gameplay/UI/UpgradeMenuController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/UI/UpgradeMenuController.cs
@@ -87,6 +87,11 @@ namespace Castlebound.Gameplay.UI
             ApplyMenuState(false);
         }
 
+        public void ReopenMenuAfterPlacement()
+        {
+            ApplyMenuState(true);
+        }
+
         private void OnPhaseChanged(WavePhase phase)
         {
             if (phase != WavePhase.PreWave)

--- a/Assets/_Project/Scripts/_Project.Gameplay/UI/UpgradeMenuListView.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/UI/UpgradeMenuListView.cs
@@ -380,13 +380,20 @@ namespace Castlebound.Gameplay.UI
                 return false;
             }
 
-            if (!bearTrapPlacementController.BeginPlacement(bearTrapDefinition))
+            if (!bearTrapPlacementController.BeginPlacement(bearTrapDefinition, ReopenDefenseTabAfterPlacement))
             {
                 return false;
             }
 
             menuController?.HideMenuForPlacement();
             return true;
+        }
+
+        private void ReopenDefenseTabAfterPlacement()
+        {
+            activeTab = UpgradeMenuTab.Defense;
+            menuController?.ReopenMenuAfterPlacement();
+            Refresh();
         }
 
         private ActionRow CreateTowerPlotRow(TowerPlot plot, int plotIndex, bool endsBarrierGroup)

--- a/Assets/_Project/Scripts/_Project.Gameplay/UI/UpgradeMenuListView.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/UI/UpgradeMenuListView.cs
@@ -4,6 +4,7 @@ using Castlebound.Gameplay.Barrier;
 using Castlebound.Gameplay.Castle;
 using Castlebound.Gameplay.Inventory;
 using Castlebound.Gameplay.Tower;
+using Castlebound.Gameplay.World.Placement;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -26,6 +27,8 @@ namespace Castlebound.Gameplay.UI
         [SerializeField] private FeedbackEventChannel feedbackChannel;
         [SerializeField] private InventoryStateComponent inventorySource;
         [SerializeField] private TowerBuildController towerBuildController;
+        [SerializeField] private WorldPlaceablePlacementController bearTrapPlacementController;
+        [SerializeField] private PlaceableObjectDefinition bearTrapDefinition;
         [SerializeField] private UpgradeMenuTab activeTab = UpgradeMenuTab.Castle;
 
         private readonly List<ActionRow> rows = new List<ActionRow>();
@@ -77,6 +80,11 @@ namespace Castlebound.Gameplay.UI
             var controllers = FindObjectsOfType<BarrierUpgradeController>();
             var inventory = inventorySource != null ? inventorySource.State : null;
 
+            if (activeTab == UpgradeMenuTab.Defense)
+            {
+                CreateBearTrapPlacementRow();
+            }
+
             foreach (var controller in controllers)
             {
                 if (controller == null || !controller.isActiveAndEnabled)
@@ -117,6 +125,16 @@ namespace Castlebound.Gameplay.UI
             towerBuildController = controller;
         }
 
+        public void SetBearTrapPlacementController(WorldPlaceablePlacementController controller)
+        {
+            bearTrapPlacementController = controller;
+        }
+
+        public void SetBearTrapDefinition(PlaceableObjectDefinition definition)
+        {
+            bearTrapDefinition = definition;
+        }
+
         public void SetActiveTab(UpgradeMenuTab tab)
         {
             if (activeTab == tab)
@@ -148,6 +166,16 @@ namespace Castlebound.Gameplay.UI
             if (towerBuildController == null)
             {
                 towerBuildController = FindObjectOfType<TowerBuildController>();
+            }
+
+            if (bearTrapPlacementController == null)
+            {
+                bearTrapPlacementController = FindObjectOfType<WorldPlaceablePlacementController>();
+            }
+
+            if (bearTrapDefinition == null && bearTrapPlacementController != null)
+            {
+                bearTrapDefinition = bearTrapPlacementController.DefaultPlaceable;
             }
         }
 
@@ -309,6 +337,56 @@ namespace Castlebound.Gameplay.UI
                     ? CreateTowerUpgradeRow(plot, i, i == plots.PlotCount - 1)
                     : CreateTowerPlotRow(plot, i, i == plots.PlotCount - 1));
             }
+        }
+
+        private void CreateBearTrapPlacementRow()
+        {
+            if (bearTrapDefinition == null)
+            {
+                return;
+            }
+
+            var rowObject = new GameObject("BearTrapPlacementRow", typeof(RectTransform), typeof(HorizontalLayoutGroup), typeof(ContentSizeFitter));
+            rowObject.transform.SetParent(rowRoot, false);
+            ConfigureRowLayout(rowObject, 0f, 35f);
+
+            var nameText = CreateText("Name", rowObject.transform, 16, TextAlignmentOptions.Left);
+            ConfigureLayoutElement(nameText.gameObject, 150f, 0f);
+
+            var detailText = CreateText("Details", rowObject.transform, 16, TextAlignmentOptions.Left);
+            ConfigureLayoutElement(detailText.gameObject, 425f, 0f);
+            var button = CreateButton("BearTrapButton", rowObject.transform, "Place", 100f, 18);
+
+            var row = new ActionRow(
+                rowObject,
+                nameText,
+                detailText,
+                button,
+                () => bearTrapDefinition.DisplayName,
+                () => "Free | Outside ground | 1x1",
+                () => "Place",
+                () => bearTrapPlacementController != null && bearTrapDefinition.IsValid,
+                BeginBearTrapPlacement,
+                Refresh,
+                FlashButton);
+            row.Refresh();
+            rows.Add(row);
+        }
+
+        private bool BeginBearTrapPlacement()
+        {
+            if (bearTrapPlacementController == null || bearTrapDefinition == null)
+            {
+                return false;
+            }
+
+            if (!bearTrapPlacementController.BeginPlacement(bearTrapDefinition))
+            {
+                return false;
+            }
+
+            menuController?.HideMenuForPlacement();
+            return true;
         }
 
         private ActionRow CreateTowerPlotRow(TowerPlot plot, int plotIndex, bool endsBarrierGroup)

--- a/Assets/_Project/Scripts/_Project.Gameplay/UI/UpgradeMenuListView.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/UI/UpgradeMenuListView.cs
@@ -26,8 +26,12 @@ namespace Castlebound.Gameplay.UI
         [SerializeField] private FeedbackEventChannel feedbackChannel;
         [SerializeField] private InventoryStateComponent inventorySource;
         [SerializeField] private TowerBuildController towerBuildController;
+        [SerializeField] private UpgradeMenuTab activeTab = UpgradeMenuTab.Castle;
 
         private readonly List<ActionRow> rows = new List<ActionRow>();
+        private RectTransform rowRoot;
+        private UpgradeMenuTabStrip tabStrip;
+
         private static readonly TowerUpgradeTrack[] TowerUpgradeTracks =
         {
             TowerUpgradeTrack.Damage,
@@ -35,6 +39,8 @@ namespace Castlebound.Gameplay.UI
             TowerUpgradeTrack.Health,
             TowerUpgradeTrack.Range
         };
+
+        public UpgradeMenuTab ActiveTab => activeTab;
 
         private void OnEnable()
         {
@@ -64,6 +70,8 @@ namespace Castlebound.Gameplay.UI
         public void Refresh()
         {
             EnsureContentRoot();
+            EnsureTabControls();
+            EnsureRowRoot();
             ClearRows();
 
             var controllers = FindObjectsOfType<BarrierUpgradeController>();
@@ -86,9 +94,17 @@ namespace Castlebound.Gameplay.UI
                     controller.SetFeedbackChannel(feedbackChannel);
                 }
 
-                rows.Add(CreateBarrierUpgradeRow(controller));
-                CreateTowerPlotRows(controller);
+                if (activeTab == UpgradeMenuTab.Castle)
+                {
+                    rows.Add(CreateBarrierUpgradeRow(controller));
+                }
+                else
+                {
+                    CreateTowerPlotRows(controller);
+                }
             }
+
+            RefreshTabButtons();
         }
 
         public void SetContentRoot(RectTransform root)
@@ -99,6 +115,17 @@ namespace Castlebound.Gameplay.UI
         public void SetTowerBuildController(TowerBuildController controller)
         {
             towerBuildController = controller;
+        }
+
+        public void SetActiveTab(UpgradeMenuTab tab)
+        {
+            if (activeTab == tab)
+            {
+                return;
+            }
+
+            activeTab = tab;
+            Refresh();
         }
 
         private void ResolveReferences()
@@ -176,18 +203,60 @@ namespace Castlebound.Gameplay.UI
             fitter.horizontalFit = ContentSizeFitter.FitMode.Unconstrained;
         }
 
+        private void EnsureTabControls()
+        {
+            if (contentRoot == null)
+            {
+                return;
+            }
+
+            if (tabStrip == null)
+            {
+                tabStrip = new UpgradeMenuTabStrip(CreateButton, SetActiveTab);
+            }
+
+            tabStrip.Ensure(contentRoot);
+            RefreshTabButtons();
+        }
+
+        private void RefreshTabButtons()
+        {
+            tabStrip?.Refresh(activeTab, normalButtonColor, hoverButtonColor);
+        }
+
+        private void EnsureRowRoot()
+        {
+            if (contentRoot == null || rowRoot != null)
+            {
+                return;
+            }
+
+            var rowObject = new GameObject("UpgradeMenuRows", typeof(RectTransform), typeof(VerticalLayoutGroup), typeof(ContentSizeFitter));
+            rowObject.transform.SetParent(contentRoot, false);
+            rowRoot = rowObject.GetComponent<RectTransform>();
+
+            var layout = rowObject.GetComponent<VerticalLayoutGroup>();
+            layout.spacing = 8f;
+            layout.childForceExpandHeight = false;
+            layout.childForceExpandWidth = true;
+
+            var fitter = rowObject.GetComponent<ContentSizeFitter>();
+            fitter.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
+            fitter.horizontalFit = ContentSizeFitter.FitMode.Unconstrained;
+        }
+
         private ActionRow CreateBarrierUpgradeRow(BarrierUpgradeController controller)
         {
             var rowObject = new GameObject("UpgradeRow", typeof(RectTransform), typeof(HorizontalLayoutGroup), typeof(ContentSizeFitter));
-            rowObject.transform.SetParent(contentRoot, false);
-            ConfigureRowLayout(rowObject, 0f, 28f);
+            rowObject.transform.SetParent(rowRoot, false);
+            ConfigureRowLayout(rowObject, 0f, 35f);
 
-            var nameText = CreateText("Name", rowObject.transform, 18, TextAlignmentOptions.Left);
-            ConfigureLayoutElement(nameText.gameObject, 150f, 0f);
+            var nameText = CreateText("Name", rowObject.transform, 22, TextAlignmentOptions.Left);
+            ConfigureLayoutElement(nameText.gameObject, 188f, 0f);
 
-            var detailText = CreateText("Details", rowObject.transform, 16, TextAlignmentOptions.Left);
-            ConfigureLayoutElement(detailText.gameObject, 340f, 0f);
-            var button = CreateButton("UpgradeButton", rowObject.transform, "Upgrade", 96f);
+            var detailText = CreateText("Details", rowObject.transform, 20, TextAlignmentOptions.Left);
+            ConfigureLayoutElement(detailText.gameObject, 425f, 0f);
+            var button = CreateButton("UpgradeButton", rowObject.transform, "Upgrade", 120f, 18);
 
             var row = new ActionRow(
                 rowObject,
@@ -245,22 +314,22 @@ namespace Castlebound.Gameplay.UI
         private ActionRow CreateTowerPlotRow(TowerPlot plot, int plotIndex, bool endsBarrierGroup)
         {
             var rowObject = new GameObject("TowerPlotRow", typeof(RectTransform), typeof(HorizontalLayoutGroup), typeof(ContentSizeFitter));
-            rowObject.transform.SetParent(contentRoot, false);
+            rowObject.transform.SetParent(rowRoot, false);
             if (endsBarrierGroup)
             {
                 var groupSpacing = rowObject.AddComponent<LayoutElement>();
-                groupSpacing.minHeight = 48f;
-                groupSpacing.preferredHeight = 48f;
+                groupSpacing.minHeight = 60f;
+                groupSpacing.preferredHeight = 60f;
             }
 
-            ConfigureRowLayout(rowObject, 42f, 28f);
+            ConfigureRowLayout(rowObject, 0f, 35f);
 
-            var nameText = CreateText("Name", rowObject.transform, 13, TextAlignmentOptions.Left);
-            ConfigureLayoutElement(nameText.gameObject, 120f, 0f);
+            var nameText = CreateText("Name", rowObject.transform, 16, TextAlignmentOptions.Left);
+            ConfigureLayoutElement(nameText.gameObject, 150f, 0f);
 
-            var detailText = CreateText("Details", rowObject.transform, 13, TextAlignmentOptions.Left);
-            ConfigureLayoutElement(detailText.gameObject, 340f, 0f);
-            var button = CreateButton("BuildButton", rowObject.transform, "Build", 80f);
+            var detailText = CreateText("Details", rowObject.transform, 16, TextAlignmentOptions.Left);
+            ConfigureLayoutElement(detailText.gameObject, 425f, 0f);
+            var button = CreateButton("BuildButton", rowObject.transform, "Build", 100f, 18);
 
             var row = new ActionRow(
                 rowObject,
@@ -281,21 +350,21 @@ namespace Castlebound.Gameplay.UI
         private ActionRow CreateTowerUpgradeRow(TowerPlot plot, int plotIndex, bool endsBarrierGroup)
         {
             var rowObject = new GameObject("TowerUpgradeRow", typeof(RectTransform), typeof(HorizontalLayoutGroup), typeof(ContentSizeFitter));
-            rowObject.transform.SetParent(contentRoot, false);
+            rowObject.transform.SetParent(rowRoot, false);
             if (endsBarrierGroup)
             {
                 var groupSpacing = rowObject.AddComponent<LayoutElement>();
-                groupSpacing.minHeight = 48f;
-                groupSpacing.preferredHeight = 48f;
+                groupSpacing.minHeight = 60f;
+                groupSpacing.preferredHeight = 60f;
             }
 
-            ConfigureRowLayout(rowObject, 42f, 10f);
+            ConfigureRowLayout(rowObject, 0f, 12f);
 
-            var nameText = CreateText("Name", rowObject.transform, 13, TextAlignmentOptions.Left);
-            ConfigureLayoutElement(nameText.gameObject, 120f, 0f);
+            var nameText = CreateText("Name", rowObject.transform, 16, TextAlignmentOptions.Left);
+            ConfigureLayoutElement(nameText.gameObject, 150f, 0f);
 
-            var detailText = CreateText("Details", rowObject.transform, 13, TextAlignmentOptions.Left);
-            ConfigureLayoutElement(detailText.gameObject, 260f, 0f);
+            var detailText = CreateText("Details", rowObject.transform, 16, TextAlignmentOptions.Left);
+            ConfigureLayoutElement(detailText.gameObject, 325f, 0f);
 
             var upgradeController = GetTowerUpgradeController(plot);
             var bindings = new List<TowerUpgradeButtonBinding>();
@@ -324,7 +393,7 @@ namespace Castlebound.Gameplay.UI
                     continue;
                 }
 
-                var trackButton = CreateButton($"{track}Button", rowObject.transform, GetTrackLabel(track), 68f, 13);
+                var trackButton = CreateButton($"{track}Button", rowObject.transform, GetTrackLabel(track), 85f, 16);
                 var capturedTrack = track;
                 trackButton.onClick.AddListener(() =>
                 {
@@ -460,10 +529,10 @@ namespace Castlebound.Gameplay.UI
             textRect.offsetMax = Vector2.zero;
 
             var rect = go.GetComponent<RectTransform>();
-            rect.sizeDelta = new Vector2(width, 28f);
+            rect.sizeDelta = new Vector2(width, 35f);
             var layout = go.AddComponent<LayoutElement>();
             layout.preferredWidth = width;
-            layout.preferredHeight = 28f;
+            layout.preferredHeight = 35f;
             layout.flexibleWidth = 0f;
             layout.flexibleHeight = 0f;
 

--- a/Assets/_Project/Scripts/_Project.Gameplay/UI/UpgradeMenuTab.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/UI/UpgradeMenuTab.cs
@@ -1,0 +1,8 @@
+namespace Castlebound.Gameplay.UI
+{
+    public enum UpgradeMenuTab
+    {
+        Castle = 0,
+        Defense = 1
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/UI/UpgradeMenuTab.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/UI/UpgradeMenuTab.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1d51de1b28ef4699854afbbd92b3a6f8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/_Project.Gameplay/UI/UpgradeMenuTabStrip.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/UI/UpgradeMenuTabStrip.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Castlebound.Gameplay.UI
+{
+    public sealed class UpgradeMenuTabStrip
+    {
+        private readonly Func<string, Transform, string, float, int, Button> createButton;
+        private readonly Action<UpgradeMenuTab> selectTab;
+        private readonly List<TabBinding> tabs = new List<TabBinding>();
+
+        private RectTransform root;
+
+        public UpgradeMenuTabStrip(
+            Func<string, Transform, string, float, int, Button> createButton,
+            Action<UpgradeMenuTab> selectTab)
+        {
+            this.createButton = createButton;
+            this.selectTab = selectTab;
+        }
+
+        public RectTransform Root => root;
+
+        public void Ensure(RectTransform parent)
+        {
+            if (parent == null || root != null)
+            {
+                return;
+            }
+
+            var tabObject = new GameObject("UpgradeMenuTabs", typeof(RectTransform), typeof(HorizontalLayoutGroup), typeof(ContentSizeFitter));
+            tabObject.transform.SetParent(parent, false);
+            root = tabObject.GetComponent<RectTransform>();
+
+            var layout = tabObject.GetComponent<HorizontalLayoutGroup>();
+            layout.spacing = 12f;
+            layout.childAlignment = TextAnchor.MiddleLeft;
+            layout.childForceExpandHeight = false;
+            layout.childForceExpandWidth = false;
+
+            var fitter = tabObject.GetComponent<ContentSizeFitter>();
+            fitter.horizontalFit = ContentSizeFitter.FitMode.PreferredSize;
+            fitter.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
+
+            AddTab("CastleTab", "Castle", UpgradeMenuTab.Castle);
+            AddTab("DefenseTab", "Defense", UpgradeMenuTab.Defense);
+        }
+
+        public void Refresh(UpgradeMenuTab activeTab, Color normalColor, Color activeColor)
+        {
+            for (int i = 0; i < tabs.Count; i++)
+            {
+                var tab = tabs[i];
+                if (tab.Button == null)
+                {
+                    continue;
+                }
+
+                var isActive = tab.Tab == activeTab;
+                var image = tab.Button.GetComponent<Image>();
+                if (image != null)
+                {
+                    image.color = isActive ? activeColor : normalColor;
+                }
+            }
+        }
+
+        private void AddTab(string name, string label, UpgradeMenuTab tab)
+        {
+            var button = createButton.Invoke(name, root, label, 140f, 18);
+            button.onClick.AddListener(() => selectTab.Invoke(tab));
+            tabs.Add(new TabBinding(button, tab));
+        }
+
+        private readonly struct TabBinding
+        {
+            public TabBinding(Button button, UpgradeMenuTab tab)
+            {
+                Button = button;
+                Tab = tab;
+            }
+
+            public Button Button { get; }
+            public UpgradeMenuTab Tab { get; }
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/UI/UpgradeMenuTabStrip.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/UI/UpgradeMenuTabStrip.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7fcf3d7a8c784c49b6a5b9c0e99d4e58
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/_Project.Gameplay/World/Placement/BearTrapVisualState.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/World/Placement/BearTrapVisualState.cs
@@ -1,0 +1,64 @@
+using UnityEngine;
+
+namespace Castlebound.Gameplay.World.Placement
+{
+    public class BearTrapVisualState : MonoBehaviour
+    {
+        private static readonly int CloseTrigger = Animator.StringToHash("Close");
+
+        [SerializeField] private SpriteRenderer visualRenderer;
+        [SerializeField] private Sprite openSprite;
+        [SerializeField] private Sprite closedSprite;
+        [SerializeField] private Animator animator;
+        [SerializeField] private string closeTriggerName = "Close";
+
+        public Sprite OpenSprite
+        {
+            get => openSprite;
+            set => openSprite = value;
+        }
+
+        public Sprite ClosedSprite
+        {
+            get => closedSprite;
+            set => closedSprite = value;
+        }
+
+        private void Awake()
+        {
+            if (visualRenderer == null)
+            {
+                visualRenderer = GetComponentInChildren<SpriteRenderer>();
+            }
+
+            if (animator == null)
+            {
+                animator = GetComponentInChildren<Animator>();
+            }
+
+            ApplyOpenVisual();
+        }
+
+        public void ApplyOpenVisual()
+        {
+            if (visualRenderer != null && openSprite != null)
+            {
+                visualRenderer.sprite = openSprite;
+            }
+        }
+
+        public void ApplyClosedVisual()
+        {
+            if (animator != null)
+            {
+                animator.SetTrigger(string.IsNullOrWhiteSpace(closeTriggerName) ? CloseTrigger : Animator.StringToHash(closeTriggerName));
+                return;
+            }
+
+            if (visualRenderer != null && closedSprite != null)
+            {
+                visualRenderer.sprite = closedSprite;
+            }
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/World/Placement/BearTrapVisualState.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/World/Placement/BearTrapVisualState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3a98ab4f8e5647088ef3b760f1b69710
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/_Project.Gameplay/World/Placement/WorldPlaceablePlacementController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/World/Placement/WorldPlaceablePlacementController.cs
@@ -1,0 +1,275 @@
+using Castlebound.Gameplay.Castle;
+using TMPro;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.InputSystem;
+using UnityEngine.UI;
+
+namespace Castlebound.Gameplay.World.Placement
+{
+    public class WorldPlaceablePlacementController : MonoBehaviour
+    {
+        [SerializeField] private PlaceableObjectDefinition defaultPlaceable;
+        [SerializeField] private Grid worldGrid;
+        [SerializeField] private Camera worldCamera;
+        [SerializeField] private Transform placedParent;
+        [SerializeField] private Transform uiParent;
+        [SerializeField] private Button selectButton;
+        [SerializeField] private SpriteRenderer previewRenderer;
+        [SerializeField] private Sprite placeholderPreviewSprite;
+        [SerializeField] private PlaceablePlacementSurface currentSurface = PlaceablePlacementSurface.OutsideGround;
+        [SerializeField] private float gridCellSize = 1f;
+        [SerializeField] private Color validPreviewColor = new Color(0.35f, 1f, 0.35f, 0.55f);
+        [SerializeField] private Color invalidPreviewColor = new Color(1f, 0.25f, 0.2f, 0.55f);
+
+        private readonly CastleOccupancyMap occupancy = new CastleOccupancyMap();
+        private PlaceableObjectDefinition selectedPlaceable;
+
+        public bool HasSelection => selectedPlaceable != null;
+
+        public PlaceableObjectDefinition SelectedPlaceable => selectedPlaceable;
+
+        public PlaceableObjectDefinition DefaultPlaceable => defaultPlaceable;
+
+        private void Awake()
+        {
+            ResolveReferences();
+            EnsureSelectButton();
+            EnsurePreviewRenderer();
+        }
+
+        private void OnEnable()
+        {
+            if (selectButton != null)
+            {
+                selectButton.onClick.AddListener(SelectDefaultPlaceable);
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (selectButton != null)
+            {
+                selectButton.onClick.RemoveListener(SelectDefaultPlaceable);
+            }
+        }
+
+        private void Update()
+        {
+            if (selectedPlaceable == null)
+            {
+                SetPreviewActive(false);
+                return;
+            }
+
+            if (!TryGetPointerWorldPosition(out var worldPosition))
+            {
+                SetPreviewActive(false);
+                return;
+            }
+
+            var snapped = WorldPlaceablePlacementRules.SnapToGrid(worldPosition, gridCellSize);
+            var canPlace = CanPlaceSelectedAt(snapped);
+            UpdatePreview(snapped, canPlace);
+
+            if (WasPrimaryPointerPressedThisFrame() && !IsPointerOverUi())
+            {
+                TryPlaceSelectedAt(snapped);
+            }
+        }
+
+        public void SelectDefaultPlaceable()
+        {
+            if (defaultPlaceable != null && defaultPlaceable.IsValid)
+            {
+                selectedPlaceable = defaultPlaceable;
+            }
+        }
+
+        public bool CanPlaceSelectedAt(Vector2 snappedWorldPosition)
+        {
+            return WorldPlaceablePlacementRules.CanPlaceAt(
+                selectedPlaceable,
+                snappedWorldPosition,
+                currentSurface,
+                occupancy);
+        }
+
+        public bool TryPlaceSelectedAt(Vector2 snappedWorldPosition)
+        {
+            if (!CanPlaceSelectedAt(snappedWorldPosition))
+            {
+                return false;
+            }
+
+            var instance = Instantiate(selectedPlaceable.Prefab, snappedWorldPosition, Quaternion.identity, placedParent);
+            instance.name = selectedPlaceable.DisplayName;
+            occupancy.Occupy(snappedWorldPosition, selectedPlaceable.Footprint);
+            return true;
+        }
+
+        private void ResolveReferences()
+        {
+            if (worldGrid == null)
+            {
+                worldGrid = FindObjectOfType<Grid>();
+            }
+
+            if (worldCamera == null)
+            {
+                worldCamera = Camera.main;
+            }
+
+            if (placedParent == null)
+            {
+                placedParent = transform;
+            }
+
+            if (uiParent == null)
+            {
+                var canvas = FindObjectOfType<Canvas>();
+                if (canvas != null)
+                {
+                    uiParent = canvas.transform;
+                }
+            }
+
+            if (worldGrid != null)
+            {
+                gridCellSize = Mathf.Max(0.01f, worldGrid.cellSize.x);
+            }
+        }
+
+        private void EnsureSelectButton()
+        {
+            if (selectButton != null || uiParent == null)
+            {
+                return;
+            }
+
+            var buttonObject = new GameObject("BearTrapPlaceButton", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image), typeof(Button));
+            buttonObject.transform.SetParent(uiParent, false);
+
+            var rect = buttonObject.GetComponent<RectTransform>();
+            rect.anchorMin = new Vector2(0f, 1f);
+            rect.anchorMax = new Vector2(0f, 1f);
+            rect.pivot = new Vector2(0f, 1f);
+            rect.anchoredPosition = new Vector2(24f, -96f);
+            rect.sizeDelta = new Vector2(148f, 42f);
+
+            var image = buttonObject.GetComponent<Image>();
+            image.color = new Color(0.12f, 0.12f, 0.12f, 0.9f);
+
+            selectButton = buttonObject.GetComponent<Button>();
+
+            var labelObject = new GameObject("Label", typeof(RectTransform), typeof(TextMeshProUGUI));
+            labelObject.transform.SetParent(buttonObject.transform, false);
+
+            var labelRect = labelObject.GetComponent<RectTransform>();
+            labelRect.anchorMin = Vector2.zero;
+            labelRect.anchorMax = Vector2.one;
+            labelRect.offsetMin = Vector2.zero;
+            labelRect.offsetMax = Vector2.zero;
+
+            var label = labelObject.GetComponent<TextMeshProUGUI>();
+            label.text = "Bear Trap";
+            label.fontSize = 16;
+            label.alignment = TextAlignmentOptions.Center;
+            label.color = Color.white;
+        }
+
+        private void EnsurePreviewRenderer()
+        {
+            if (previewRenderer != null)
+            {
+                return;
+            }
+
+            var previewObject = new GameObject("BearTrapPlacementPreview", typeof(SpriteRenderer));
+            previewObject.transform.SetParent(transform, false);
+            previewRenderer = previewObject.GetComponent<SpriteRenderer>();
+            previewRenderer.sprite = placeholderPreviewSprite;
+            previewRenderer.sortingOrder = 25;
+            SetPreviewActive(false);
+        }
+
+        private bool TryGetPointerWorldPosition(out Vector2 worldPosition)
+        {
+            worldPosition = default;
+
+            if (worldCamera == null)
+            {
+                return false;
+            }
+
+            Vector2 screenPosition;
+            if (Touchscreen.current != null && Touchscreen.current.primaryTouch.press.isPressed)
+            {
+                screenPosition = Touchscreen.current.primaryTouch.position.ReadValue();
+            }
+            else if (Mouse.current != null)
+            {
+                screenPosition = Mouse.current.position.ReadValue();
+            }
+            else
+            {
+                return false;
+            }
+
+            var world = worldCamera.ScreenToWorldPoint(screenPosition);
+            worldPosition = new Vector2(world.x, world.y);
+            return true;
+        }
+
+        private static bool WasPrimaryPointerPressedThisFrame()
+        {
+            return (Mouse.current != null && Mouse.current.leftButton.wasPressedThisFrame)
+                || (Touchscreen.current != null && Touchscreen.current.primaryTouch.press.wasPressedThisFrame);
+        }
+
+        private static bool IsPointerOverUi()
+        {
+            return EventSystem.current != null && EventSystem.current.IsPointerOverGameObject();
+        }
+
+        private void UpdatePreview(Vector2 snappedPosition, bool canPlace)
+        {
+            if (previewRenderer == null)
+            {
+                return;
+            }
+
+            previewRenderer.transform.position = snappedPosition;
+            previewRenderer.color = canPlace ? validPreviewColor : invalidPreviewColor;
+            previewRenderer.sprite = ResolvePreviewSprite();
+            SetPreviewActive(true);
+        }
+
+        private Sprite ResolvePreviewSprite()
+        {
+            if (placeholderPreviewSprite != null)
+            {
+                return placeholderPreviewSprite;
+            }
+
+            if (selectedPlaceable != null && selectedPlaceable.Prefab != null)
+            {
+                var renderer = selectedPlaceable.Prefab.GetComponentInChildren<SpriteRenderer>(true);
+                if (renderer != null)
+                {
+                    return renderer.sprite;
+                }
+            }
+
+            return null;
+        }
+
+        private void SetPreviewActive(bool active)
+        {
+            if (previewRenderer != null)
+            {
+                previewRenderer.gameObject.SetActive(active);
+            }
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/World/Placement/WorldPlaceablePlacementController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/World/Placement/WorldPlaceablePlacementController.cs
@@ -1,9 +1,7 @@
 using Castlebound.Gameplay.Castle;
-using TMPro;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.InputSystem;
-using UnityEngine.UI;
 
 namespace Castlebound.Gameplay.World.Placement
 {
@@ -13,8 +11,6 @@ namespace Castlebound.Gameplay.World.Placement
         [SerializeField] private Grid worldGrid;
         [SerializeField] private Camera worldCamera;
         [SerializeField] private Transform placedParent;
-        [SerializeField] private Transform uiParent;
-        [SerializeField] private Button selectButton;
         [SerializeField] private SpriteRenderer previewRenderer;
         [SerializeField] private Sprite placeholderPreviewSprite;
         [SerializeField] private PlaceablePlacementSurface currentSurface = PlaceablePlacementSurface.OutsideGround;
@@ -34,24 +30,7 @@ namespace Castlebound.Gameplay.World.Placement
         private void Awake()
         {
             ResolveReferences();
-            EnsureSelectButton();
             EnsurePreviewRenderer();
-        }
-
-        private void OnEnable()
-        {
-            if (selectButton != null)
-            {
-                selectButton.onClick.AddListener(SelectDefaultPlaceable);
-            }
-        }
-
-        private void OnDisable()
-        {
-            if (selectButton != null)
-            {
-                selectButton.onClick.RemoveListener(SelectDefaultPlaceable);
-            }
         }
 
         private void Update()
@@ -80,10 +59,18 @@ namespace Castlebound.Gameplay.World.Placement
 
         public void SelectDefaultPlaceable()
         {
-            if (defaultPlaceable != null && defaultPlaceable.IsValid)
+            BeginPlacement(defaultPlaceable);
+        }
+
+        public bool BeginPlacement(PlaceableObjectDefinition definition)
+        {
+            if (definition == null || !definition.IsValid)
             {
-                selectedPlaceable = defaultPlaceable;
+                return false;
             }
+
+            selectedPlaceable = definition;
+            return true;
         }
 
         public bool CanPlaceSelectedAt(Vector2 snappedWorldPosition)
@@ -125,57 +112,10 @@ namespace Castlebound.Gameplay.World.Placement
                 placedParent = transform;
             }
 
-            if (uiParent == null)
-            {
-                var canvas = FindObjectOfType<Canvas>();
-                if (canvas != null)
-                {
-                    uiParent = canvas.transform;
-                }
-            }
-
             if (worldGrid != null)
             {
                 gridCellSize = Mathf.Max(0.01f, worldGrid.cellSize.x);
             }
-        }
-
-        private void EnsureSelectButton()
-        {
-            if (selectButton != null || uiParent == null)
-            {
-                return;
-            }
-
-            var buttonObject = new GameObject("BearTrapPlaceButton", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image), typeof(Button));
-            buttonObject.transform.SetParent(uiParent, false);
-
-            var rect = buttonObject.GetComponent<RectTransform>();
-            rect.anchorMin = new Vector2(0f, 1f);
-            rect.anchorMax = new Vector2(0f, 1f);
-            rect.pivot = new Vector2(0f, 1f);
-            rect.anchoredPosition = new Vector2(24f, -96f);
-            rect.sizeDelta = new Vector2(148f, 42f);
-
-            var image = buttonObject.GetComponent<Image>();
-            image.color = new Color(0.12f, 0.12f, 0.12f, 0.9f);
-
-            selectButton = buttonObject.GetComponent<Button>();
-
-            var labelObject = new GameObject("Label", typeof(RectTransform), typeof(TextMeshProUGUI));
-            labelObject.transform.SetParent(buttonObject.transform, false);
-
-            var labelRect = labelObject.GetComponent<RectTransform>();
-            labelRect.anchorMin = Vector2.zero;
-            labelRect.anchorMax = Vector2.one;
-            labelRect.offsetMin = Vector2.zero;
-            labelRect.offsetMax = Vector2.zero;
-
-            var label = labelObject.GetComponent<TextMeshProUGUI>();
-            label.text = "Bear Trap";
-            label.fontSize = 16;
-            label.alignment = TextAlignmentOptions.Center;
-            label.color = Color.white;
         }
 
         private void EnsurePreviewRenderer()

--- a/Assets/_Project/Scripts/_Project.Gameplay/World/Placement/WorldPlaceablePlacementController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/World/Placement/WorldPlaceablePlacementController.cs
@@ -1,3 +1,4 @@
+using Castlebound.Gameplay.AI;
 using Castlebound.Gameplay.Castle;
 using Castlebound.Gameplay.Input;
 using System;
@@ -15,6 +16,7 @@ namespace Castlebound.Gameplay.World.Placement
         [SerializeField] private Camera worldCamera;
         [SerializeField] private Transform placedParent;
         [SerializeField] private Transform uiParent;
+        [SerializeField] private Collider2D castleRegionCollider;
         [SerializeField] private TouchAimAttackZone touchAimAttackZone;
         [SerializeField] private PlayerFireInputController playerFireInputController;
         [SerializeField] private PlayerController playerController;
@@ -23,6 +25,7 @@ namespace Castlebound.Gameplay.World.Placement
         [SerializeField] private Button confirmButton;
         [SerializeField] private Button cancelButton;
         [SerializeField] private PlaceablePlacementSurface currentSurface = PlaceablePlacementSurface.OutsideGround;
+        [SerializeField] private LayerMask placementBlockingLayers;
         [SerializeField] private float gridCellSize = 1f;
         [SerializeField] private Color validPreviewColor = new Color(0.35f, 1f, 0.35f, 0.55f);
         [SerializeField] private Color invalidPreviewColor = new Color(1f, 0.25f, 0.2f, 0.55f);
@@ -172,10 +175,26 @@ namespace Castlebound.Gameplay.World.Placement
 
         public bool CanPlaceSelectedAt(Vector2 snappedWorldPosition)
         {
+            if (selectedPlaceable == null)
+            {
+                return false;
+            }
+
+            var availableSurface = WorldPlaceablePlacementRules.ResolveAvailableSurface(
+                snappedWorldPosition,
+                selectedPlaceable.Footprint,
+                currentSurface,
+                castleRegionCollider);
+
+            if (IsFootprintBlocked(snappedWorldPosition, selectedPlaceable.Footprint))
+            {
+                return false;
+            }
+
             return WorldPlaceablePlacementRules.CanPlaceAt(
                 selectedPlaceable,
                 snappedWorldPosition,
-                currentSurface,
+                availableSurface,
                 occupancy);
         }
 
@@ -219,6 +238,11 @@ namespace Castlebound.Gameplay.World.Placement
                 }
             }
 
+            if (castleRegionCollider == null)
+            {
+                castleRegionCollider = ResolveCastleRegionCollider();
+            }
+
             if (touchAimAttackZone == null)
             {
                 touchAimAttackZone = FindObjectOfType<TouchAimAttackZone>();
@@ -237,6 +261,11 @@ namespace Castlebound.Gameplay.World.Placement
             if (worldGrid != null)
             {
                 gridCellSize = Mathf.Max(0.01f, worldGrid.cellSize.x);
+            }
+
+            if (placementBlockingLayers.value == 0)
+            {
+                placementBlockingLayers = LayerMask.GetMask("Walls", "Barriers");
             }
         }
 
@@ -368,6 +397,48 @@ namespace Castlebound.Gameplay.World.Placement
             }
 
             playerController?.ClearAttackInputState();
+        }
+
+        private static Collider2D ResolveCastleRegionCollider()
+        {
+            var detector = CastleRegionDetector.Instance != null
+                ? CastleRegionDetector.Instance
+                : FindObjectOfType<CastleRegionDetector>();
+            if (detector != null)
+            {
+                return detector.GetComponent<Collider2D>();
+            }
+
+            var tracker = FindObjectOfType<CastleRegionTracker>();
+            if (tracker != null)
+            {
+                return tracker.GetComponent<Collider2D>();
+            }
+
+            var regionObject = GameObject.Find("CastleRegion");
+            return regionObject != null ? regionObject.GetComponent<Collider2D>() : null;
+        }
+
+        private bool IsFootprintBlocked(Vector2 snappedWorldPosition, GridFootprint footprint)
+        {
+            if (placementBlockingLayers.value == 0)
+            {
+                return false;
+            }
+
+            var origin = new Vector2Int(
+                Mathf.RoundToInt(snappedWorldPosition.x),
+                Mathf.RoundToInt(snappedWorldPosition.y));
+
+            foreach (var cell in footprint.EnumerateCells(origin))
+            {
+                if (Physics2D.OverlapPoint(new Vector2(cell.x, cell.y), placementBlockingLayers) != null)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private bool TryGetPointerScreenPosition(out Vector2 screenPosition)

--- a/Assets/_Project/Scripts/_Project.Gameplay/World/Placement/WorldPlaceablePlacementController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/World/Placement/WorldPlaceablePlacementController.cs
@@ -1,7 +1,10 @@
 using Castlebound.Gameplay.Castle;
+using Castlebound.Gameplay.Input;
+using System;
+using TMPro;
 using UnityEngine;
-using UnityEngine.EventSystems;
 using UnityEngine.InputSystem;
+using UnityEngine.UI;
 
 namespace Castlebound.Gameplay.World.Placement
 {
@@ -11,8 +14,14 @@ namespace Castlebound.Gameplay.World.Placement
         [SerializeField] private Grid worldGrid;
         [SerializeField] private Camera worldCamera;
         [SerializeField] private Transform placedParent;
+        [SerializeField] private Transform uiParent;
+        [SerializeField] private TouchAimAttackZone touchAimAttackZone;
+        [SerializeField] private PlayerFireInputController playerFireInputController;
+        [SerializeField] private PlayerController playerController;
         [SerializeField] private SpriteRenderer previewRenderer;
         [SerializeField] private Sprite placeholderPreviewSprite;
+        [SerializeField] private Button confirmButton;
+        [SerializeField] private Button cancelButton;
         [SerializeField] private PlaceablePlacementSurface currentSurface = PlaceablePlacementSurface.OutsideGround;
         [SerializeField] private float gridCellSize = 1f;
         [SerializeField] private Color validPreviewColor = new Color(0.35f, 1f, 0.35f, 0.55f);
@@ -20,8 +29,19 @@ namespace Castlebound.Gameplay.World.Placement
 
         private readonly CastleOccupancyMap occupancy = new CastleOccupancyMap();
         private PlaceableObjectDefinition selectedPlaceable;
+        private Vector2 currentPreviewPosition;
+        private Vector2 lockedPlacementPosition;
+        private bool hasPreviewTarget;
+        private bool hasLockedTarget;
+        private Action placementCanceled;
 
         public bool HasSelection => selectedPlaceable != null;
+
+        public bool IsPlacementActive => selectedPlaceable != null;
+
+        public bool HasLockedTarget => hasLockedTarget;
+
+        public Vector2 LockedPlacementPosition => lockedPlacementPosition;
 
         public PlaceableObjectDefinition SelectedPlaceable => selectedPlaceable;
 
@@ -31,6 +51,18 @@ namespace Castlebound.Gameplay.World.Placement
         {
             ResolveReferences();
             EnsurePreviewRenderer();
+            EnsurePlacementControls();
+            RefreshPlacementControls();
+        }
+
+        private void OnEnable()
+        {
+            HookPlacementControls();
+        }
+
+        private void OnDisable()
+        {
+            UnhookPlacementControls();
         }
 
         private void Update()
@@ -41,20 +73,36 @@ namespace Castlebound.Gameplay.World.Placement
                 return;
             }
 
-            if (!TryGetPointerWorldPosition(out var worldPosition))
+            if (worldCamera != null
+                && TryGetPointerScreenPosition(out var screenPosition)
+                && !IsPointerOverPlacementControls(screenPosition))
+            {
+                var worldPosition = ScreenToWorldPosition(screenPosition);
+                var snapped = WorldPlaceablePlacementRules.SnapToGrid(worldPosition, gridCellSize);
+                currentPreviewPosition = snapped;
+                hasPreviewTarget = true;
+
+                if (!hasLockedTarget)
+                {
+                    UpdatePreview(currentPreviewPosition, CanPlaceSelectedAt(currentPreviewPosition));
+                }
+
+                if (WasWorldLockRequested())
+                {
+                    LockPlacementTarget(currentPreviewPosition);
+                }
+            }
+
+            if (hasLockedTarget)
+            {
+                UpdatePreview(lockedPlacementPosition, CanPlaceSelectedAt(lockedPlacementPosition));
+            }
+            else if (!hasPreviewTarget)
             {
                 SetPreviewActive(false);
-                return;
             }
 
-            var snapped = WorldPlaceablePlacementRules.SnapToGrid(worldPosition, gridCellSize);
-            var canPlace = CanPlaceSelectedAt(snapped);
-            UpdatePreview(snapped, canPlace);
-
-            if (WasPrimaryPointerPressedThisFrame() && !IsPointerOverUi())
-            {
-                TryPlaceSelectedAt(snapped);
-            }
+            RefreshPlacementControls();
         }
 
         public void SelectDefaultPlaceable()
@@ -64,13 +112,62 @@ namespace Castlebound.Gameplay.World.Placement
 
         public bool BeginPlacement(PlaceableObjectDefinition definition)
         {
+            return BeginPlacement(definition, null);
+        }
+
+        public bool BeginPlacement(PlaceableObjectDefinition definition, Action onCanceled)
+        {
             if (definition == null || !definition.IsValid)
             {
                 return false;
             }
 
             selectedPlaceable = definition;
+            placementCanceled = onCanceled;
+            ClearTarget();
+            SetPlacementControlsActive(true);
             return true;
+        }
+
+        public void LockPlacementTarget(Vector2 snappedWorldPosition)
+        {
+            lockedPlacementPosition = snappedWorldPosition;
+            hasLockedTarget = true;
+            UpdatePreview(lockedPlacementPosition, CanPlaceSelectedAt(lockedPlacementPosition));
+            RefreshPlacementControls();
+        }
+
+        public bool ConfirmPlacement()
+        {
+            if (!hasLockedTarget)
+            {
+                return false;
+            }
+
+            if (!TryPlaceSelectedAt(lockedPlacementPosition))
+            {
+                RefreshPlacementControls();
+                return false;
+            }
+
+            ClearTarget();
+            RefreshPlacementControls();
+            return true;
+        }
+
+        public void CancelPlacement()
+        {
+            selectedPlaceable = null;
+            ClearTarget();
+            SetPreviewActive(false);
+            SetPlacementControlsActive(false);
+            ReleaseTouchAimAttackState();
+            ReleasePlayerFireInputState();
+            ReleasePlayerAttackInputState();
+
+            var callback = placementCanceled;
+            placementCanceled = null;
+            callback?.Invoke();
         }
 
         public bool CanPlaceSelectedAt(Vector2 snappedWorldPosition)
@@ -89,7 +186,8 @@ namespace Castlebound.Gameplay.World.Placement
                 return false;
             }
 
-            var instance = Instantiate(selectedPlaceable.Prefab, snappedWorldPosition, Quaternion.identity, placedParent);
+            var parent = placedParent != null ? placedParent : transform;
+            var instance = Instantiate(selectedPlaceable.Prefab, snappedWorldPosition, Quaternion.identity, parent);
             instance.name = selectedPlaceable.DisplayName;
             occupancy.Occupy(snappedWorldPosition, selectedPlaceable.Footprint);
             return true;
@@ -110,6 +208,30 @@ namespace Castlebound.Gameplay.World.Placement
             if (placedParent == null)
             {
                 placedParent = transform;
+            }
+
+            if (uiParent == null)
+            {
+                var canvas = FindObjectOfType<Canvas>();
+                if (canvas != null)
+                {
+                    uiParent = canvas.transform;
+                }
+            }
+
+            if (touchAimAttackZone == null)
+            {
+                touchAimAttackZone = FindObjectOfType<TouchAimAttackZone>();
+            }
+
+            if (playerFireInputController == null)
+            {
+                playerFireInputController = FindObjectOfType<PlayerFireInputController>();
+            }
+
+            if (playerController == null)
+            {
+                playerController = FindObjectOfType<PlayerController>();
             }
 
             if (worldGrid != null)
@@ -133,17 +255,128 @@ namespace Castlebound.Gameplay.World.Placement
             SetPreviewActive(false);
         }
 
-        private bool TryGetPointerWorldPosition(out Vector2 worldPosition)
+        private void EnsurePlacementControls()
         {
-            worldPosition = default;
-
-            if (worldCamera == null)
+            if (uiParent == null)
             {
-                return false;
+                return;
             }
 
-            Vector2 screenPosition;
-            if (Touchscreen.current != null && Touchscreen.current.primaryTouch.press.isPressed)
+            if (confirmButton == null)
+            {
+                confirmButton = CreatePlacementButton("BearTrapConfirmButton", "Confirm", new Vector2(-82f, 96f));
+            }
+
+            if (cancelButton == null)
+            {
+                cancelButton = CreatePlacementButton("BearTrapCancelButton", "Cancel", new Vector2(82f, 96f));
+            }
+
+            SetPlacementControlsActive(false);
+        }
+
+        private Button CreatePlacementButton(string name, string label, Vector2 anchoredPosition)
+        {
+            var buttonObject = new GameObject(name, typeof(RectTransform), typeof(CanvasRenderer), typeof(Image), typeof(Button));
+            buttonObject.transform.SetParent(uiParent, false);
+
+            var rect = buttonObject.GetComponent<RectTransform>();
+            rect.anchorMin = new Vector2(0.5f, 0f);
+            rect.anchorMax = new Vector2(0.5f, 0f);
+            rect.pivot = new Vector2(0.5f, 0f);
+            rect.anchoredPosition = anchoredPosition;
+            rect.sizeDelta = new Vector2(148f, 44f);
+
+            var image = buttonObject.GetComponent<Image>();
+            image.color = new Color(0.12f, 0.12f, 0.12f, 0.9f);
+
+            var textObject = new GameObject("Label", typeof(RectTransform), typeof(TextMeshProUGUI));
+            textObject.transform.SetParent(buttonObject.transform, false);
+
+            var textRect = textObject.GetComponent<RectTransform>();
+            textRect.anchorMin = Vector2.zero;
+            textRect.anchorMax = Vector2.one;
+            textRect.offsetMin = Vector2.zero;
+            textRect.offsetMax = Vector2.zero;
+
+            var text = textObject.GetComponent<TextMeshProUGUI>();
+            text.text = label;
+            text.fontSize = 18;
+            text.alignment = TextAlignmentOptions.Center;
+            text.color = Color.white;
+            text.raycastTarget = false;
+
+            return buttonObject.GetComponent<Button>();
+        }
+
+        private void HookPlacementControls()
+        {
+            if (confirmButton != null)
+            {
+                confirmButton.onClick.AddListener(OnConfirmClicked);
+            }
+
+            if (cancelButton != null)
+            {
+                cancelButton.onClick.AddListener(CancelPlacement);
+            }
+        }
+
+        private void UnhookPlacementControls()
+        {
+            if (confirmButton != null)
+            {
+                confirmButton.onClick.RemoveListener(OnConfirmClicked);
+            }
+
+            if (cancelButton != null)
+            {
+                cancelButton.onClick.RemoveListener(CancelPlacement);
+            }
+        }
+
+        private void OnConfirmClicked()
+        {
+            ConfirmPlacement();
+        }
+
+        private void ReleaseTouchAimAttackState()
+        {
+            if (touchAimAttackZone == null)
+            {
+                touchAimAttackZone = FindObjectOfType<TouchAimAttackZone>();
+            }
+
+            touchAimAttackZone?.SimulatePointerUp();
+        }
+
+        private void ReleasePlayerFireInputState()
+        {
+            if (playerFireInputController == null)
+            {
+                playerFireInputController = FindObjectOfType<PlayerFireInputController>();
+            }
+
+            playerFireInputController?.ClearHeldFire();
+        }
+
+        private void ReleasePlayerAttackInputState()
+        {
+            if (playerController == null)
+            {
+                playerController = FindObjectOfType<PlayerController>();
+            }
+
+            playerController?.ClearAttackInputState();
+        }
+
+        private bool TryGetPointerScreenPosition(out Vector2 screenPosition)
+        {
+            screenPosition = default;
+
+            if (Touchscreen.current != null
+                && (Touchscreen.current.primaryTouch.press.isPressed
+                    || Touchscreen.current.primaryTouch.press.wasReleasedThisFrame))
             {
                 screenPosition = Touchscreen.current.primaryTouch.position.ReadValue();
             }
@@ -156,20 +389,36 @@ namespace Castlebound.Gameplay.World.Placement
                 return false;
             }
 
-            var world = worldCamera.ScreenToWorldPoint(screenPosition);
-            worldPosition = new Vector2(world.x, world.y);
             return true;
         }
 
-        private static bool WasPrimaryPointerPressedThisFrame()
+        private Vector2 ScreenToWorldPosition(Vector2 screenPosition)
         {
-            return (Mouse.current != null && Mouse.current.leftButton.wasPressedThisFrame)
-                || (Touchscreen.current != null && Touchscreen.current.primaryTouch.press.wasPressedThisFrame);
+            var world = worldCamera.ScreenToWorldPoint(screenPosition);
+            return new Vector2(world.x, world.y);
         }
 
-        private static bool IsPointerOverUi()
+        private static bool WasWorldLockRequested()
         {
-            return EventSystem.current != null && EventSystem.current.IsPointerOverGameObject();
+            return (Mouse.current != null && Mouse.current.leftButton.wasPressedThisFrame)
+                || (Touchscreen.current != null && Touchscreen.current.primaryTouch.press.wasReleasedThisFrame);
+        }
+
+        private bool IsPointerOverPlacementControls(Vector2 screenPosition)
+        {
+            return IsScreenPositionInsideButton(confirmButton, screenPosition)
+                || IsScreenPositionInsideButton(cancelButton, screenPosition);
+        }
+
+        private bool IsScreenPositionInsideButton(Button button, Vector2 screenPosition)
+        {
+            if (button == null || !button.gameObject.activeInHierarchy)
+            {
+                return false;
+            }
+
+            return button.transform is RectTransform rectTransform
+                && RectTransformUtility.RectangleContainsScreenPoint(rectTransform, screenPosition);
         }
 
         private void UpdatePreview(Vector2 snappedPosition, bool canPlace)
@@ -209,6 +458,37 @@ namespace Castlebound.Gameplay.World.Placement
             if (previewRenderer != null)
             {
                 previewRenderer.gameObject.SetActive(active);
+            }
+        }
+
+        private void ClearTarget()
+        {
+            hasPreviewTarget = false;
+            hasLockedTarget = false;
+            currentPreviewPosition = default;
+            lockedPlacementPosition = default;
+        }
+
+        private void RefreshPlacementControls()
+        {
+            if (confirmButton != null)
+            {
+                confirmButton.interactable = IsPlacementActive
+                    && hasLockedTarget
+                    && CanPlaceSelectedAt(lockedPlacementPosition);
+            }
+        }
+
+        private void SetPlacementControlsActive(bool active)
+        {
+            if (confirmButton != null)
+            {
+                confirmButton.gameObject.SetActive(active);
+            }
+
+            if (cancelButton != null)
+            {
+                cancelButton.gameObject.SetActive(active);
             }
         }
     }

--- a/Assets/_Project/Scripts/_Project.Gameplay/World/Placement/WorldPlaceablePlacementController.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/World/Placement/WorldPlaceablePlacementController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0c5af0a1321b4ba9844194255614a28c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/_Project.Gameplay/World/Placement/WorldPlaceablePlacementRules.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/World/Placement/WorldPlaceablePlacementRules.cs
@@ -35,5 +35,41 @@ namespace Castlebound.Gameplay.World.Placement
 
             return !occupancy.IsAnyCellOccupied(snappedWorldPosition, definition.Footprint);
         }
+
+        public static PlaceablePlacementSurface ResolveAvailableSurface(
+            Vector2 snappedWorldPosition,
+            GridFootprint footprint,
+            PlaceablePlacementSurface fallbackSurface,
+            Collider2D castleRegion)
+        {
+            if (castleRegion == null || !footprint.IsValid)
+            {
+                return fallbackSurface;
+            }
+
+            foreach (var cell in EnumerateFootprintCells(snappedWorldPosition, footprint))
+            {
+                if (castleRegion.OverlapPoint(cell))
+                {
+                    return PlaceablePlacementSurface.CastleFloor;
+                }
+            }
+
+            return PlaceablePlacementSurface.OutsideGround;
+        }
+
+        private static System.Collections.Generic.IEnumerable<Vector2> EnumerateFootprintCells(
+            Vector2 snappedWorldPosition,
+            GridFootprint footprint)
+        {
+            var origin = new Vector2Int(
+                Mathf.RoundToInt(snappedWorldPosition.x),
+                Mathf.RoundToInt(snappedWorldPosition.y));
+
+            foreach (var cell in footprint.EnumerateCells(origin))
+            {
+                yield return new Vector2(cell.x, cell.y);
+            }
+        }
     }
 }

--- a/Assets/_Project/Scripts/_Project.Gameplay/World/Placement/WorldPlaceablePlacementRules.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/World/Placement/WorldPlaceablePlacementRules.cs
@@ -1,0 +1,39 @@
+using Castlebound.Gameplay.Castle;
+using UnityEngine;
+
+namespace Castlebound.Gameplay.World.Placement
+{
+    public static class WorldPlaceablePlacementRules
+    {
+        public static Vector2 SnapToGrid(Vector2 worldPosition, float cellSize = 1f)
+        {
+            if (cellSize <= 0f)
+            {
+                throw new System.ArgumentOutOfRangeException(nameof(cellSize), "Cell size must be positive.");
+            }
+
+            return new Vector2(
+                Mathf.Round(worldPosition.x / cellSize) * cellSize,
+                Mathf.Round(worldPosition.y / cellSize) * cellSize);
+        }
+
+        public static bool CanPlaceAt(
+            PlaceableObjectDefinition definition,
+            Vector2 snappedWorldPosition,
+            PlaceablePlacementSurface availableSurface,
+            CastleOccupancyMap occupancy)
+        {
+            if (definition == null || !definition.IsValid || occupancy == null)
+            {
+                return false;
+            }
+
+            if (definition.PlacementSurface != availableSurface)
+            {
+                return false;
+            }
+
+            return !occupancy.IsAnyCellOccupied(snappedWorldPosition, definition.Footprint);
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/World/Placement/WorldPlaceablePlacementRules.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/World/Placement/WorldPlaceablePlacementRules.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 961550f076cb493294998c2b36a73cb2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/EditMode/Player/PlayerAttackInputTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Player/PlayerAttackInputTests.cs
@@ -61,5 +61,24 @@ namespace Castlebound.Tests.Player
             Assert.DoesNotThrow(() => _controller.StopMovement(),
                 "StopMovement should not throw after unlocking.");
         }
+
+        [Test]
+        public void ClearAttackInputState_StopsHeldFireAndAttackLoop()
+        {
+            Object.DestroyImmediate(_controller);
+            var fireInput = _playerGo.AddComponent<PlayerFireInputController>();
+            var attackLoop = _playerGo.AddComponent<PlayerAttackLoop>();
+            _controller = _playerGo.AddComponent<PlayerController>();
+            fireInput.OnFirePressedStateChanged(true);
+            attackLoop.Tick(0f, 1.5f, true);
+
+            Assert.IsTrue(fireInput.IsFireHeld, "Precondition: fire should be held.");
+            Assert.IsTrue(attackLoop.IsSwingActive, "Precondition: attack loop should be active.");
+
+            _controller.ClearAttackInputState();
+
+            Assert.IsFalse(fireInput.IsFireHeld);
+            Assert.IsFalse(attackLoop.IsSwingActive);
+        }
     }
 }

--- a/Assets/_Project/_Tests/EditMode/UI/UpgradeMenuControllerTests.cs
+++ b/Assets/_Project/_Tests/EditMode/UI/UpgradeMenuControllerTests.cs
@@ -136,5 +136,42 @@ namespace Castlebound.Tests.UI
             Object.DestroyImmediate(menu);
             Object.DestroyImmediate(player);
         }
+
+        [Test]
+        public void HideMenuForPlacement_DoesNotStartWave_AndCanReopen()
+        {
+            var phase = new WavePhaseTracker();
+            var menu = new GameObject("Menu");
+            var root = new GameObject("MenuRoot", typeof(RectTransform));
+            var controller = menu.AddComponent<UpgradeMenuController>();
+
+            SetPrivateField(controller, "menuRoot", root.GetComponent<RectTransform>());
+            controller.SetPhaseTracker(phase);
+            controller.SetAutoOpenOnFirstPreWave(false);
+
+            phase.SetPhase(WavePhase.PreWave);
+            controller.ToggleMenu();
+            Assert.IsTrue(controller.IsMenuOpen, "Precondition: menu should open during pre-wave.");
+
+            controller.HideMenuForPlacement();
+
+            Assert.IsFalse(controller.IsMenuOpen);
+            Assert.That(phase.CurrentPhase, Is.EqualTo(WavePhase.PreWave), "Hiding for placement should not start the wave.");
+
+            controller.ReopenMenuAfterPlacement();
+
+            Assert.IsTrue(controller.IsMenuOpen);
+            Assert.That(phase.CurrentPhase, Is.EqualTo(WavePhase.PreWave));
+
+            Object.DestroyImmediate(menu);
+            Object.DestroyImmediate(root);
+        }
+
+        private static void SetPrivateField<T>(object target, string fieldName, T value)
+        {
+            var field = target.GetType().GetField(fieldName, System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            Assert.NotNull(field, $"Expected private field '{fieldName}' to exist.");
+            field.SetValue(target, value);
+        }
     }
 }

--- a/Assets/_Project/_Tests/EditMode/UI/UpgradeMenuListViewTowerRowsTests.cs
+++ b/Assets/_Project/_Tests/EditMode/UI/UpgradeMenuListViewTowerRowsTests.cs
@@ -26,12 +26,55 @@ namespace Castlebound.Tests.UI
             {
                 context.View.Refresh();
 
+                Assert.That(context.View.ActiveTab, Is.EqualTo(UpgradeMenuTab.Castle));
+                AssertTextExists(context.ContentRoot, "Castle");
+                AssertTextExists(context.ContentRoot, "Defense");
                 AssertTextExists(context.ContentRoot, "North Barrier");
                 AssertTextExists(context.ContentRoot, "Tier 0 | HP 10/10 | 20 Gold");
+                AssertTextDoesNotExist(context.ContentRoot, "- Left Plot");
+                AssertTextDoesNotExist(context.ContentRoot, "- Right Plot");
+            }
+            finally
+            {
+                context.Destroy();
+            }
+        }
+
+        [Test]
+        public void DefenseTab_RendersTowerPlotChildRows()
+        {
+            var context = CreateContext();
+
+            try
+            {
+                context.View.SetActiveTab(UpgradeMenuTab.Defense);
+
                 AssertTextExists(context.ContentRoot, "- Left Plot");
                 AssertTextExists(context.ContentRoot, "- Right Plot");
                 AssertTextExists(context.ContentRoot, "ArcherTower | HP 10 | DMG 3 | Build 50 Gold");
-                Assert.That(context.ContentRoot.GetComponentsInChildren<Button>(true).Length, Is.EqualTo(3));
+                AssertTextDoesNotExist(context.ContentRoot, "North Barrier");
+            }
+            finally
+            {
+                context.Destroy();
+            }
+        }
+
+        [Test]
+        public void DefenseTabButton_SwitchesActiveTab()
+        {
+            var context = CreateContext();
+
+            try
+            {
+                context.View.Refresh();
+                var defenseTab = FindButtonByLabel(context.ContentRoot, "Defense");
+
+                defenseTab.onClick.Invoke();
+
+                Assert.That(context.View.ActiveTab, Is.EqualTo(UpgradeMenuTab.Defense));
+                AssertTextExists(context.ContentRoot, "- Left Plot");
+                AssertTextDoesNotExist(context.ContentRoot, "North Barrier");
             }
             finally
             {
@@ -46,7 +89,7 @@ namespace Castlebound.Tests.UI
 
             try
             {
-                context.View.Refresh();
+                context.View.SetActiveTab(UpgradeMenuTab.Defense);
                 var buildButton = FindButtonByLabel(context.ContentRoot, "Build");
 
                 buildButton.onClick.Invoke();
@@ -71,9 +114,9 @@ namespace Castlebound.Tests.UI
 
             try
             {
-                context.View.Refresh();
+                context.View.SetActiveTab(UpgradeMenuTab.Defense);
 
-                AssertTextExists(context.ContentRoot, "North Barrier");
+                AssertTextDoesNotExist(context.ContentRoot, "North Barrier");
                 AssertTextExists(context.ContentRoot, "ArcherTower | HP 10/10 | DMG 3 | RATE 1 | RNG 5");
 
                 Assert.NotNull(FindButtonByLabel(context.ContentRoot, "DMG 10"));
@@ -101,7 +144,7 @@ namespace Castlebound.Tests.UI
 
             try
             {
-                context.View.Refresh();
+                context.View.SetActiveTab(UpgradeMenuTab.Defense);
                 var damageButton = FindButtonByLabel(context.ContentRoot, "DMG 10");
 
                 damageButton.onClick.Invoke();
@@ -129,7 +172,7 @@ namespace Castlebound.Tests.UI
 
             try
             {
-                context.View.Refresh();
+                context.View.SetActiveTab(UpgradeMenuTab.Defense);
 
                 var damageButton = FindButtonByLabel(context.ContentRoot, "DMG 10");
                 Assert.IsTrue(damageButton.interactable, "Tower upgrade buttons should use the build controller pre-wave tracker.");
@@ -335,6 +378,12 @@ namespace Castlebound.Tests.UI
         {
             var texts = root.GetComponentsInChildren<TextMeshProUGUI>(true);
             Assert.IsTrue(texts.Any(text => text.text == expected), $"Expected UI text '{expected}' was not found.");
+        }
+
+        private static void AssertTextDoesNotExist(Transform root, string unexpected)
+        {
+            var texts = root.GetComponentsInChildren<TextMeshProUGUI>(true);
+            Assert.IsFalse(texts.Any(text => text.text == unexpected), $"Unexpected UI text '{unexpected}' was found.");
         }
 
         private static Button FindButtonByLabel(Transform root, string label)

--- a/Assets/_Project/_Tests/EditMode/UI/UpgradeMenuListViewTowerRowsTests.cs
+++ b/Assets/_Project/_Tests/EditMode/UI/UpgradeMenuListViewTowerRowsTests.cs
@@ -6,6 +6,7 @@ using Castlebound.Gameplay.Inventory;
 using Castlebound.Gameplay.Spawning;
 using Castlebound.Gameplay.Tower;
 using Castlebound.Gameplay.UI;
+using Castlebound.Gameplay.World.Placement;
 using NUnit.Framework;
 using UnityEditor.SceneManagement;
 using TMPro;
@@ -49,6 +50,8 @@ namespace Castlebound.Tests.UI
             {
                 context.View.SetActiveTab(UpgradeMenuTab.Defense);
 
+                AssertTextExists(context.ContentRoot, "Bear Trap");
+                AssertTextExists(context.ContentRoot, "Free | Outside ground | 1x1");
                 AssertTextExists(context.ContentRoot, "- Left Plot");
                 AssertTextExists(context.ContentRoot, "- Right Plot");
                 AssertTextExists(context.ContentRoot, "ArcherTower | HP 10 | DMG 3 | Build 50 Gold");
@@ -75,6 +78,27 @@ namespace Castlebound.Tests.UI
                 Assert.That(context.View.ActiveTab, Is.EqualTo(UpgradeMenuTab.Defense));
                 AssertTextExists(context.ContentRoot, "- Left Plot");
                 AssertTextDoesNotExist(context.ContentRoot, "North Barrier");
+            }
+            finally
+            {
+                context.Destroy();
+            }
+        }
+
+        [Test]
+        public void BearTrapPlaceButton_StartsPlacementFromDefenseTab()
+        {
+            var context = CreateContext();
+
+            try
+            {
+                context.View.SetActiveTab(UpgradeMenuTab.Defense);
+                var placeButton = FindButtonByLabel(context.ContentRoot, "Place");
+
+                placeButton.onClick.Invoke();
+
+                Assert.IsTrue(context.PlacementController.HasSelection, "Bear Trap row should select the placeable placement controller.");
+                Assert.AreSame(context.BearTrapDefinition, context.PlacementController.SelectedPlaceable);
             }
             finally
             {
@@ -232,6 +256,10 @@ namespace Castlebound.Tests.UI
                 var field = typeof(UpgradeMenuListView).GetField("towerBuildController", BindingFlags.NonPublic | BindingFlags.Instance);
                 Assert.NotNull(field, "UpgradeMenuListView should serialize its TowerBuildController reference.");
                 Assert.AreSame(controller, field.GetValue(view), "UpgradeMenuListView should be wired to the scene TowerBuildController.");
+
+                var placementField = typeof(UpgradeMenuListView).GetField("bearTrapPlacementController", BindingFlags.NonPublic | BindingFlags.Instance);
+                Assert.NotNull(placementField, "UpgradeMenuListView should serialize its Bear Trap placement controller reference.");
+                Assert.NotNull(placementField.GetValue(view), "MainPrototype should wire the Bear Trap placement controller into the upgrade menu.");
             }
             finally
             {
@@ -295,6 +323,18 @@ namespace Castlebound.Tests.UI
             towerController.TowerParent = towerParent;
             view.SetTowerBuildController(towerController);
 
+            var placementRoot = new GameObject("WorldPlaceablePlacementController");
+            var placementController = placementRoot.AddComponent<WorldPlaceablePlacementController>();
+            var bearTrapDefinition = ScriptableObject.CreateInstance<PlaceableObjectDefinition>();
+            bearTrapDefinition.Id = "defense.bear_trap";
+            bearTrapDefinition.DisplayName = "Bear Trap";
+            bearTrapDefinition.Category = PlaceableObjectCategory.Defense;
+            bearTrapDefinition.PlacementSurface = PlaceablePlacementSurface.OutsideGround;
+            bearTrapDefinition.SetFootprint(GridFootprint.OneByOne);
+            bearTrapDefinition.Prefab = new GameObject("BearTrapPrefab");
+            view.SetBearTrapPlacementController(placementController);
+            view.SetBearTrapDefinition(bearTrapDefinition);
+
             return new TestContext(
                 viewRoot,
                 contentRoot.gameObject,
@@ -307,6 +347,9 @@ namespace Castlebound.Tests.UI
                 towerConfig,
                 towerPrefab,
                 towerParent,
+                placementRoot,
+                placementController,
+                bearTrapDefinition,
                 inventory,
                 phase);
         }
@@ -443,6 +486,7 @@ namespace Castlebound.Tests.UI
             private readonly GameObject towerRoot;
             private readonly TowerBuildConfig towerConfig;
             private readonly GameObject towerPrefab;
+            private readonly GameObject placementRoot;
 
             public TestContext(
                 GameObject viewRoot,
@@ -456,6 +500,9 @@ namespace Castlebound.Tests.UI
                 TowerBuildConfig towerConfig,
                 GameObject towerPrefab,
                 Transform towerParent,
+                GameObject placementRoot,
+                WorldPlaceablePlacementController placementController,
+                PlaceableObjectDefinition bearTrapDefinition,
                 InventoryState inventory,
                 WavePhaseTracker phase)
             {
@@ -470,6 +517,9 @@ namespace Castlebound.Tests.UI
                 this.towerConfig = towerConfig;
                 this.towerPrefab = towerPrefab;
                 TowerParent = towerParent;
+                this.placementRoot = placementRoot;
+                PlacementController = placementController;
+                BearTrapDefinition = bearTrapDefinition;
                 Inventory = inventory;
                 Phase = phase;
             }
@@ -480,11 +530,28 @@ namespace Castlebound.Tests.UI
             public TowerPlot LeftPlot { get; }
             public TowerPlot RightPlot { get; }
             public Transform TowerParent { get; }
+            public WorldPlaceablePlacementController PlacementController { get; }
+            public PlaceableObjectDefinition BearTrapDefinition { get; }
             public InventoryState Inventory { get; }
             public WavePhaseTracker Phase { get; }
 
             public void Destroy()
             {
+                if (BearTrapDefinition != null)
+                {
+                    if (BearTrapDefinition.Prefab != null)
+                    {
+                        Object.DestroyImmediate(BearTrapDefinition.Prefab);
+                    }
+
+                    Object.DestroyImmediate(BearTrapDefinition);
+                }
+
+                if (placementRoot != null)
+                {
+                    Object.DestroyImmediate(placementRoot);
+                }
+
                 if (TowerParent != null)
                 {
                     Object.DestroyImmediate(TowerParent.gameObject);

--- a/Assets/_Project/_Tests/EditMode/World/Placement/BearTrapPlacementPrototypeTests.cs
+++ b/Assets/_Project/_Tests/EditMode/World/Placement/BearTrapPlacementPrototypeTests.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using Castlebound.Gameplay.Castle;
 using Castlebound.Gameplay.World.Placement;
 using NUnit.Framework;
@@ -13,6 +14,7 @@ namespace Castlebound.Tests.World.Placement
         private const string BearTrapDefinitionPath = "Assets/_Project/Placeables/Defense/Placeable_Defense_BearTrap.asset";
         private const string BearTrapPrefabPath = "Assets/_Project/Prefabs/BearTrap.prefab";
         private const string MainPrototypeScenePath = "Assets/_Project/Scenes/MainPrototype.unity";
+        private const string PlacementControllerSourcePath = "Assets/_Project/Scripts/_Project.Gameplay/World/Placement/WorldPlaceablePlacementController.cs";
 
         [Test]
         public void BearTrapDefinition_IsDefenseOutsideGroundOneByOne()
@@ -107,6 +109,15 @@ namespace Castlebound.Tests.World.Placement
                     EditorSceneManager.CloseScene(scene, true);
                 }
             }
+        }
+
+        [Test]
+        public void PlacementController_DoesNotCreateStandaloneBearTrapButton()
+        {
+            var source = File.ReadAllText(PlacementControllerSourcePath);
+
+            StringAssert.DoesNotContain("BearTrapPlaceButton", source);
+            StringAssert.DoesNotContain("EnsureSelectButton", source);
         }
 
         private static PlaceableObjectDefinition CreateBearTrapDefinition()

--- a/Assets/_Project/_Tests/EditMode/World/Placement/BearTrapPlacementPrototypeTests.cs
+++ b/Assets/_Project/_Tests/EditMode/World/Placement/BearTrapPlacementPrototypeTests.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using Castlebound.Gameplay.Input;
 using Castlebound.Gameplay.Castle;
 using Castlebound.Gameplay.World.Placement;
 using NUnit.Framework;
@@ -120,6 +121,192 @@ namespace Castlebound.Tests.World.Placement
             StringAssert.DoesNotContain("EnsureSelectButton", source);
         }
 
+        [Test]
+        public void PlacementController_DoesNotBlockPreviewOnGlobalUiHitTests()
+        {
+            var source = File.ReadAllText(PlacementControllerSourcePath);
+
+            StringAssert.DoesNotContain("IsPointerOverGameObject", source);
+        }
+
+        [Test]
+        public void ConfirmPlacement_PlacesLockedTrapAndKeepsPlacementActiveForNextTrap()
+        {
+            var controllerObject = new GameObject("PlacementController");
+            var controller = controllerObject.AddComponent<WorldPlaceablePlacementController>();
+            var definition = CreateBearTrapDefinition();
+
+            try
+            {
+                Assert.IsTrue(controller.BeginPlacement(definition));
+
+                controller.LockPlacementTarget(new Vector2(4f, -2f));
+                Assert.IsTrue(controller.HasLockedTarget);
+                Assert.IsTrue(controller.ConfirmPlacement());
+
+                Assert.IsTrue(controller.IsPlacementActive, "Placement should remain active after one trap is placed.");
+                Assert.IsFalse(controller.HasLockedTarget, "Placed trap should clear the lock so another target can be selected.");
+                Assert.That(CountPlacedTraps(controllerObject.transform), Is.EqualTo(1));
+
+                controller.LockPlacementTarget(new Vector2(5f, -2f));
+                Assert.IsTrue(controller.ConfirmPlacement());
+                Assert.That(CountPlacedTraps(controllerObject.transform), Is.EqualTo(2));
+            }
+            finally
+            {
+                Object.DestroyImmediate(definition.Prefab);
+                Object.DestroyImmediate(definition);
+                Object.DestroyImmediate(controllerObject);
+            }
+        }
+
+        [Test]
+        public void ConfirmPlacement_RejectsOccupiedLockedCell()
+        {
+            var controllerObject = new GameObject("PlacementController");
+            var controller = controllerObject.AddComponent<WorldPlaceablePlacementController>();
+            var definition = CreateBearTrapDefinition();
+
+            try
+            {
+                Assert.IsTrue(controller.BeginPlacement(definition));
+
+                controller.LockPlacementTarget(new Vector2(4f, -2f));
+                Assert.IsTrue(controller.ConfirmPlacement());
+
+                controller.LockPlacementTarget(new Vector2(4f, -2f));
+                Assert.IsFalse(controller.ConfirmPlacement());
+
+                Assert.IsTrue(controller.IsPlacementActive);
+                Assert.IsTrue(controller.HasLockedTarget, "Rejected placement should keep the locked cell for player correction.");
+                Assert.That(CountPlacedTraps(controllerObject.transform), Is.EqualTo(1));
+            }
+            finally
+            {
+                Object.DestroyImmediate(definition.Prefab);
+                Object.DestroyImmediate(definition);
+                Object.DestroyImmediate(controllerObject);
+            }
+        }
+
+        [Test]
+        public void CancelPlacement_ClearsSelectionAndInvokesCallback()
+        {
+            var controllerObject = new GameObject("PlacementController");
+            var controller = controllerObject.AddComponent<WorldPlaceablePlacementController>();
+            var definition = CreateBearTrapDefinition();
+            var canceled = false;
+
+            try
+            {
+                Assert.IsTrue(controller.BeginPlacement(definition, () => canceled = true));
+                controller.LockPlacementTarget(new Vector2(4f, -2f));
+
+                controller.CancelPlacement();
+
+                Assert.IsFalse(controller.IsPlacementActive);
+                Assert.IsFalse(controller.HasLockedTarget);
+                Assert.IsTrue(canceled);
+            }
+            finally
+            {
+                Object.DestroyImmediate(definition.Prefab);
+                Object.DestroyImmediate(definition);
+                Object.DestroyImmediate(controllerObject);
+            }
+        }
+
+        [Test]
+        public void CancelPlacement_ReleasesActiveTouchAttackState()
+        {
+            var aimObject = new GameObject("TouchAimAttackZone");
+            var aimZone = aimObject.AddComponent<TouchAimAttackZone>();
+            var controllerObject = new GameObject("PlacementController");
+            var controller = controllerObject.AddComponent<WorldPlaceablePlacementController>();
+            var definition = CreateBearTrapDefinition();
+
+            try
+            {
+                aimZone.AttackDeadzone = 10f;
+                aimZone.SimulatePointerDown(Vector2.zero);
+                aimZone.SimulateAimInput(new Vector2(100f, 0f));
+                Assert.IsTrue(aimZone.IsFiring, "Precondition: touch attack should be active.");
+
+                Assert.IsTrue(controller.BeginPlacement(definition));
+                controller.CancelPlacement();
+
+                Assert.IsFalse(aimZone.IsFiring);
+                Assert.That(aimZone.FacingDirection, Is.EqualTo(Vector2.zero));
+            }
+            finally
+            {
+                Object.DestroyImmediate(definition.Prefab);
+                Object.DestroyImmediate(definition);
+                Object.DestroyImmediate(controllerObject);
+                Object.DestroyImmediate(aimObject);
+            }
+        }
+
+        [Test]
+        public void CancelPlacement_ReleasesHeldPcFireState()
+        {
+            var fireObject = new GameObject("PlayerFireInputController");
+            var fireInput = fireObject.AddComponent<PlayerFireInputController>();
+            var controllerObject = new GameObject("PlacementController");
+            var controller = controllerObject.AddComponent<WorldPlaceablePlacementController>();
+            var definition = CreateBearTrapDefinition();
+
+            try
+            {
+                fireInput.OnFirePressedStateChanged(true);
+                Assert.IsTrue(fireInput.IsFireHeld, "Precondition: PC fire should be held.");
+
+                Assert.IsTrue(controller.BeginPlacement(definition));
+                controller.CancelPlacement();
+
+                Assert.IsFalse(fireInput.IsFireHeld);
+            }
+            finally
+            {
+                Object.DestroyImmediate(definition.Prefab);
+                Object.DestroyImmediate(definition);
+                Object.DestroyImmediate(controllerObject);
+                Object.DestroyImmediate(fireObject);
+            }
+        }
+
+        [Test]
+        public void CancelPlacement_ResetsActivePcAttackLoop()
+        {
+            var playerObject = new GameObject("Player");
+            var fireInput = playerObject.AddComponent<PlayerFireInputController>();
+            var attackLoop = playerObject.AddComponent<PlayerAttackLoop>();
+            playerObject.AddComponent<PlayerController>();
+            var controllerObject = new GameObject("PlacementController");
+            var controller = controllerObject.AddComponent<WorldPlaceablePlacementController>();
+            var definition = CreateBearTrapDefinition();
+
+            try
+            {
+                fireInput.OnFirePressedStateChanged(true);
+                attackLoop.Tick(0f, 1.5f, true);
+                Assert.IsTrue(attackLoop.IsSwingActive, "Precondition: PC fire click should have started an attack swing.");
+
+                Assert.IsTrue(controller.BeginPlacement(definition));
+                controller.CancelPlacement();
+
+                Assert.IsFalse(fireInput.IsFireHeld);
+                Assert.IsFalse(attackLoop.IsSwingActive);
+            }
+            finally
+            {
+                Object.DestroyImmediate(definition.Prefab);
+                Object.DestroyImmediate(definition);
+                Object.DestroyImmediate(controllerObject);
+                Object.DestroyImmediate(playerObject);
+            }
+        }
+
         private static PlaceableObjectDefinition CreateBearTrapDefinition()
         {
             var definition = ScriptableObject.CreateInstance<PlaceableObjectDefinition>();
@@ -130,6 +317,20 @@ namespace Castlebound.Tests.World.Placement
             definition.SetFootprint(GridFootprint.OneByOne);
             definition.Prefab = new GameObject("BearTrapPrefab");
             return definition;
+        }
+
+        private static int CountPlacedTraps(Transform root)
+        {
+            var count = 0;
+            foreach (Transform child in root)
+            {
+                if (child.name == "Bear Trap")
+                {
+                    count++;
+                }
+            }
+
+            return count;
         }
     }
 }

--- a/Assets/_Project/_Tests/EditMode/World/Placement/BearTrapPlacementPrototypeTests.cs
+++ b/Assets/_Project/_Tests/EditMode/World/Placement/BearTrapPlacementPrototypeTests.cs
@@ -1,0 +1,124 @@
+using Castlebound.Gameplay.Castle;
+using Castlebound.Gameplay.World.Placement;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace Castlebound.Tests.World.Placement
+{
+    public class BearTrapPlacementPrototypeTests
+    {
+        private const string BearTrapDefinitionPath = "Assets/_Project/Placeables/Defense/Placeable_Defense_BearTrap.asset";
+        private const string BearTrapPrefabPath = "Assets/_Project/Prefabs/BearTrap.prefab";
+        private const string MainPrototypeScenePath = "Assets/_Project/Scenes/MainPrototype.unity";
+
+        [Test]
+        public void BearTrapDefinition_IsDefenseOutsideGroundOneByOne()
+        {
+            var definition = AssetDatabase.LoadAssetAtPath<PlaceableObjectDefinition>(BearTrapDefinitionPath);
+
+            Assert.NotNull(definition, "Bear trap placeable definition must exist.");
+            Assert.IsTrue(definition.IsValid, "Bear trap definition should be fully authored.");
+            Assert.That(definition.Id, Is.EqualTo("defense.bear_trap"));
+            Assert.That(definition.DisplayName, Is.EqualTo("Bear Trap"));
+            Assert.That(definition.Category, Is.EqualTo(PlaceableObjectCategory.Defense));
+            Assert.That(definition.PlacementSurface, Is.EqualTo(PlaceablePlacementSurface.OutsideGround));
+            Assert.That(definition.Footprint, Is.EqualTo(GridFootprint.OneByOne));
+        }
+
+        [Test]
+        public void BearTrapPlacementRules_AcceptsOutsideGroundAndRejectsOccupiedOrWrongSurface()
+        {
+            var definition = CreateBearTrapDefinition();
+            var occupancy = new CastleOccupancyMap();
+            var position = new Vector2(2f, -4f);
+
+            try
+            {
+                Assert.IsTrue(WorldPlaceablePlacementRules.CanPlaceAt(
+                    definition,
+                    position,
+                    PlaceablePlacementSurface.OutsideGround,
+                    occupancy));
+
+                Assert.IsFalse(WorldPlaceablePlacementRules.CanPlaceAt(
+                    definition,
+                    position,
+                    PlaceablePlacementSurface.CastleWall,
+                    occupancy));
+
+                occupancy.Occupy(position, definition.Footprint);
+
+                Assert.IsFalse(WorldPlaceablePlacementRules.CanPlaceAt(
+                    definition,
+                    position,
+                    PlaceablePlacementSurface.OutsideGround,
+                    occupancy));
+            }
+            finally
+            {
+                Object.DestroyImmediate(definition.Prefab);
+                Object.DestroyImmediate(definition);
+            }
+        }
+
+        [Test]
+        public void SnapToGrid_RoundsPointerWorldPositionToOneByOneGrid()
+        {
+            var snapped = WorldPlaceablePlacementRules.SnapToGrid(new Vector2(2.49f, -4.51f));
+
+            Assert.That(snapped, Is.EqualTo(new Vector2(2f, -5f)));
+        }
+
+        [Test]
+        public void BearTrapPrefab_UsesReplaceableSpriteOrAnimatorVisualContract()
+        {
+            var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(BearTrapPrefabPath);
+
+            Assert.NotNull(prefab, "Bear trap prefab must exist.");
+            Assert.NotNull(prefab.GetComponentInChildren<SpriteRenderer>(true), "Bear trap prefab should expose a SpriteRenderer for placeholder art.");
+
+            var visualState = prefab.GetComponent<BearTrapVisualState>();
+            Assert.NotNull(visualState, "Bear trap prefab should include BearTrapVisualState so closed art or animation can be swapped later.");
+            Assert.NotNull(visualState.OpenSprite, "Bear trap visual state should reference the current placeholder/open sprite.");
+        }
+
+        [Test]
+        public void MainPrototype_HasBearTrapPlacementPrototypeController()
+        {
+            Scene scene = default;
+            try
+            {
+                scene = EditorSceneManager.OpenScene(MainPrototypeScenePath, OpenSceneMode.Additive);
+                Assert.IsTrue(scene.isLoaded, "MainPrototype scene failed to load.");
+
+                var controller = Object.FindObjectOfType<WorldPlaceablePlacementController>();
+
+                Assert.NotNull(controller, "MainPrototype should include the prototype bear trap placement controller.");
+                Assert.NotNull(controller.DefaultPlaceable, "MainPrototype should reference the bear trap definition.");
+                Assert.That(controller.DefaultPlaceable.Id, Is.EqualTo("defense.bear_trap"));
+            }
+            finally
+            {
+                if (scene.IsValid() && scene.isLoaded)
+                {
+                    EditorSceneManager.CloseScene(scene, true);
+                }
+            }
+        }
+
+        private static PlaceableObjectDefinition CreateBearTrapDefinition()
+        {
+            var definition = ScriptableObject.CreateInstance<PlaceableObjectDefinition>();
+            definition.Id = "defense.bear_trap";
+            definition.DisplayName = "Bear Trap";
+            definition.Category = PlaceableObjectCategory.Defense;
+            definition.PlacementSurface = PlaceablePlacementSurface.OutsideGround;
+            definition.SetFootprint(GridFootprint.OneByOne);
+            definition.Prefab = new GameObject("BearTrapPrefab");
+            return definition;
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/World/Placement/BearTrapPlacementPrototypeTests.cs
+++ b/Assets/_Project/_Tests/EditMode/World/Placement/BearTrapPlacementPrototypeTests.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Reflection;
 using Castlebound.Gameplay.Input;
 using Castlebound.Gameplay.Castle;
 using Castlebound.Gameplay.World.Placement;
@@ -102,6 +103,15 @@ namespace Castlebound.Tests.World.Placement
                 Assert.NotNull(controller, "MainPrototype should include the prototype bear trap placement controller.");
                 Assert.NotNull(controller.DefaultPlaceable, "MainPrototype should reference the bear trap definition.");
                 Assert.That(controller.DefaultPlaceable.Id, Is.EqualTo("defense.bear_trap"));
+
+                var serializedController = new SerializedObject(controller);
+                Assert.NotNull(
+                    serializedController.FindProperty("castleRegionCollider").objectReferenceValue,
+                    "MainPrototype placement controller should reference the castle region collider for outside-ground validation.");
+                Assert.That(
+                    serializedController.FindProperty("placementBlockingLayers").intValue,
+                    Is.EqualTo(LayerMask.GetMask("Walls", "Barriers")),
+                    "MainPrototype placement controller should reject blocking wall and barrier colliders.");
             }
             finally
             {
@@ -127,6 +137,37 @@ namespace Castlebound.Tests.World.Placement
             var source = File.ReadAllText(PlacementControllerSourcePath);
 
             StringAssert.DoesNotContain("IsPointerOverGameObject", source);
+        }
+
+        [Test]
+        public void PlacementRules_ResolveCastleRegionAsCastleFloor()
+        {
+            var regionObject = new GameObject("CastleRegion");
+            var region = regionObject.AddComponent<BoxCollider2D>();
+            region.size = new Vector2(4f, 4f);
+
+            try
+            {
+                Assert.That(
+                    WorldPlaceablePlacementRules.ResolveAvailableSurface(
+                        Vector2.zero,
+                        GridFootprint.OneByOne,
+                        PlaceablePlacementSurface.OutsideGround,
+                        region),
+                    Is.EqualTo(PlaceablePlacementSurface.CastleFloor));
+
+                Assert.That(
+                    WorldPlaceablePlacementRules.ResolveAvailableSurface(
+                        new Vector2(5f, 0f),
+                        GridFootprint.OneByOne,
+                        PlaceablePlacementSurface.OutsideGround,
+                        region),
+                    Is.EqualTo(PlaceablePlacementSurface.OutsideGround));
+            }
+            finally
+            {
+                Object.DestroyImmediate(regionObject);
+            }
         }
 
         [Test]
@@ -186,6 +227,83 @@ namespace Castlebound.Tests.World.Placement
                 Object.DestroyImmediate(definition.Prefab);
                 Object.DestroyImmediate(definition);
                 Object.DestroyImmediate(controllerObject);
+            }
+        }
+
+        [Test]
+        public void ConfirmPlacement_RejectsLockedCellInsideCastleRegion()
+        {
+            var regionObject = new GameObject("CastleRegion");
+            var region = regionObject.AddComponent<BoxCollider2D>();
+            region.size = new Vector2(4f, 4f);
+            var controllerObject = new GameObject("PlacementController");
+            var controller = controllerObject.AddComponent<WorldPlaceablePlacementController>();
+            var definition = CreateBearTrapDefinition();
+
+            try
+            {
+                SetPrivateField(controller, "castleRegionCollider", region);
+
+                Assert.IsTrue(controller.BeginPlacement(definition));
+                controller.LockPlacementTarget(Vector2.zero);
+
+                Assert.IsFalse(controller.CanPlaceSelectedAt(Vector2.zero));
+                Assert.IsFalse(controller.ConfirmPlacement());
+                Assert.That(CountPlacedTraps(controllerObject.transform), Is.EqualTo(0));
+
+                controller.LockPlacementTarget(new Vector2(5f, 0f));
+
+                Assert.IsTrue(controller.CanPlaceSelectedAt(new Vector2(5f, 0f)));
+                Assert.IsTrue(controller.ConfirmPlacement());
+                Assert.That(CountPlacedTraps(controllerObject.transform), Is.EqualTo(1));
+            }
+            finally
+            {
+                Object.DestroyImmediate(definition.Prefab);
+                Object.DestroyImmediate(definition);
+                Object.DestroyImmediate(controllerObject);
+                Object.DestroyImmediate(regionObject);
+            }
+        }
+
+        [Test]
+        [TestCase("Walls")]
+        [TestCase("Barriers")]
+        public void ConfirmPlacement_RejectsLockedCellOnBlockingLayer(string layerName)
+        {
+            var blockerObject = new GameObject($"{layerName}Blocker");
+            var blocker = blockerObject.AddComponent<BoxCollider2D>();
+            blocker.size = Vector2.one;
+            var layer = LayerMask.NameToLayer(layerName);
+            Assert.That(layer, Is.Not.EqualTo(-1), $"Project must define the {layerName} layer.");
+            blockerObject.layer = layer;
+            var controllerObject = new GameObject("PlacementController");
+            var controller = controllerObject.AddComponent<WorldPlaceablePlacementController>();
+            var definition = CreateBearTrapDefinition();
+
+            try
+            {
+                SetPrivateField(controller, "placementBlockingLayers", (LayerMask)LayerMask.GetMask("Walls", "Barriers"));
+
+                Assert.IsTrue(controller.BeginPlacement(definition));
+                controller.LockPlacementTarget(Vector2.zero);
+
+                Assert.IsFalse(controller.CanPlaceSelectedAt(Vector2.zero));
+                Assert.IsFalse(controller.ConfirmPlacement());
+                Assert.That(CountPlacedTraps(controllerObject.transform), Is.EqualTo(0));
+
+                controller.LockPlacementTarget(new Vector2(3f, 0f));
+
+                Assert.IsTrue(controller.CanPlaceSelectedAt(new Vector2(3f, 0f)));
+                Assert.IsTrue(controller.ConfirmPlacement());
+                Assert.That(CountPlacedTraps(controllerObject.transform), Is.EqualTo(1));
+            }
+            finally
+            {
+                Object.DestroyImmediate(definition.Prefab);
+                Object.DestroyImmediate(definition);
+                Object.DestroyImmediate(controllerObject);
+                Object.DestroyImmediate(blockerObject);
             }
         }
 
@@ -331,6 +449,13 @@ namespace Castlebound.Tests.World.Placement
             }
 
             return count;
+        }
+
+        private static void SetPrivateField(object target, string fieldName, object value)
+        {
+            var field = target.GetType().GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(field, $"Expected private field '{fieldName}' to exist.");
+            field.SetValue(target, value);
         }
     }
 }

--- a/Assets/_Project/_Tests/EditMode/World/Placement/BearTrapPlacementPrototypeTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/World/Placement/BearTrapPlacementPrototypeTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 78ffc01518f042fc928cafe48243d2db
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/PlayMode/Tower/TowerBuildUpgradeMenuVerticalSlicePlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/Tower/TowerBuildUpgradeMenuVerticalSlicePlayTests.cs
@@ -53,6 +53,9 @@ namespace Castlebound.Tests.PlayMode.Tower
             yield return null;
 
             Assert.IsTrue(menu.IsMenuOpen, "Upgrade menu should open in pre-wave.");
+            listView.SetActiveTab(UpgradeMenuTab.Defense);
+            yield return null;
+
             var buildButton = FindActiveButtonWithLabel("Build");
             Assert.NotNull(buildButton, "Expected the upgrade menu to expose a Build button for an empty tower plot.");
             Assert.IsTrue(buildButton.interactable, "Empty tower plot Build button should be interactable.");
@@ -125,6 +128,8 @@ namespace Castlebound.Tests.PlayMode.Tower
             var plots = FindPlots();
             Assert.That(plots.Any(plot => !plot.IsOccupied), Is.True, "Expected at least one empty tower plot before building.");
             menu.ToggleMenu();
+            yield return null;
+            listView.SetActiveTab(UpgradeMenuTab.Defense);
             yield return null;
 
             var buildButton = FindActiveButtonWithLabel("Build");

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,23 @@
 
 ---
 
+## 2026-06-08 - feat(ui): add castle and defense upgrade tabs
+
+### Summary
+- Added Castle and Defense tabs to the upgrade menu while keeping the same menu frame.
+- Moved barrier upgrade rows under Castle and tower build/upgrade rows under Defense.
+- Enlarged per-tab row content and extracted tab strip behavior away from row rendering.
+
+### New or Updated Tests
+**EditMode**
+- `UpgradeMenuListViewTowerRowsTests` - verifies Castle tab barrier rows, Defense tab tower rows, and existing barrier/tower actions after tab split.
+
+**PlayMode**
+- `TowerBuildUpgradeMenuVerticalSlicePlayTests` - switches to the Defense tab before tower build/upgrade vertical-slice assertions.
+
+### Notes
+- Local batchmode run was blocked because the project was already open in another Unity instance; awaiting validation.
+
 ## 2026-06-08 - feat(defense): add bear trap placement prototype
 
 ### Summary

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,23 @@
 
 ---
 
+## 2026-06-08 - feat(defense): validate trap placement surface
+
+### Summary
+- Resolved Bear Trap placement surface from the castle region collider instead of assuming every cursor cell is outside ground.
+- Rejected locked trap placement inside the castle region and on wall/barrier blockers while keeping outside-ground placement valid.
+- Wired MainPrototype placement validation to the existing CastleRegion collider.
+
+### New or Updated Tests
+**EditMode**
+- `BearTrapPlacementPrototypeTests` - verifies castle-region surface resolution, inside-castle rejection, wall/barrier blocker rejection, outside-ground acceptance, and MainPrototype validation wiring.
+
+**PlayMode**
+- N/A - N/A
+
+### Notes
+- Local batchmode run was blocked because the project was already open in another Unity instance; awaiting validation.
+
 ## 2026-06-08 - feat(defense): add confirm cancel placement loop
 
 ### Summary

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,23 @@
 
 ---
 
+## 2026-06-08 - feat(defense): add bear trap placement prototype
+
+### Summary
+- Added a minimal bear trap placeable definition and prefab using a replaceable placeholder sprite visual.
+- Added runtime placement rules for 1x1 outside-ground snapping and occupied-footprint rejection.
+- Wired MainPrototype with a prototype bear trap placement controller that creates a simple runtime select button.
+
+### New or Updated Tests
+**EditMode**
+- `BearTrapPlacementPrototypeTests` - verifies bear trap definition authoring, outside-ground validation, occupied rejection, grid snapping, prefab visual swap contract, and MainPrototype controller wiring.
+
+**PlayMode**
+- N/A - N/A
+
+### Notes
+- EditMode passing per user validation; local batchmode run was blocked because the project was already open in another Unity instance.
+
 ## 2026-06-08 - feat(world): add castle and defense placeable definitions
 
 ### Summary

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,24 @@
 
 ---
 
+## 2026-06-08 - feat(defense): move trap placement into upgrade flow
+
+### Summary
+- Moved Bear Trap placement entry into the Defense tab of the upgrade menu.
+- Removed standalone Bear Trap button creation from the placement controller.
+- Added a menu hide path that starts placement without starting the next wave.
+
+### New or Updated Tests
+**EditMode**
+- `UpgradeMenuListViewTowerRowsTests` - verifies the Defense tab renders Bear Trap and delegates placement to the world placement controller.
+- `BearTrapPlacementPrototypeTests` - verifies the standalone Bear Trap button path is no longer present.
+
+**PlayMode**
+- N/A - N/A
+
+### Notes
+- Local batchmode run was blocked because the project was already open in another Unity instance; awaiting validation.
+
 ## 2026-06-08 - feat(ui): add castle and defense upgrade tabs
 
 ### Summary

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,27 @@
 
 ---
 
+## 2026-06-08 - feat(defense): add confirm cancel placement loop
+
+### Summary
+- Added locked-target Bear Trap placement with Confirm and Cancel controls.
+- Kept placement mode active after each confirmed trap so another trap can be placed.
+- Reopened the upgrade menu on the Defense tab when placement is canceled, without leaving touch or PC attack stuck active.
+- Added player attack cleanup that clears held fire, resets active attack loops, and syncs attack presentation without locking movement.
+- Limited placement pointer blocking to Confirm/Cancel controls so full-screen touch zones do not hide the preview.
+
+### New or Updated Tests
+**EditMode**
+- `BearTrapPlacementPrototypeTests` - verifies locked target confirmation, repeat placement, occupied-cell rejection, cancel callback behavior, touch/PC attack release on cancel, and no global UI hit-test blocking for preview.
+- `PlayerAttackInputTests` - verifies player attack cleanup clears held fire and active attack loop state.
+- `UpgradeMenuControllerTests` - verifies hiding for placement does not start the wave and can reopen the menu.
+
+**PlayMode**
+- N/A - N/A
+
+### Notes
+- Local batchmode run was blocked because the project was already open in another Unity instance; awaiting validation.
+
 ## 2026-06-08 - feat(defense): move trap placement into upgrade flow
 
 ### Summary


### PR DESCRIPTION
## Why
Adds the first usable authored defense placement flow so players can place Bear Traps between waves from the Defense upgrade tab.

## What changed
- Added Bear Trap placeable definition, prefab placeholder visual contract, and runtime placement controller
- Added Castle/Defense upgrade tabs and moved Bear Trap placement into the Defense tab
- Added locked preview placement with Confirm/Cancel controls and repeat placement
- Validates placement against outside-ground surface, castle region, wall/barrier blockers, and occupied trap cells
- Keeps player movement available during placement and restores the upgrade menu on cancel

## How to test
1. Open MainPrototype
2. Press Play -> open upgrade menu -> Defense tab -> Bear Trap
3. Verify traps place only outside, cannot overlap, and cannot place on castle walls/barriers/interior
4. Run tests:
   - EditMode
   - PlayMode

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched (N/A - TEST_LOG updated instead)

## Related
- Closes #192