### PR TITLE
feat(loot): add magnetic pickup attraction

### DIFF
--- a/Assets/_Project/Balance/EconomyBalanceTable.asset
+++ b/Assets/_Project/Balance/EconomyBalanceTable.asset
@@ -14,3 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   startingGold: 0
   startingXp: 0
+  pickupMagnetRange: 8
+  pickupMagnetSpeed: 10.4
+  pickupSweepRange: 30
+  pickupSweepSpeed: 26

--- a/Assets/_Project/Prefabs/Pickups/Pickup_Gold_1.prefab
+++ b/Assets/_Project/Prefabs/Pickups/Pickup_Gold_1.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 1000000003}
   - component: {fileID: 1000000004}
   - component: {fileID: 1000000005}
+  - component: {fileID: 1000000006}
   m_Layer: 0
   m_Name: Pickup_Gold_1
   m_TagString: Untagged
@@ -159,9 +160,22 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0a7f6e3d2e1b4f9aa4d0bdb5c4a9e3d9, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   kind: 2
   itemDefinition: {fileID: 11400000, guid: c1f4b2a3d5e647f8a9b0c1d2e3f4a5b6, type: 2}
   amount: 1
   pickupDelaySeconds: 0.3
+--- !u!114 &1000000006
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 31b4d6a0c8f94c46b3d29f2101930003, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  magnetField: {fileID: 0}

--- a/Assets/_Project/Prefabs/Pickups/Pickup_Potion_Health.prefab
+++ b/Assets/_Project/Prefabs/Pickups/Pickup_Potion_Health.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 1000000003}
   - component: {fileID: 1000000004}
   - component: {fileID: 1000000005}
+  - component: {fileID: 1000000006}
   m_Layer: 0
   m_Name: Pickup_Potion_Health
   m_TagString: Untagged
@@ -159,9 +160,22 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0a7f6e3d2e1b4f9aa4d0bdb5c4a9e3d9, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   kind: 1
   itemDefinition: {fileID: 11400000, guid: cd2861bff7fa4d4f99ca4fe0c314a971, type: 2}
   amount: 1
   pickupDelaySeconds: 0.3
+--- !u!114 &1000000006
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 31b4d6a0c8f94c46b3d29f2101930003, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  magnetField: {fileID: 0}

--- a/Assets/_Project/Prefabs/Pickups/Pickup_Weapon_Sword.prefab
+++ b/Assets/_Project/Prefabs/Pickups/Pickup_Weapon_Sword.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 1000000003}
   - component: {fileID: 1000000004}
   - component: {fileID: 1000000005}
+  - component: {fileID: 1000000006}
   m_Layer: 0
   m_Name: Pickup_Weapon_Sword
   m_TagString: Untagged
@@ -159,9 +160,22 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0a7f6e3d2e1b4f9aa4d0bdb5c4a9e3d9, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   kind: 0
   itemDefinition: {fileID: 11400000, guid: d2a3b4c5e6f708192a3b4c5d6e7f8091, type: 2}
   amount: 1
   pickupDelaySeconds: 0.3
+--- !u!114 &1000000006
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 31b4d6a0c8f94c46b3d29f2101930003, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  magnetField: {fileID: 0}

--- a/Assets/_Project/Prefabs/Player.prefab
+++ b/Assets/_Project/Prefabs/Player.prefab
@@ -88,8 +88,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: bbfff868dea261e44802d7a99abd02ca, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   playerHitEnemyFeedbackChannel: {fileID: 11400000, guid: 80d7fae19fc8c724fb8344818aae2e88, type: 2}
 --- !u!1 &8325390509751579795
 GameObject:
@@ -122,6 +122,7 @@ GameObject:
   - component: {fileID: 9150000000000000204}
   - component: {fileID: 9150000000000000205}
   - component: {fileID: 9150000000000000301}
+  - component: {fileID: 9150000000000000401}
   m_Layer: 3
   m_Name: Player
   m_TagString: Player
@@ -730,3 +731,17 @@ SpriteRenderer:
   m_WasSpriteAssigned: 0
   m_MaskInteraction: 0
   m_SpriteSortPoint: 1
