### PR TITLE
fix(barrier): allow repair below max health with cooldown

### DIFF
--- a/Assets/_Project/Balance/PlayerBalanceTable.asset
+++ b/Assets/_Project/Balance/PlayerBalanceTable.asset
@@ -15,3 +15,4 @@ MonoBehaviour:
   baseMaxHealth: 200
   baseMoveSpeed: 12
   baseRepairRange: 2
+  baseRepairCooldownSeconds: 1

--- a/Assets/_Project/Prefabs/Player.prefab
+++ b/Assets/_Project/Prefabs/Player.prefab
@@ -245,6 +245,7 @@ MonoBehaviour:
     barrierMask:
       serializedVersion: 2
       m_Bits: 256
+  repairCooldownSeconds: 1
   potionUseController: {fileID: 0}
   inventorySource: {fileID: 0}
   weaponSlotSwapHandler:

--- a/Assets/_Project/Scripts/_Project.Gameplay/Balance/PlayerBalanceApplier.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Balance/PlayerBalanceApplier.cs
@@ -70,6 +70,7 @@ namespace Castlebound.Gameplay.Balance
             if (controller != null)
             {
                 controller.RepairRange = table.BaseRepairRange;
+                controller.RepairCooldownSeconds = table.BaseRepairCooldownSeconds;
             }
         }
     }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Balance/PlayerBalanceTable.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Balance/PlayerBalanceTable.cs
@@ -8,6 +8,7 @@ namespace Castlebound.Gameplay.Balance
         [SerializeField] private int baseMaxHealth = 200;
         [SerializeField] private float baseMoveSpeed = 12f;
         [SerializeField] private float baseRepairRange = 2f;
+        [SerializeField] private float baseRepairCooldownSeconds = 1f;
 
         public int BaseMaxHealth
         {
@@ -27,11 +28,18 @@ namespace Castlebound.Gameplay.Balance
             set => baseRepairRange = Mathf.Max(0f, value);
         }
 
+        public float BaseRepairCooldownSeconds
+        {
+            get => baseRepairCooldownSeconds;
+            set => baseRepairCooldownSeconds = Mathf.Max(0f, value);
+        }
+
         private void OnValidate()
         {
             BaseMaxHealth = baseMaxHealth;
             BaseMoveSpeed = baseMoveSpeed;
             BaseRepairRange = baseRepairRange;
+            BaseRepairCooldownSeconds = baseRepairCooldownSeconds;
         }
     }
 }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Barrier/BarrierHealth.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Barrier/BarrierHealth.cs
@@ -31,6 +31,8 @@ public class BarrierHealth : MonoBehaviour, IDamageable
     }
 
     public bool IsBroken { get; private set; }
+    public bool IsDamaged => MaxHealth > 0 && CurrentHealth < MaxHealth;
+    public bool CanRepair => IsDamaged;
     public float EnemyPushInDistance => enemyPushInDistance;
 
     private void OnEnable()
@@ -74,22 +76,20 @@ public class BarrierHealth : MonoBehaviour, IDamageable
         }
     }
 
-    public void Repair()
+    public bool Repair()
     {
-        // If max health is zero, there's nothing to repair.
-        if (MaxHealth <= 0)
+        if (!CanRepair)
         {
-            return;
+            return false;
         }
 
-        // Restore health and clear broken flag.
         CurrentHealth = MaxHealth;
         IsBroken = false;
 
-        // Ensure collider + sprite are re-enabled.
         UpdateBrokenState();
         ResolveActiveOverlaps();
         OnRepaired?.Invoke();
+        return true;
     }
 
     public void ReviveIfNeeded()

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/RepairSensor.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/RepairSensor.cs
@@ -13,8 +13,14 @@ public class RepairSensor
         set => repairRadius = Mathf.Max(0f, value);
     }
 
+    public LayerMask BarrierMask
+    {
+        get => barrierMask;
+        set => barrierMask = value;
+    }
+
     /// <summary>
