### PR TITLE
feat(inventory): add castle inventory vault

### DIFF
--- a/Assets/_Project/Scripts/_Project.Gameplay/Inventory/CastleInventoryEntry.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Inventory/CastleInventoryEntry.cs
@@ -1,0 +1,14 @@
+namespace Castlebound.Gameplay.Inventory
+{
+    public sealed class CastleInventoryEntry
+    {
+        public CastleInventoryEntry(string itemId, int count)
+        {
+            ItemId = itemId;
+            Count = count;
+        }
+
+        public string ItemId { get; }
+        public int Count { get; }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Inventory/CastleInventoryEntry.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Inventory/CastleInventoryEntry.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c7c8aa1199d140edab4b08ed0aad84a9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/_Project.Gameplay/Inventory/CastleInventoryState.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Inventory/CastleInventoryState.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+
+namespace Castlebound.Gameplay.Inventory
+{
+    public class CastleInventoryState
+    {
+        private readonly Dictionary<string, int> itemCounts = new Dictionary<string, int>(StringComparer.Ordinal);
+
+        public event Action OnInventoryChanged;
+
+        public int EntryCount => itemCounts.Count;
+
+        public IReadOnlyList<CastleInventoryEntry> Entries
+        {
+            get
+            {
+                var entries = new List<CastleInventoryEntry>(itemCounts.Count);
+                foreach (var pair in itemCounts)
+                {
+                    entries.Add(new CastleInventoryEntry(pair.Key, pair.Value));
+                }
+
+                entries.Sort((a, b) => string.CompareOrdinal(a.ItemId, b.ItemId));
+                return entries;
+            }
+        }
+
+        public int GetCount(string itemId)
+        {
+            if (!IsValidItemId(itemId))
+            {
+                return 0;
+            }
+
+            return itemCounts.TryGetValue(itemId, out var count) ? count : 0;
+        }
+
+        public bool AddItem(string itemId, int amount)
+        {
+            if (!IsValidItemId(itemId) || amount <= 0)
+            {
+                return false;
+            }
+
+            itemCounts.TryGetValue(itemId, out var currentCount);
+            itemCounts[itemId] = currentCount + amount;
+            RaiseChanged();
+            return true;
+        }
+
+        public bool TryRemoveItem(string itemId, int amount)
+        {
+            if (!IsValidItemId(itemId) || amount <= 0)
+            {
+                return false;
+            }
+
+            if (!itemCounts.TryGetValue(itemId, out var currentCount) || currentCount < amount)
+            {
+                return false;
+            }
+
+            var remaining = currentCount - amount;
+            if (remaining == 0)
+            {
+                itemCounts.Remove(itemId);
+            }
+            else
+            {
+                itemCounts[itemId] = remaining;
+            }
+
+            RaiseChanged();
+            return true;
+        }
+
+        private static bool IsValidItemId(string itemId)
+        {
+            return !string.IsNullOrWhiteSpace(itemId);
+        }
+
+        private void RaiseChanged()
+        {
+            OnInventoryChanged?.Invoke();
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Inventory/CastleInventoryState.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Inventory/CastleInventoryState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6454e3dd19d84ddf971deb9639877317
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/_Project.Gameplay/Inventory/CastleInventoryStateComponent.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Inventory/CastleInventoryStateComponent.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+
+namespace Castlebound.Gameplay.Inventory
+{
+    public class CastleInventoryStateComponent : MonoBehaviour
+    {
+        private CastleInventoryState state;
+
+        public CastleInventoryState State
+        {
+            get
+            {
+                if (state == null)
+                {
+                    state = new CastleInventoryState();
+                }
+
+                return state;
+            }
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Inventory/CastleInventoryStateComponent.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Inventory/CastleInventoryStateComponent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 70bc9d27b3ee42a98d972f4180fde0da
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/_Tests/EditMode/Inventory/CastleInventoryStateComponentTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Inventory/CastleInventoryStateComponentTests.cs
@@ -1,0 +1,31 @@
+using Castlebound.Gameplay.Inventory;
+using NUnit.Framework;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace Castlebound.Tests.Inventory
+{
+    public class CastleInventoryStateComponentTests
+    {
+        [Test]
+        public void State_ReturnsStableVaultState()
+        {
+            var go = new GameObject("CastleInventory");
+
+            try
+            {
+                var component = go.AddComponent<CastleInventoryStateComponent>();
+                var state = component.State;
+
+                state.AddItem("potion_basic", 2);
+
+                Assert.AreSame(state, component.State);
+                Assert.That(component.State.GetCount("potion_basic"), Is.EqualTo(2));
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+            }
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Inventory/CastleInventoryStateComponentTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Inventory/CastleInventoryStateComponentTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d734680bc4c94225934277cedac12836
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/_Tests/EditMode/Inventory/CastleInventoryStateTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Inventory/CastleInventoryStateTests.cs
@@ -1,0 +1,143 @@
+using System.Collections.Generic;
+using Castlebound.Gameplay.Inventory;
+using NUnit.Framework;
+
+namespace Castlebound.Tests.Inventory
+{
+    public class CastleInventoryStateTests
+    {
+        [Test]
+        public void AddItem_WithValidItem_AddsCountAndRaisesChanged()
+        {
+            var state = new CastleInventoryState();
+            var recorder = new EventRecorder();
+            state.OnInventoryChanged += recorder.Record;
+
+            var added = state.AddItem("potion_basic", 2);
+
+            Assert.IsTrue(added);
+            Assert.That(state.GetCount("potion_basic"), Is.EqualTo(2));
+            Assert.That(state.EntryCount, Is.EqualTo(1));
+            Assert.That(recorder.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void AddItem_ExistingItem_IncrementsCount()
+        {
+            var state = new CastleInventoryState();
+
+            state.AddItem("potion_basic", 2);
+            state.AddItem("potion_basic", 3);
+
+            Assert.That(state.GetCount("potion_basic"), Is.EqualTo(5));
+            Assert.That(state.EntryCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void AddItem_InvalidInput_IsRejectedAndDoesNotRaiseChanged()
+        {
+            var state = new CastleInventoryState();
+            var recorder = new EventRecorder();
+            state.OnInventoryChanged += recorder.Record;
+
+            Assert.IsFalse(state.AddItem(null, 1));
+            Assert.IsFalse(state.AddItem("", 1));
+            Assert.IsFalse(state.AddItem("   ", 1));
+            Assert.IsFalse(state.AddItem("potion_basic", 0));
+            Assert.IsFalse(state.AddItem("potion_basic", -1));
+
+            Assert.That(state.EntryCount, Is.EqualTo(0));
+            Assert.That(recorder.Count, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void TryRemoveItem_WithEnoughCount_DecrementsCountAndRaisesChanged()
+        {
+            var state = new CastleInventoryState();
+            var recorder = new EventRecorder();
+            state.AddItem("potion_basic", 5);
+            state.OnInventoryChanged += recorder.Record;
+
+            var removed = state.TryRemoveItem("potion_basic", 2);
+
+            Assert.IsTrue(removed);
+            Assert.That(state.GetCount("potion_basic"), Is.EqualTo(3));
+            Assert.That(recorder.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void TryRemoveItem_WhenCountReachesZero_RemovesEntry()
+        {
+            var state = new CastleInventoryState();
+            state.AddItem("potion_basic", 2);
+
+            var removed = state.TryRemoveItem("potion_basic", 2);
+
+            Assert.IsTrue(removed);
+            Assert.That(state.GetCount("potion_basic"), Is.EqualTo(0));
+            Assert.That(state.EntryCount, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void TryRemoveItem_WithInvalidOrInsufficientCount_IsRejectedAndDoesNotRaiseChanged()
+        {
+            var state = new CastleInventoryState();
+            var recorder = new EventRecorder();
+            state.AddItem("potion_basic", 1);
+            state.OnInventoryChanged += recorder.Record;
+
+            Assert.IsFalse(state.TryRemoveItem(null, 1));
+            Assert.IsFalse(state.TryRemoveItem("", 1));
+            Assert.IsFalse(state.TryRemoveItem("   ", 1));
+            Assert.IsFalse(state.TryRemoveItem("potion_basic", 0));
+            Assert.IsFalse(state.TryRemoveItem("potion_basic", -1));
+            Assert.IsFalse(state.TryRemoveItem("missing_item", 1));
+            Assert.IsFalse(state.TryRemoveItem("potion_basic", 2));
+
+            Assert.That(state.GetCount("potion_basic"), Is.EqualTo(1));
+            Assert.That(recorder.Count, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void Entries_ReturnSnapshotThatCannotMutateVault()
+        {
+            var state = new CastleInventoryState();
+            state.AddItem("potion_basic", 2);
+
+            var entries = state.Entries;
+            Assert.That(entries.Count, Is.EqualTo(1));
+            Assert.That(entries[0].ItemId, Is.EqualTo("potion_basic"));
+            Assert.That(entries[0].Count, Is.EqualTo(2));
+
+            var mutableSnapshot = entries as IList<CastleInventoryEntry>;
+            Assert.NotNull(mutableSnapshot);
+            mutableSnapshot.Clear();
+
+            Assert.That(state.EntryCount, Is.EqualTo(1));
+            Assert.That(state.GetCount("potion_basic"), Is.EqualTo(2));
+        }
+
+        [Test]
+        public void Entries_AreSortedByItemId()
+        {
+            var state = new CastleInventoryState();
+            state.AddItem("weapon_sword", 1);
+            state.AddItem("potion_basic", 1);
+
+            var entries = state.Entries;
+
+            Assert.That(entries[0].ItemId, Is.EqualTo("potion_basic"));
+            Assert.That(entries[1].ItemId, Is.EqualTo("weapon_sword"));
+        }
+
+        private sealed class EventRecorder
+        {
+            public int Count { get; private set; }
+
+            public void Record()
+            {
+                Count++;
+            }
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Inventory/CastleInventoryStateTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Inventory/CastleInventoryStateTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 27378eabce7941329fbdf9b795ac04e0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,24 @@
 
 ---
 
+## 2026-07-01 - feat(inventory): add Castle Inventory persistent vault
+
+### Summary
+- Added a separate Castle Inventory vault state for persistent count-based item storage.
+- Added a lightweight runtime component wrapper without changing active player inventory behavior.
+- Covered valid adds, rejected inputs, removals, event emission, sorted entries, and snapshot safety.
+
+### New or Updated Tests
+**EditMode**
+- `CastleInventoryStateTests` — validates vault item counts, invalid input rejection, removal semantics, change events, sorted entries, and snapshot safety.
+- `CastleInventoryStateComponentTests` — validates stable component access to the vault state.
+
+**PlayMode**
+- N/A — data-model slice only; no scene or prefab runtime path changed.
+
+### Notes
+- Active `InventoryState` combat inventory remains unchanged.
+
 ## 2026-06-26 - fix(barrier): allow repair below max health with cooldown
 
 ### Summary


### PR DESCRIPTION
## Why
P4 needs a persistent Castle Inventory foundation before backpack, shop, wave-end transfer, or inventory UI work can safely build on it.

## What changed
- Added a count-based Castle Inventory vault state
- Added immutable vault entry snapshots
- Added a lightweight runtime component wrapper
- Kept active player combat inventory unchanged
- Added EditMode coverage for vault storage behavior and component state access

## How to test
1. Run tests:
   - EditMode
   - PlayMode (N/A - data-model slice; no scene or prefab runtime path changed)

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included (N/A - data-model slice)
- [x] Demo scene updated (N/A - no scene changes)
- [x] Prefab links, tags, and layers validated (N/A - no prefab/tag/layer changes)
- [x] README / Docs touched (TEST_LOG updated)

## Related
- Closes #90