+--- !u!114 &9150000000000000401
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8325390509751579795}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 31b4d6a0c8f94c46b3d29f2101930001, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  balanceStation: {fileID: 11400000, guid: d70caaeb4e66400f8127d62f459cae21, type: 2}
+  waveRunner: {fileID: 0}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Balance/EconomyBalanceTable.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Balance/EconomyBalanceTable.cs
@@ -7,6 +7,10 @@ namespace Castlebound.Gameplay.Balance
     {
         [SerializeField] private int startingGold = 0;
         [SerializeField] private int startingXp = 0;
+        [SerializeField] private float pickupMagnetRange = 8f;
+        [SerializeField] private float pickupMagnetSpeed = 10.4f;
+        [SerializeField] private float pickupSweepRange = 30f;
+        [SerializeField] private float pickupSweepSpeed = 26f;
 
         public int StartingGold
         {
@@ -20,10 +24,38 @@ namespace Castlebound.Gameplay.Balance
             set => startingXp = Mathf.Max(0, value);
         }
 
+        public float PickupMagnetRange
+        {
+            get => pickupMagnetRange;
+            set => pickupMagnetRange = Mathf.Max(0f, value);
+        }
+
+        public float PickupMagnetSpeed
+        {
+            get => pickupMagnetSpeed;
+            set => pickupMagnetSpeed = Mathf.Max(0f, value);
+        }
+
+        public float PickupSweepRange
+        {
+            get => pickupSweepRange;
+            set => pickupSweepRange = Mathf.Max(0f, value);
+        }
+
+        public float PickupSweepSpeed
+        {
+            get => pickupSweepSpeed;
+            set => pickupSweepSpeed = Mathf.Max(0f, value);
+        }
+
         private void OnValidate()
         {
             StartingGold = startingGold;
             StartingXp = startingXp;
+            PickupMagnetRange = pickupMagnetRange;
+            PickupMagnetSpeed = pickupMagnetSpeed;
+            PickupSweepRange = pickupSweepRange;
+            PickupSweepSpeed = pickupSweepSpeed;
         }
     }
 }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Inventory/ItemPickupComponent.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Inventory/ItemPickupComponent.cs
@@ -10,23 +10,37 @@ namespace Castlebound.Gameplay.Inventory
         [SerializeField] private float pickupDelaySeconds = 0f;
 
         private float pickupDelayRemaining = 0f;
+        private ItemPickup cachedPickup;
+        private bool isPickupCacheDirty = true;
 
         public ItemPickupKind Kind
         {
             get => kind;
-            set => kind = value;
+            set
+            {
+                kind = value;
+                InvalidatePickupCache();
+            }
         }
 
         public ItemDefinition ItemDefinition
         {
             get => itemDefinition;
-            set => itemDefinition = value;
+            set
+            {
+                itemDefinition = value;
+                InvalidatePickupCache();
+            }
         }
 
         public int Amount
         {
             get => amount;
-            set => amount = value;
+            set
+            {
+                amount = value;
+                InvalidatePickupCache();
+            }
         }
 
         public bool IsConsumed { get; private set; }
@@ -83,22 +97,12 @@ namespace Castlebound.Gameplay.Inventory
 
         public bool TryAutoPickup(InventoryState inventory)
         {
-            if (IsConsumed)
+            if (!CanAutoPickup(inventory))
             {
                 return false;
             }
 
-            if (pickupDelayRemaining > 0f)
-            {
-                return false;
-            }
-
-            ItemPickup pickup = BuildPickup();
-            if (pickup == null)
-            {
-                return false;
-            }
-
+            ItemPickup pickup = GetPickup();
             bool result = pickup.TryAutoPickup(inventory);
             if (result)
             {
@@ -106,6 +110,17 @@ namespace Castlebound.Gameplay.Inventory
             }
 
             return result;
+        }
+
+        public bool CanAutoPickup(InventoryState inventory)
+        {
+            if (IsConsumed || pickupDelayRemaining > 0f)
+            {
+                return false;
+            }
+
+            ItemPickup pickup = GetPickup();
+            return pickup != null && pickup.CanAutoPickup(inventory);
         }
 
         public bool TryManualPickup(InventoryState inventory)
@@ -120,7 +135,7 @@ namespace Castlebound.Gameplay.Inventory
                 return false;
             }
 
-            ItemPickup pickup = BuildPickup();
+            ItemPickup pickup = GetPickup();
             if (pickup == null)
             {
                 return false;
@@ -133,6 +148,18 @@ namespace Castlebound.Gameplay.Inventory
             }
 
             return result;