-    /// Returns true if there is at least one broken barrier within repair range.
+    /// Returns true if there is at least one damaged barrier within repair range.
     /// </summary>
     public bool HasRepairableBarrierInRange(Vector2 position)
     {
@@ -25,19 +31,19 @@ public class RepairSensor
             var hit = hits[i];
             if (!hit) continue;
             var barrier = hit.GetComponentInParent<BarrierHealth>();
-            if (barrier != null && barrier.IsBroken) return true;
+            if (barrier != null && barrier.CanRepair) return true;
         }
         return false;
     }
 
     /// <summary>
-    /// Finds the first broken barrier within repair range and repairs it.
+    /// Finds the first damaged barrier within repair range and repairs it.
     /// </summary>
-    public void TryRepairNearest(Vector2 position)
+    public bool TryRepairNearest(Vector2 position)
     {
         var hits = Physics2D.OverlapCircleAll(position, repairRadius, barrierMask);
         if (hits == null || hits.Length == 0)
-            return;
+            return false;
 
         for (int i = 0; i < hits.Length; i++)
         {
@@ -48,11 +54,12 @@ public class RepairSensor
             if (barrier == null)
                 continue;
 
-            if (!barrier.IsBroken)
+            if (!barrier.CanRepair)
                 continue;
 
-            barrier.Repair();
-            break; // Repair one barrier per key press.
+            return barrier.Repair();
         }
+
+        return false;
     }
 }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Input/TouchRepairButton.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Input/TouchRepairButton.cs
@@ -69,7 +69,7 @@ namespace Castlebound.Gameplay.Input
             for (int i = 0; i < all.Count; i++)
             {
                 var barrier = all[i];
-                if (barrier == null || !barrier.IsBroken)
+                if (barrier == null || !barrier.CanRepair)
                     continue;
 
                 var barrierPos = (Vector2)barrier.transform.position;

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/PlayerController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/PlayerController.cs
@@ -11,6 +11,7 @@ public class PlayerController : MonoBehaviour
 
     [Header("Repair")]
     [SerializeField] private RepairSensor _repairSensor;
+    [SerializeField] private float repairCooldownSeconds = 1f;
 
     [Header("Potions")]
     [SerializeField] private PotionUseController potionUseController;
@@ -36,6 +37,7 @@ public class PlayerController : MonoBehaviour
     private PlayerCollisionMove2D mover;
     private InventoryState inventoryState;
     private bool inputLocked;
+    private float repairCooldownRemaining;
 
     public float RepairRange
     {
@@ -50,6 +52,25 @@ public class PlayerController : MonoBehaviour
             _repairSensor.RepairRadius = value;
         }
     }
+
+    public LayerMask RepairBarrierMask
+    {
+        get => _repairSensor != null ? _repairSensor.BarrierMask : default(LayerMask);
+        set
+        {
+            EnsureRepairSensor();
+            _repairSensor.BarrierMask = value;
+        }
+    }
+
+    public float RepairCooldownSeconds
+    {
+        get => repairCooldownSeconds;
+        set => repairCooldownSeconds = Mathf.Max(0f, value);
+    }
+
+    public float RepairCooldownRemaining => repairCooldownRemaining;
+    public bool IsRepairOnCooldown => repairCooldownRemaining > 0f;
 
     void Awake()
     {
@@ -104,6 +125,8 @@ public class PlayerController : MonoBehaviour
 
     void FixedUpdate()
     {
+        TickRepairCooldown(Time.fixedDeltaTime);
+
         if (inputLocked)
             return;
 
@@ -141,11 +164,11 @@ public class PlayerController : MonoBehaviour
     }
 
     /// <summary>
-    /// Returns true if there is at least one broken barrier within repair range.
+    /// Returns true if there is at least one damaged barrier within repair range.
     /// </summary>
     public bool HasRepairableBarrierInRange()
     {
-        return _repairSensor.HasRepairableBarrierInRange(transform.position);
+        return _repairSensor != null && _repairSensor.HasRepairableBarrierInRange(transform.position);
     }
 
     public void OnRepair(InputValue value)
@@ -156,7 +179,33 @@ public class PlayerController : MonoBehaviour
         if (!value.isPressed)
             return;
 
-        _repairSensor.TryRepairNearest(transform.position);
+        TryRepair();
+    }
+
+    public bool TryRepair()
+    {
+        if (inputLocked || IsRepairOnCooldown || _repairSensor == null)
+        {
+            return false;
+        }
+
+        if (!_repairSensor.TryRepairNearest(transform.position))
+        {
+            return false;
+        }
+
+        repairCooldownRemaining = repairCooldownSeconds;
+        return true;
+    }
+
+    public void TickRepairCooldown(float deltaTime)
+    {
+        if (repairCooldownRemaining <= 0f)
+        {
+            return;
+        }
+
+        repairCooldownRemaining = Mathf.Max(0f, repairCooldownRemaining - Mathf.Max(0f, deltaTime));
     }
 
     public void OnUsePotion(InputValue value)
@@ -203,6 +252,14 @@ public class PlayerController : MonoBehaviour
         inventorySource = inventorySource != null ? inventorySource : GetComponent<InventoryStateComponent>();
         inventoryState = inventorySource != null ? inventorySource.State : null;
         return inventoryState != null;
+    }
+
+    private void EnsureRepairSensor()
+    {
+        if (_repairSensor == null)
+        {
+            _repairSensor = new RepairSensor();
+        }
     }
 
     public void StopMovement()

--- a/Assets/_Project/_Tests/EditMode/Balance/PlayerBalanceApplierTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Balance/PlayerBalanceApplierTests.cs
@@ -26,6 +26,7 @@ namespace Castlebound.Tests.Balance
                 table.BaseMaxHealth = 150;
                 table.BaseMoveSpeed = 9.5f;
                 table.BaseRepairRange = 3.25f;
+                table.BaseRepairCooldownSeconds = 1.5f;
                 station.Player = table;
                 applier.BalanceStation = station;
                 applier.PlayerController = controller;
@@ -36,6 +37,7 @@ namespace Castlebound.Tests.Balance
                 Assert.That(health.Current, Is.EqualTo(150));
                 Assert.That(mover.MoveSpeed, Is.EqualTo(9.5f).Within(0.001f));
                 Assert.That(controller.RepairRange, Is.EqualTo(3.25f).Within(0.001f));
+                Assert.That(controller.RepairCooldownSeconds, Is.EqualTo(1.5f).Within(0.001f));
             }
             finally
             {
@@ -63,6 +65,7 @@ namespace Castlebound.Tests.Balance
                 health.ConfigureMaxHealth(200, true);
                 mover.MoveSpeed = 12f;
                 controller.RepairRange = 2f;
+                controller.RepairCooldownSeconds = 1f;
                 applier.BalanceStation = station;
                 applier.PlayerController = controller;
 
@@ -71,6 +74,7 @@ namespace Castlebound.Tests.Balance
                 Assert.That(health.Max, Is.EqualTo(200));
                 Assert.That(mover.MoveSpeed, Is.EqualTo(12f).Within(0.001f));
                 Assert.That(controller.RepairRange, Is.EqualTo(2f).Within(0.001f));
+                Assert.That(controller.RepairCooldownSeconds, Is.EqualTo(1f).Within(0.001f));
             }
             finally
             {

--- a/Assets/_Project/_Tests/EditMode/Balance/PlayerBalanceTableTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Balance/PlayerBalanceTableTests.cs
@@ -21,6 +21,7 @@ namespace Castlebound.Tests.Balance
                 Assert.That(table.BaseMaxHealth, Is.EqualTo(200));
                 Assert.That(table.BaseMoveSpeed, Is.EqualTo(12f).Within(0.001f));
                 Assert.That(table.BaseRepairRange, Is.EqualTo(2f).Within(0.001f));
+                Assert.That(table.BaseRepairCooldownSeconds, Is.EqualTo(1f).Within(0.001f));
             }
             finally
             {
@@ -38,10 +39,12 @@ namespace Castlebound.Tests.Balance
                 table.BaseMaxHealth = -1;
                 table.BaseMoveSpeed = -1f;
                 table.BaseRepairRange = -1f;
+                table.BaseRepairCooldownSeconds = -1f;
 
                 Assert.That(table.BaseMaxHealth, Is.EqualTo(0));
                 Assert.That(table.BaseMoveSpeed, Is.EqualTo(0f));
                 Assert.That(table.BaseRepairRange, Is.EqualTo(0f));
+                Assert.That(table.BaseRepairCooldownSeconds, Is.EqualTo(0f));
             }
             finally
             {
@@ -61,6 +64,7 @@ namespace Castlebound.Tests.Balance
             Assert.That(table.BaseMaxHealth, Is.EqualTo(200));
             Assert.That(table.BaseMoveSpeed, Is.EqualTo(12f).Within(0.001f));
             Assert.That(table.BaseRepairRange, Is.EqualTo(2f).Within(0.001f));
+            Assert.That(table.BaseRepairCooldownSeconds, Is.EqualTo(1f).Within(0.001f));
         }
     }
 }