+        }
+
+        private ItemPickup GetPickup()
+        {
+            if (!isPickupCacheDirty)
+            {
+                return cachedPickup;
+            }
+
+            cachedPickup = BuildPickup();
+            isPickupCacheDirty = false;
+            return cachedPickup;
         }
 
         private ItemPickup BuildPickup()
@@ -160,6 +187,17 @@ namespace Castlebound.Gameplay.Inventory
                 default:
                     return null;
             }
+        }
+
+        private void InvalidatePickupCache()
+        {
+            cachedPickup = null;
+            isPickupCacheDirty = true;
+        }
+
+        private void OnValidate()
+        {
+            InvalidatePickupCache();
         }
 
         private static bool TryGetInventory(Component other, out InventoryState inventory)

--- a/Assets/_Project/Scripts/_Project.Gameplay/Loot/LootSpillMotion.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Loot/LootSpillMotion.cs
@@ -12,6 +12,8 @@ namespace Castlebound.Gameplay.Loot
         private float elapsed;
         private bool isActive;
 
+        public bool IsActive => isActive;
+
         public void Initialize(Vector3 target, float moveDuration)
         {
             startPosition = transform.position;

--- a/Assets/_Project/Scripts/_Project.Gameplay/Loot/PickupMagnetMotion.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Loot/PickupMagnetMotion.cs
@@ -1,0 +1,67 @@
+using Castlebound.Gameplay.Inventory;
+using Castlebound.Gameplay.Player;
+using UnityEngine;
+
+namespace Castlebound.Gameplay.Loot
+{
+    [RequireComponent(typeof(ItemPickupComponent))]
+    public sealed class PickupMagnetMotion : MonoBehaviour
+    {
+        [SerializeField] private PickupMagnetField magnetField;
+
+        private ItemPickupComponent pickup;
+        private LootSpillMotion spillMotion;
+
+        public PickupMagnetField MagnetField
+        {
+            get => magnetField;
+            set => magnetField = value;
+        }
+
+        private void Awake()
+        {
+            pickup = GetComponent<ItemPickupComponent>();
+            spillMotion = GetComponent<LootSpillMotion>();
+        }
+
+        private void Update()
+        {
+            Step(Time.deltaTime);
+        }
+
+        public void Step(float deltaTime)
+        {
+            EnsureReferences();
+            if (magnetField == null || pickup == null || (spillMotion != null && spillMotion.IsActive))
+            {
+                return;
+            }
+
+            if (!magnetField.IsWithinRange(transform.position) || !magnetField.CanAttract(pickup))
+            {
+                return;
+            }
+
+            float distance = magnetField.ActiveSpeed * Mathf.Max(0f, deltaTime);
+            transform.position = Vector3.MoveTowards(transform.position, magnetField.transform.position, distance);
+        }
+
+        private void EnsureReferences()
+        {
+            if (pickup == null)
+            {
+                pickup = GetComponent<ItemPickupComponent>();
+            }
+
+            if (spillMotion == null)
+            {
+                spillMotion = GetComponent<LootSpillMotion>();
+            }
+
+            if (magnetField == null)
+            {
+                magnetField = FindObjectOfType<PickupMagnetField>();
+            }
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Loot/PickupMagnetMotion.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Loot/PickupMagnetMotion.cs.meta
@@ -6,6 +6,6 @@ MonoImporter:
   defaultReferences: []
   executionOrder: 0
   icon: {instanceID: 0}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/_Project.Gameplay/Loot/PickupMagnetMotion.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Loot/PickupMagnetMotion.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 31b4d6a0c8f94c46b3d29f2101930003
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/PickupMagnetField.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/PickupMagnetField.cs
@@ -1,0 +1,118 @@
+using Castlebound.Gameplay.Balance;
+using Castlebound.Gameplay.Inventory;
+using Castlebound.Gameplay.Spawning;
+using UnityEngine;
+
+namespace Castlebound.Gameplay.Player
+{
+    public sealed class PickupMagnetField : MonoBehaviour
+    {
+        [SerializeField] private GameBalanceStation balanceStation;
+        [SerializeField] private EnemySpawnerRunner waveRunner;
+
+        private InventoryStateComponent inventoryComponent;
+        private bool isSweepActive;
+
+        public GameBalanceStation BalanceStation
+        {
+            get => balanceStation;
+            set => balanceStation = value;
+        }
+
+        public EnemySpawnerRunner WaveRunner
+        {
+            get => waveRunner;
+            set => waveRunner = value;
+        }
+
+        public bool IsSweepActive => isSweepActive;
+        public float ActiveRange => Economy == null
+            ? 0f
+            : isSweepActive ? Economy.PickupSweepRange : Economy.PickupMagnetRange;
+        public float ActiveSpeed => Economy == null
+            ? 0f
+            : isSweepActive ? Economy.PickupSweepSpeed : Economy.PickupMagnetSpeed;
+
+        private EconomyBalanceTable Economy => balanceStation != null ? balanceStation.Economy : null;
+
+        private void Awake()
+        {
+            inventoryComponent = GetComponentInChildren<InventoryStateComponent>();
+            EnsureWaveRunner();
+        }
+
+        private void OnEnable()
+        {
+            EnsureWaveRunner();
+            Subscribe();
+        }
+
+        private void OnDisable()
+        {
+            Unsubscribe();
+        }
+
+        public void HandleWaveStarted(int waveIndex)
+        {
+            isSweepActive = false;
+        }
+
+        public void HandleWaveEnded()
+        {
+            isSweepActive = true;
+        }
+
+        public bool CanAttract(ItemPickupComponent pickup)
+        {
+            if (inventoryComponent == null)
+            {
+                inventoryComponent = GetComponentInChildren<InventoryStateComponent>();
+            }
+
+            if (pickup == null || pickup.IsConsumed || inventoryComponent == null)
+            {
+                return false;
+            }
+
+            return pickup.CanAutoPickup(inventoryComponent.State);
+        }
+
+        public bool IsWithinRange(Vector3 position)
+        {
+            float range = ActiveRange;
+            return range > 0f && (transform.position - position).sqrMagnitude <= range * range;
+        }
+
+        private void EnsureWaveRunner()
+        {
+            if (waveRunner == null)
+            {
+                waveRunner = FindObjectOfType<EnemySpawnerRunner>();
+            }
+        }
+
+        private void Subscribe()
+        {
+            if (waveRunner == null)
+            {
+                return;
+            }
+
+            waveRunner.OnWaveStarted -= HandleWaveStarted;
+            waveRunner.OnWaveEnded -= HandleWaveEnded;
+            waveRunner.OnWaveStarted += HandleWaveStarted;
+            waveRunner.OnWaveEnded += HandleWaveEnded;
+        }
+
+        private void Unsubscribe()
+        {
+            if (waveRunner == null)
+            {
+                return;
+            }
+
+            waveRunner.OnWaveStarted -= HandleWaveStarted;
+            waveRunner.OnWaveEnded -= HandleWaveEnded;
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/PickupMagnetField.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/PickupMagnetField.cs.meta
@@ -6,6 +6,6 @@ MonoImporter:
   defaultReferences: []
   executionOrder: 0
   icon: {instanceID: 0}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/PickupMagnetField.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/PickupMagnetField.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 31b4d6a0c8f94c46b3d29f2101930001
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/EditMode/Inventory/ItemPickupComponentTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Inventory/ItemPickupComponentTests.cs
@@ -91,5 +91,57 @@ namespace Castlebound.Tests.Inventory
             Object.DestroyImmediate(pickupGo);
             Object.DestroyImmediate(playerGo);
         }
+
+        [Test]
+        public void CanAutoPickup_ReusesCachedPickup_WithoutAllocating()
+        {
+            var inventory = new InventoryState();
+            var pickupGo = new GameObject("Pickup");
+            var pickup = pickupGo.AddComponent<ItemPickupComponent>();
+            pickup.Kind = ItemPickupKind.Gold;
+            pickup.Amount = 1;
+            pickup.CanAutoPickup(inventory);
+
+            long before = System.GC.GetAllocatedBytesForCurrentThread();
+            for (int i = 0; i < 1000; i++)
+            {
+                pickup.CanAutoPickup(inventory);
+            }
+            long allocated = System.GC.GetAllocatedBytesForCurrentThread() - before;
+
+            Assert.AreEqual(0L, allocated);
+
+            Object.DestroyImmediate(pickupGo);
+        }
+
+        [Test]
+        public void CachedPickup_Invalidates_WhenConfigurationChanges()
+        {
+            var inventory = new InventoryState();
+            var weapon = ScriptableObject.CreateInstance<WeaponDefinition>();
+            weapon.ItemId = "weapon_basic";
+            var pickupGo = new GameObject("Pickup");
+            var pickup = pickupGo.AddComponent<ItemPickupComponent>();
+            pickup.Kind = ItemPickupKind.Gold;
+            pickup.Amount = 1;
+
+            Assert.IsTrue(pickup.CanAutoPickup(inventory));
+
+            pickup.Amount = 0;
+            Assert.IsFalse(pickup.CanAutoPickup(inventory));
+
+            pickup.Amount = 1;
+            pickup.Kind = ItemPickupKind.Weapon;
+            Assert.IsFalse(pickup.CanAutoPickup(inventory));
+
+            pickup.ItemDefinition = weapon;
+            Assert.IsTrue(pickup.CanAutoPickup(inventory));
+
+            pickup.ItemDefinition = null;
+            Assert.IsFalse(pickup.CanAutoPickup(inventory));
+
+            Object.DestroyImmediate(pickupGo);
+            Object.DestroyImmediate(weapon);
+        }
     }
 }

--- a/Assets/_Project/_Tests/EditMode/Inventory/PickupMagnetFieldTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Inventory/PickupMagnetFieldTests.cs
@@ -1,0 +1,62 @@
+using Castlebound.Gameplay.Balance;
+using Castlebound.Gameplay.Player;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Castlebound.Tests.Inventory
+{
+    public class PickupMagnetFieldTests
+    {
+        [Test]
+        public void WaveEnd_UsesExtendedSweepProfile_UntilNextWaveStarts()
+        {
+            var economy = ScriptableObject.CreateInstance<EconomyBalanceTable>();
+            economy.PickupMagnetRange = 8f;
+            economy.PickupMagnetSpeed = 10.4f;
+            economy.PickupSweepRange = 30f;
+            economy.PickupSweepSpeed = 26f;
+            var station = ScriptableObject.CreateInstance<GameBalanceStation>();
+            station.Economy = economy;
+            var player = new GameObject("Player");
+            var field = player.AddComponent<PickupMagnetField>();
+            field.BalanceStation = station;
+
+            Assert.AreEqual(8f, field.ActiveRange);
+            Assert.AreEqual(10.4f, field.ActiveSpeed);
+
+            field.HandleWaveEnded();
+
+            Assert.IsTrue(field.IsSweepActive);
+            Assert.AreEqual(30f, field.ActiveRange);
+            Assert.AreEqual(26f, field.ActiveSpeed);
+            Assert.IsTrue(field.IsWithinRange(new Vector3(29f, 0f)));
+
+            field.HandleWaveStarted(2);
+
+            Assert.IsFalse(field.IsSweepActive);
+            Assert.IsFalse(field.IsWithinRange(new Vector3(9f, 0f)));
+
+            Object.DestroyImmediate(player);
+            Object.DestroyImmediate(station);
+            Object.DestroyImmediate(economy);
+        }
+
+        [Test]
+        public void EconomyTuning_ClampsNegativeMagnetValues()
+        {
+            var economy = ScriptableObject.CreateInstance<EconomyBalanceTable>();
+
+            economy.PickupMagnetRange = -1f;
+            economy.PickupMagnetSpeed = -1f;
+            economy.PickupSweepRange = -1f;
+            economy.PickupSweepSpeed = -1f;
+
+            Assert.AreEqual(0f, economy.PickupMagnetRange);
+            Assert.AreEqual(0f, economy.PickupMagnetSpeed);
+            Assert.AreEqual(0f, economy.PickupSweepRange);
+            Assert.AreEqual(0f, economy.PickupSweepSpeed);
+
+            Object.DestroyImmediate(economy);
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Inventory/PickupMagnetFieldTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Inventory/PickupMagnetFieldTests.cs.meta
@@ -6,6 +6,6 @@ MonoImporter:
   defaultReferences: []
   executionOrder: 0
   icon: {instanceID: 0}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/_Tests/EditMode/Inventory/PickupMagnetFieldTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Inventory/PickupMagnetFieldTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 31b4d6a0c8f94c46b3d29f2101930002
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/EditMode/Loot/PickupMagnetMotionTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Loot/PickupMagnetMotionTests.cs
@@ -1,0 +1,120 @@
+using Castlebound.Gameplay.Balance;
+using Castlebound.Gameplay.Inventory;
+using Castlebound.Gameplay.Loot;
+using Castlebound.Gameplay.Player;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Castlebound.Tests.Loot
+{
+    public class PickupMagnetMotionTests
+    {
+        [Test]
+        public void Step_AttractsEligiblePickupThroughCollider()
+        {
+            var economy = ScriptableObject.CreateInstance<EconomyBalanceTable>();
+            economy.PickupMagnetRange = 3f;
+            economy.PickupMagnetSpeed = 4f;
+            var station = ScriptableObject.CreateInstance<GameBalanceStation>();
+            station.Economy = economy;
+            var player = new GameObject("Player");
+            player.AddComponent<InventoryStateComponent>();
+            var field = player.AddComponent<PickupMagnetField>();
+            field.BalanceStation = station;
+            var wall = new GameObject("Wall");
+            wall.transform.position = Vector3.right;
+            wall.AddComponent<BoxCollider2D>();
+            var pickupObject = CreateGoldPickup(new Vector3(2f, 0f));
+            var motion = pickupObject.AddComponent<PickupMagnetMotion>();
+            motion.MagnetField = field;
+
+            motion.Step(0.25f);
+
+            Assert.AreEqual(1f, pickupObject.transform.position.x, 0.001f);
+
+            Object.DestroyImmediate(pickupObject);
+            Object.DestroyImmediate(wall);
+            Object.DestroyImmediate(player);
+            Object.DestroyImmediate(station);
+            Object.DestroyImmediate(economy);
+        }
+
+        [Test]
+        public void Step_WaitsForSpillMotionToFinish()
+        {
+            var economy = ScriptableObject.CreateInstance<EconomyBalanceTable>();
+            economy.PickupMagnetRange = 10f;
+            economy.PickupMagnetSpeed = 4f;
+            var station = ScriptableObject.CreateInstance<GameBalanceStation>();
+            station.Economy = economy;
+            var player = new GameObject("Player");
+            player.AddComponent<InventoryStateComponent>();
+            var field = player.AddComponent<PickupMagnetField>();
+            field.BalanceStation = station;
+            var pickupObject = CreateGoldPickup(new Vector3(2f, 0f));
+            var spill = pickupObject.AddComponent<LootSpillMotion>();
+            spill.Initialize(new Vector3(3f, 0f), 1f);
+            var motion = pickupObject.AddComponent<PickupMagnetMotion>();
+            motion.MagnetField = field;
+
+            motion.Step(0.25f);
+
+            Assert.AreEqual(2f, pickupObject.transform.position.x, 0.001f);
+
+            spill.Step(1f);
+            motion.Step(0.25f);
+
+            Assert.AreEqual(2f, pickupObject.transform.position.x, 0.001f);
+
+            Object.DestroyImmediate(pickupObject);
+            Object.DestroyImmediate(player);
+            Object.DestroyImmediate(station);
+            Object.DestroyImmediate(economy);
+        }
+
+        [Test]
+        public void Step_DoesNotAttractWeapon_WhenInventoryIsFull()
+        {
+            var economy = ScriptableObject.CreateInstance<EconomyBalanceTable>();
+            economy.PickupMagnetRange = 10f;
+            economy.PickupMagnetSpeed = 4f;
+            var station = ScriptableObject.CreateInstance<GameBalanceStation>();
+            station.Economy = economy;
+            var player = new GameObject("Player");
+            var inventory = player.AddComponent<InventoryStateComponent>();
+            inventory.State.AddWeapon("weapon_a");
+            inventory.State.AddWeapon("weapon_b");
+            var field = player.AddComponent<PickupMagnetField>();
+            field.BalanceStation = station;
+            var definition = ScriptableObject.CreateInstance<WeaponDefinition>();
+            definition.ItemId = "weapon_c";
+            var pickupObject = new GameObject("Weapon Pickup");
+            pickupObject.transform.position = new Vector3(2f, 0f);
+            var pickup = pickupObject.AddComponent<ItemPickupComponent>();
+            pickup.Kind = ItemPickupKind.Weapon;
+            pickup.ItemDefinition = definition;
+            var motion = pickupObject.AddComponent<PickupMagnetMotion>();
+            motion.MagnetField = field;
+
+            motion.Step(0.25f);
+
+            Assert.AreEqual(2f, pickupObject.transform.position.x, 0.001f);
+
+            Object.DestroyImmediate(pickupObject);
+            Object.DestroyImmediate(definition);
+            Object.DestroyImmediate(player);
+            Object.DestroyImmediate(station);
+            Object.DestroyImmediate(economy);
+        }
+
+        private static GameObject CreateGoldPickup(Vector3 position)
+        {
+            var pickupObject = new GameObject("Gold Pickup");
+            pickupObject.transform.position = position;
+            var pickup = pickupObject.AddComponent<ItemPickupComponent>();
+            pickup.Kind = ItemPickupKind.Gold;
+            pickup.Amount = 1;
+            return pickupObject;
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Loot/PickupMagnetMotionTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Loot/PickupMagnetMotionTests.cs.meta
@@ -6,6 +6,6 @@ MonoImporter:
   defaultReferences: []
   executionOrder: 0
   icon: {instanceID: 0}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/_Tests/EditMode/Loot/PickupMagnetMotionTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Loot/PickupMagnetMotionTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 31b4d6a0c8f94c46b3d29f2101930004
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/EditMode/Loot/PickupMagnetPrefabContractTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Loot/PickupMagnetPrefabContractTests.cs
@@ -1,0 +1,42 @@
+using Castlebound.Gameplay.Balance;
+using Castlebound.Gameplay.Loot;
+using Castlebound.Gameplay.Player;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+
+namespace Castlebound.Tests.Loot
+{
+    public class PickupMagnetPrefabContractTests
+    {
+        private static readonly string[] PickupPaths =
+        {
+            "Assets/_Project/Prefabs/Pickups/Pickup_Gold_1.prefab",
+            "Assets/_Project/Prefabs/Pickups/Pickup_Potion_Health.prefab",
+            "Assets/_Project/Prefabs/Pickups/Pickup_Weapon_Sword.prefab"
+        };
+
+        [TestCaseSource(nameof(PickupPaths))]
+        public void PickupPrefab_HasMagnetMotion(string path)
+        {
+            var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(path);
+
+            Assert.IsNotNull(prefab, path);
+            Assert.IsNotNull(prefab.GetComponent<PickupMagnetMotion>(), path);
+        }
+
+        [Test]
+        public void PlayerPrefab_HasConfiguredMagnetField()
+        {
+            var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(
+                "Assets/_Project/Prefabs/Player.prefab");
+
+            Assert.IsNotNull(prefab);
+            var field = prefab.GetComponent<PickupMagnetField>();
+            Assert.IsNotNull(field);
+            var expectedStation = AssetDatabase.LoadAssetAtPath<GameBalanceStation>(
+                "Assets/_Project/Balance/GameBalanceStation.asset");
+            Assert.AreSame(expectedStation, field.BalanceStation);
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Loot/PickupMagnetPrefabContractTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Loot/PickupMagnetPrefabContractTests.cs.meta
@@ -6,6 +6,6 @@ MonoImporter:
   defaultReferences: []
   executionOrder: 0
   icon: {instanceID: 0}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/_Tests/EditMode/Loot/PickupMagnetPrefabContractTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Loot/PickupMagnetPrefabContractTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 31b4d6a0c8f94c46b3d29f2101930007
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/PlayMode/Loot.meta
+++ b/Assets/_Project/_Tests/PlayMode/Loot.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 31b4d6a0c8f94c46b3d29f2101930005
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/PlayMode/Loot.meta
+++ b/Assets/_Project/_Tests/PlayMode/Loot.meta
@@ -3,6 +3,6 @@ guid: 31b4d6a0c8f94c46b3d29f2101930005
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/_Tests/PlayMode/Loot/PickupMagnetSweepPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/Loot/PickupMagnetSweepPlayTests.cs
@@ -1,0 +1,70 @@
+using System.Collections;
+using Castlebound.Gameplay.Balance;
+using Castlebound.Gameplay.Inventory;
+using Castlebound.Gameplay.Loot;
+using Castlebound.Gameplay.Player;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Castlebound.Tests.Loot
+{
+    public class PickupMagnetSweepPlayTests
+    {
+        [UnityTest]
+        public IEnumerator WaveEnd_SweepsDistantGoldThroughWall_IntoInventory()
+        {
+            var economy = ScriptableObject.CreateInstance<EconomyBalanceTable>();
+            economy.PickupMagnetRange = 8f;
+            economy.PickupMagnetSpeed = 10.4f;
+            economy.PickupSweepRange = 30f;
+            economy.PickupSweepSpeed = 26f;
+            var station = ScriptableObject.CreateInstance<GameBalanceStation>();
+            station.Economy = economy;
+
+            var player = new GameObject("Player");
+            var inventory = player.AddComponent<InventoryStateComponent>();
+            player.AddComponent<PlayerPickupCollider>();
+            var playerCollider = player.AddComponent<CircleCollider2D>();
+            playerCollider.isTrigger = true;
+            var field = player.AddComponent<PickupMagnetField>();
+            field.BalanceStation = station;
+            field.HandleWaveEnded();
+
+            var wall = new GameObject("Wall");
+            wall.transform.position = new Vector3(5f, 0f);
+            wall.AddComponent<BoxCollider2D>().size = new Vector2(1f, 4f);
+
+            var pickupObject = new GameObject("Gold Pickup");
+            pickupObject.transform.position = new Vector3(10f, 0f);
+            var body = pickupObject.AddComponent<Rigidbody2D>();
+            body.bodyType = RigidbodyType2D.Kinematic;
+            var pickupCollider = pickupObject.AddComponent<CircleCollider2D>();
+            pickupCollider.isTrigger = true;
+            var pickup = pickupObject.AddComponent<ItemPickupComponent>();
+            pickup.Kind = ItemPickupKind.Gold;
+            pickup.Amount = 1;
+            var motion = pickupObject.AddComponent<PickupMagnetMotion>();
+            motion.MagnetField = field;
+
+            Assert.IsFalse(10f <= economy.PickupMagnetRange);
+
+            for (int i = 0; i < 40 && pickup != null && !pickup.IsConsumed; i++)
+            {
+                yield return new WaitForFixedUpdate();
+            }
+
+            Assert.IsTrue(pickup == null || pickup.IsConsumed);
+            Assert.AreEqual(1, inventory.State.Gold);
+
+            Object.Destroy(player);
+            Object.Destroy(wall);
+            if (pickupObject != null)
+            {
+                Object.Destroy(pickupObject);
+            }
+            Object.Destroy(station);
+            Object.Destroy(economy);
+        }
+    }
+}

--- a/Assets/_Project/_Tests/PlayMode/Loot/PickupMagnetSweepPlayTests.cs.meta
+++ b/Assets/_Project/_Tests/PlayMode/Loot/PickupMagnetSweepPlayTests.cs.meta
@@ -6,6 +6,6 @@ MonoImporter:
   defaultReferences: []
   executionOrder: 0
   icon: {instanceID: 0}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/_Tests/PlayMode/Loot/PickupMagnetSweepPlayTests.cs.meta
+++ b/Assets/_Project/_Tests/PlayMode/Loot/PickupMagnetSweepPlayTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 31b4d6a0c8f94c46b3d29f2101930006
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,26 @@
 
 ---
 
+## 2026-06-21 - feat(loot): add magnetic pickup attraction
+
+### Summary
+- Added wall-agnostic pickup attraction with a moderate in-wave radius and faster extended sweep between waves.
+- Routed standard and sweep range/speed tuning through the shared economy balance table.
+- Preserved spill motion, pickup delay, inventory eligibility, and existing collection behavior while removing recurring eligibility allocations.
+
+### New or Updated Tests
+**EditMode**
+- `PickupMagnetFieldTests` - validates standard and sweep profiles, wave transitions, range checks, and normalized tuning.
+- `PickupMagnetMotionTests` - validates wall-agnostic attraction, spill coordination, and full weapon inventory regression behavior.
+- `PickupMagnetPrefabContractTests` - validates player balance configuration and magnet motion on gold, potion, and weapon prefabs.
+- `ItemPickupComponentTests` - validates allocation-free cached eligibility, cache invalidation, pickup consumption, full inventory, and delay behavior.
+
+**PlayMode**
+- `PickupMagnetSweepPlayTests` - validates wave-end collection of distant gold through a wall into player inventory.
+
+### Notes
+- Unity assemblies compiled successfully; allocation and magnet test execution awaits the next Test Runner pass.
+
 ## 2026-06-20 - fix(visual): preserve tower and projectile render order
 
 ### Summary


### PR DESCRIPTION
## Why
Scattered loot was easy to miss and slowed the combat loop, especially when towers defeated enemies outside the castle.

## What changed
- Added wall-agnostic pickup attraction for eligible loot
- Added standard and extended wave-end attraction profiles
- Routed range and speed tuning through economy balance data
- Preserved spill motion, pickup delay, and inventory eligibility
- Removed recurring allocations from pickup eligibility checks

## How to test
1. Drop gold, potion, and weapon pickups around the player
2. Verify nearby eligible pickups attract through walls
3. End a wave and verify distant pickups sweep toward the player
4. Run tests:
   - EditMode
   - PlayMode

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated (N/A - behavior is prefab-driven)
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched

## Related
- Closes #193