--- a/Assets/_Project/_Tests/EditMode/Barrier/BarrierHealthTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Barrier/BarrierHealthTests.cs
@@ -51,6 +51,49 @@ namespace Castlebound.Tests.Gate
             Object.DestroyImmediate(barrier);
         }
 
+        [Test]
+        public void Repair_WhenDamagedButNotBroken_RestoresHealthAndRaisesRepairedEvent()
+        {
+            var barrier = new GameObject("Barrier");
+            var health = barrier.AddComponent<BarrierHealth>();
+            health.MaxHealth = 10;
+            health.CurrentHealth = 10;
+            var repairedCount = 0;
+            health.OnRepaired += () => repairedCount++;
+
+            health.TakeDamage(4);
+            var repaired = health.Repair();
+
+            Assert.IsTrue(repaired);
+            Assert.IsFalse(health.IsBroken);
+            Assert.IsFalse(health.IsDamaged);
+            Assert.IsFalse(health.CanRepair);
+            Assert.That(health.CurrentHealth, Is.EqualTo(health.MaxHealth));
+            Assert.That(repairedCount, Is.EqualTo(1));
+
+            Object.DestroyImmediate(barrier);
+        }
+
+        [Test]
+        public void Repair_WhenFullHealth_DoesNotRaiseRepairedEvent()
+        {
+            var barrier = new GameObject("Barrier");
+            var health = barrier.AddComponent<BarrierHealth>();
+            health.MaxHealth = 10;
+            health.CurrentHealth = 10;
+            var repairedCount = 0;
+            health.OnRepaired += () => repairedCount++;
+
+            var repaired = health.Repair();
+
+            Assert.IsFalse(repaired);
+            Assert.IsFalse(health.IsDamaged);
+            Assert.IsFalse(health.CanRepair);
+            Assert.That(repairedCount, Is.EqualTo(0));
+
+            Object.DestroyImmediate(barrier);
+        }
+
         private static SpriteRenderer CreateRenderer(Transform parent, string name)
         {
             var child = new GameObject(name);

--- a/Assets/_Project/_Tests/EditMode/Input/TouchRepairButtonTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Input/TouchRepairButtonTests.cs
@@ -63,7 +63,7 @@ namespace Castlebound.Tests.Input
         }
 
         [Test]
-        public void IsVisible_ReturnsFalse_WhenBarrierInRangeButNotBroken()
+        public void IsVisible_ReturnsFalse_WhenBarrierInRangeButFullHealth()
         {
             _barrierGo = new GameObject("Barrier");
             _barrierGo.transform.position = new Vector3(1f, 0f, 0f);
@@ -73,7 +73,7 @@ namespace Castlebound.Tests.Input
             _button.UpdateProximity(Vector2.zero, checkRadius: 5f);
 
             Assert.IsFalse(_button.IsVisible,
-                "Button should be hidden when nearby barrier is not broken.");
+                "Button should be hidden when nearby barrier is full health.");
         }
 
         [Test]
@@ -109,7 +109,9 @@ namespace Castlebound.Tests.Input
             go = new GameObject("Barrier");
             go.transform.position = new Vector3(position.x, position.y, 0f);
             var health = go.AddComponent<BarrierHealth>();
-            health.TakeDamage(999);
+            health.MaxHealth = 10;
+            health.CurrentHealth = 10;
+            health.TakeDamage(4);
             return health;
         }
     }

--- a/Assets/_Project/_Tests/EditMode/Player/PlayerRepairControllerTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Player/PlayerRepairControllerTests.cs
@@ -1,0 +1,104 @@
+using NUnit.Framework;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace Castlebound.Tests.Player
+{
+    public class PlayerRepairControllerTests
+    {
+        private GameObject _playerGo;
+        private PlayerController _controller;
+        private GameObject _barrierGo;
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_barrierGo != null)
+            {
+                Object.DestroyImmediate(_barrierGo);
+            }
+
+            if (_playerGo != null)
+            {
+                Object.DestroyImmediate(_playerGo);
+            }
+        }
+
+        [Test]
+        public void HasRepairableBarrierInRange_ReturnsTrue_ForDamagedUnbrokenBarrier()
+        {
+            CreatePlayer();
+            var barrier = CreateBarrier(new Vector2(1f, 0f), maxHealth: 10, currentHealth: 6);
+
+            var result = _controller.HasRepairableBarrierInRange();
+
+            Assert.IsTrue(result);
+            Assert.IsTrue(barrier.CanRepair);
+        }
+
+        [Test]
+        public void TryRepair_RepairsDamagedBarrier_AndStartsCooldown()
+        {
+            CreatePlayer();
+            var barrier = CreateBarrier(new Vector2(1f, 0f), maxHealth: 10, currentHealth: 6);
+
+            var repaired = _controller.TryRepair();
+
+            Assert.IsTrue(repaired);
+            Assert.That(barrier.CurrentHealth, Is.EqualTo(10));
+            Assert.That(_controller.RepairCooldownRemaining, Is.EqualTo(_controller.RepairCooldownSeconds).Within(0.001f));
+        }
+
+        [Test]
+        public void TryRepair_WhenBarrierIsFull_DoesNotStartCooldown()
+        {
+            CreatePlayer();
+            CreateBarrier(new Vector2(1f, 0f), maxHealth: 10, currentHealth: 10);
+
+            var repaired = _controller.TryRepair();
+
+            Assert.IsFalse(repaired);
+            Assert.That(_controller.RepairCooldownRemaining, Is.EqualTo(0f));
+        }
+
+        [Test]
+        public void TryRepair_BlocksUntilCooldownExpires()
+        {
+            CreatePlayer();
+            var barrier = CreateBarrier(new Vector2(1f, 0f), maxHealth: 10, currentHealth: 6);
+
+            Assert.IsTrue(_controller.TryRepair());
+            barrier.TakeDamage(2);
+
+            Assert.IsFalse(_controller.TryRepair(), "Repair should be blocked while cooldown is active.");
+
+            _controller.TickRepairCooldown(_controller.RepairCooldownSeconds);
+
+            Assert.IsTrue(_controller.TryRepair(), "Repair should be allowed after cooldown expires.");
+            Assert.That(barrier.CurrentHealth, Is.EqualTo(10));
+        }
+
+        private void CreatePlayer()
+        {
+            _playerGo = new GameObject("Player");
+            _playerGo.transform.position = Vector3.zero;
+            _controller = _playerGo.AddComponent<PlayerController>();
+            _controller.RepairRange = 2f;
+            _controller.RepairBarrierMask = 1 << 0;
+            _controller.RepairCooldownSeconds = 1f;
+        }
+
+        private BarrierHealth CreateBarrier(Vector2 position, int maxHealth, int currentHealth)
+        {
+            _barrierGo = new GameObject("Barrier");
+            _barrierGo.layer = 0;
+            _barrierGo.transform.position = position;
+            _barrierGo.AddComponent<BoxCollider2D>();
+            var health = _barrierGo.AddComponent<BarrierHealth>();
+            health.MaxHealth = maxHealth;
+            health.CurrentHealth = currentHealth;
+            Physics2D.SyncTransforms();
+            return health;
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Player/PlayerRepairControllerTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Player/PlayerRepairControllerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 18b20542b39e4625be3879a10ae57097
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/_Tests/EditMode/PrefabSmokeTests.cs
+++ b/Assets/_Project/_Tests/EditMode/PrefabSmokeTests.cs
@@ -36,6 +36,14 @@ public class PrefabSmokeTests
         PrefabTestUtil.Unload(go);
     }
 
+    [Test] public void Player_RepairCooldown_IsAuthored() {
+        var go = PrefabTestUtil.Load(PlayerPath);
+        var controller = go.GetComponent<PlayerController>();
+        Assert.NotNull(controller);
+        Assert.That(controller.RepairCooldownSeconds, Is.EqualTo(1f).Within(0.001f));
+        PrefabTestUtil.Unload(go);
+    }
+
     [Test] public void Player_Has_Health() {
         var go = PrefabTestUtil.Load(PlayerPath);
         Assert.NotNull(go.GetComponent<Health>());

--- a/Assets/_Project/_Tests/PlayMode/Barrier/BarrierRepairOverlapIntegrationPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/Barrier/BarrierRepairOverlapIntegrationPlayTests.cs
@@ -35,6 +35,9 @@ namespace Castlebound.Tests.Gate
             Physics2D.SyncTransforms();
 
             Vector2 before = playerGo.transform.position;
+            barrierHealth.MaxHealth = 10;
+            barrierHealth.CurrentHealth = 10;
+            barrierHealth.TakeDamage(1);
             barrierHealth.Repair();
 
             yield return new WaitForFixedUpdate();

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,28 @@
 
 ---
 
+## 2026-06-26 - fix(barrier): allow repair below max health with cooldown
+
+### Summary
+- Added damaged-barrier repair coverage so barriers below max health are repairable before breaking.
+- Added player repair cooldown coverage to prevent repeated repair attempts until the cooldown expires.
+- Routed repair cooldown tuning through the player balance table and balance applier.
+
+### New or Updated Tests
+**EditMode**
+- `BarrierHealthTests` - validates damaged repair, full-health no-op repair, and repaired event behavior.
+- `PlayerRepairControllerTests` - validates repair sensor detection, repair cooldown start, full-health no-op, and cooldown expiry.
+- `PlayerBalanceTableTests` - validates repair cooldown defaults, clamping, and project asset tuning.
+- `PlayerBalanceApplierTests` - validates repair cooldown application and missing-table preservation.
+- `TouchRepairButtonTests` - validates repair visibility for damaged barriers instead of broken-only barriers.
+- `PrefabSmokeTests` - validates the authored Player prefab repair cooldown.
+
+**PlayMode**
+- `BarrierRepairOverlapIntegrationPlayTests` - validates overlap resolution still runs from a damaged repair flow.
+
+### Notes
+- N/A
+
 ## 2026-06-21 - feat(loot): add magnetic pickup attraction
 
 ### Summary


### PR DESCRIPTION
## Why
Barrier repair only targeted fully broken gates, which meant partially damaged barriers could not be restored during play. Repair input also needed a short pacing cooldown so repeated repair presses have an authored cadence.

## What changed
- Added damaged-barrier repair eligibility for barriers below max health
- Made full-health repair attempts no-op without firing repair events or consuming cooldown
- Added player repair cooldown timing and balance-table tuning
- Updated touch repair visibility to show damaged barriers instead of broken-only barriers
- Serialized repair cooldown on the Player prefab and player balance asset
- Added EditMode and PlayMode regression coverage for damaged repair, cooldown gating, prefab tuning, and repair overlap resolution

## How to test
1. Damage a barrier without breaking it
2. Verify the repair button/input appears in range and restores the barrier to max health
3. Verify full-health barriers do not consume repair cooldown
4. Verify repeated repair attempts are blocked until the cooldown expires
5. Run tests:
   - EditMode
   - PlayMode

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated (N/A - behavior is prefab and balance-data driven)
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched (N/A - TEST_LOG updated, no README change needed)

## Related
- Closes #194