### PR TITLE
feat(inventory): add backpack mid-wave carry

### DIFF
--- a/Assets/_Project/Prefabs/Player.prefab
+++ b/Assets/_Project/Prefabs/Player.prefab
@@ -109,6 +109,7 @@ GameObject:
   - component: {fileID: 2634735562689669640}
   - component: {fileID: -5784453068084145222}
   - component: {fileID: -4357144976434651652}
+  - component: {fileID: 9150000000000000501}
   - component: {fileID: -4056653655764099198}
   - component: {fileID: -6994024940450972999}
   - component: {fileID: 7777777777777777777}
@@ -236,8 +237,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 46b2ad7cb8a7016428ebbadebf1330c8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   animator: {fileID: 0}
   hitboxObject: {fileID: 1272401345759337948}
   _repairSensor:
@@ -426,6 +427,19 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   startingGold: 0
+--- !u!114 &9150000000000000501
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8325390509751579795}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a2bf8026df834bdb9808c4b877230f55, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  maxItemCount: 8
 --- !u!114 &-4056653655764099198
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/_Project/Scripts/_Project.Gameplay/Inventory/BackpackInventoryEntry.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Inventory/BackpackInventoryEntry.cs
@@ -1,0 +1,14 @@
+namespace Castlebound.Gameplay.Inventory
+{
+    public sealed class BackpackInventoryEntry
+    {
+        public BackpackInventoryEntry(string itemId, int count)
+        {
+            ItemId = itemId;
+            Count = count;
+        }
+
+        public string ItemId { get; }
+        public int Count { get; }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Inventory/BackpackInventoryEntry.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Inventory/BackpackInventoryEntry.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c0a8d85d206449ea8210b30328eb3fee
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/_Project.Gameplay/Inventory/BackpackInventoryState.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Inventory/BackpackInventoryState.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Castlebound.Gameplay.Inventory
+{
+    public class BackpackInventoryState
+    {
+        private readonly Dictionary<string, int> itemCounts = new Dictionary<string, int>(StringComparer.Ordinal);
+        private int maxItemCount;
+
+        public BackpackInventoryState(int maxItemCount = 8)
+        {
+            MaxItemCount = maxItemCount;
+        }
+
+        public event Action OnInventoryChanged;
+
+        public int MaxItemCount
+        {
+            get => maxItemCount;
+            set => maxItemCount = Mathf.Max(0, value);
+        }
+
+        public int ItemCount { get; private set; }
+        public int EntryCount => itemCounts.Count;
+
+        public IReadOnlyList<BackpackInventoryEntry> Entries
+        {
+            get
+            {
+                var entries = new List<BackpackInventoryEntry>(itemCounts.Count);
+                foreach (var pair in itemCounts)
+                {
+                    entries.Add(new BackpackInventoryEntry(pair.Key, pair.Value));
+                }
+
+                entries.Sort((a, b) => string.CompareOrdinal(a.ItemId, b.ItemId));
+                return entries;
+            }
+        }
+
+        public int GetCount(string itemId)
+        {
+            if (!IsValidItemId(itemId))
+            {
+                return 0;
+            }
+
+            return itemCounts.TryGetValue(itemId, out var count) ? count : 0;
+        }
+
+        public bool CanAddItem(string itemId, int amount)
+        {
+            return IsValidItemId(itemId) && amount > 0 && ItemCount + amount <= MaxItemCount;
+        }
+
+        public bool AddItem(string itemId, int amount)
+        {
+            if (!CanAddItem(itemId, amount))
+            {
+                return false;
+            }
+
+            itemCounts.TryGetValue(itemId, out var currentCount);
+            itemCounts[itemId] = currentCount + amount;
+            ItemCount += amount;
+            RaiseChanged();
+            return true;
+        }
+
+        public bool TryRemoveItem(string itemId, int amount)
+        {
+            if (!IsValidItemId(itemId) || amount <= 0)
+            {
+                return false;
+            }
+
+            if (!itemCounts.TryGetValue(itemId, out var currentCount) || currentCount < amount)
+            {
+                return false;
+            }
+
+            var remaining = currentCount - amount;
+            if (remaining == 0)
+            {
+                itemCounts.Remove(itemId);
+            }
+            else
+            {
+                itemCounts[itemId] = remaining;
+            }
+
+            ItemCount -= amount;
+            RaiseChanged();
+            return true;
+        }
+
+        public bool Clear()
+        {
+            if (ItemCount == 0)
+            {
+                return false;
+            }
+
+            itemCounts.Clear();
+            ItemCount = 0;
+            RaiseChanged();
+            return true;
+        }
+
+        private static bool IsValidItemId(string itemId)
+        {
+            return !string.IsNullOrWhiteSpace(itemId);
+        }
+
+        private void RaiseChanged()
+        {
+            OnInventoryChanged?.Invoke();
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Inventory/BackpackInventoryState.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Inventory/BackpackInventoryState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 43dc452b864342548f3f4643eef54a33
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/_Project.Gameplay/Inventory/BackpackInventoryStateComponent.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Inventory/BackpackInventoryStateComponent.cs
@@ -1,0 +1,42 @@
+using UnityEngine;
+
+namespace Castlebound.Gameplay.Inventory
+{
+    public class BackpackInventoryStateComponent : MonoBehaviour
+    {
+        [SerializeField] private int maxItemCount = 8;
+
+        private BackpackInventoryState state;
+
+        public int MaxItemCount
+        {
+            get => maxItemCount;
+            set
+            {
+                maxItemCount = Mathf.Max(0, value);
+                if (state != null)
+                {
+                    state.MaxItemCount = maxItemCount;
+                }
+            }
+        }
+
+        public BackpackInventoryState State
+        {
+            get
+            {
+                if (state == null)
+                {
+                    state = new BackpackInventoryState(maxItemCount);
+                }
+
+                return state;
+            }
+        }
+
+        private void OnValidate()
+        {
+            MaxItemCount = maxItemCount;
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Inventory/BackpackInventoryStateComponent.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Inventory/BackpackInventoryStateComponent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a2bf8026df834bdb9808c4b877230f55
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/_Project.Gameplay/Inventory/InventoryPickupContext.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Inventory/InventoryPickupContext.cs
@@ -1,0 +1,14 @@
+namespace Castlebound.Gameplay.Inventory
+{
+    public readonly struct InventoryPickupContext
+    {
+        public InventoryPickupContext(InventoryState activeInventory, BackpackInventoryState backpack)
+        {
+            ActiveInventory = activeInventory;
+            Backpack = backpack;
+        }
+
+        public InventoryState ActiveInventory { get; }
+        public BackpackInventoryState Backpack { get; }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Inventory/InventoryPickupContext.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Inventory/InventoryPickupContext.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1f66bebce36c497998a7d3ed7af40309
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/_Project.Gameplay/Inventory/ItemPickup.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Inventory/ItemPickup.cs
@@ -70,6 +70,11 @@ namespace Castlebound.Gameplay.Inventory
             }
         }
 
+        public bool CanAutoPickup(InventoryPickupContext context)
+        {
+            return CanAutoPickup(context.ActiveInventory) || CanOverflowToBackpack(context);
+        }
+
         public bool TryAutoPickup(InventoryState inventory)
         {
             if (!CanAutoPickup(inventory))
@@ -78,6 +83,21 @@ namespace Castlebound.Gameplay.Inventory
             }
 
             return Apply(inventory);
+        }
+
+        public bool TryAutoPickup(InventoryPickupContext context)
+        {
+            if (CanAutoPickup(context.ActiveInventory))
+            {
+                return Apply(context.ActiveInventory);
+            }
+
+            if (CanOverflowToBackpack(context))
+            {
+                return context.Backpack.AddItem(ItemId, Amount);
+            }
+
+            return false;
         }
 
         public bool TryManualPickup(InventoryState inventory)
@@ -118,6 +138,15 @@ namespace Castlebound.Gameplay.Inventory
             }
 
             return false;
+        }
+
+        private bool CanOverflowToBackpack(InventoryPickupContext context)
+        {
+            return Kind == ItemPickupKind.Weapon &&
+                !string.IsNullOrWhiteSpace(ItemId) &&
+                Amount > 0 &&
+                context.Backpack != null &&
+                context.Backpack.CanAddItem(ItemId, Amount);
         }
     }
 }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Inventory/ItemPickupComponent.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Inventory/ItemPickupComponent.cs
@@ -67,12 +67,12 @@ namespace Castlebound.Gameplay.Inventory
                 return;
             }
 
-            if (!TryGetInventory(other, out InventoryState inventory))
+            if (!TryGetPickupContext(other, out InventoryPickupContext context))
             {
                 return;
             }
 
-            TryAutoPickup(inventory);
+            TryAutoPickup(context);
         }
 
         private void OnTriggerStay2D(Collider2D other)
@@ -87,12 +87,12 @@ namespace Castlebound.Gameplay.Inventory
                 return;
             }
 
-            if (!TryGetInventory(other, out InventoryState inventory))
+            if (!TryGetPickupContext(other, out InventoryPickupContext context))
             {
                 return;
             }
 
-            TryAutoPickup(inventory);
+            TryAutoPickup(context);
         }
 
         public bool TryAutoPickup(InventoryState inventory)
@@ -112,6 +112,23 @@ namespace Castlebound.Gameplay.Inventory
             return result;
         }
 
+        public bool TryAutoPickup(InventoryPickupContext context)
+        {
+            if (!CanAutoPickup(context))
+            {
+                return false;
+            }
+
+            ItemPickup pickup = GetPickup();
+            bool result = pickup.TryAutoPickup(context);
+            if (result)
+            {
+                Consume();
+            }
+
+            return result;
+        }
+
         public bool CanAutoPickup(InventoryState inventory)
         {
             if (IsConsumed || pickupDelayRemaining > 0f)
@@ -121,6 +138,17 @@ namespace Castlebound.Gameplay.Inventory
 
             ItemPickup pickup = GetPickup();
             return pickup != null && pickup.CanAutoPickup(inventory);
+        }
+
+        public bool CanAutoPickup(InventoryPickupContext context)
+        {
+            if (IsConsumed || pickupDelayRemaining > 0f)
+            {
+                return false;
+            }
+
+            ItemPickup pickup = GetPickup();
+            return pickup != null && pickup.CanAutoPickup(context);
         }
 
         public bool TryManualPickup(InventoryState inventory)
@@ -200,22 +228,25 @@ namespace Castlebound.Gameplay.Inventory
             InvalidatePickupCache();
         }
 
-        private static bool TryGetInventory(Component other, out InventoryState inventory)
+        private static bool TryGetPickupContext(Component other, out InventoryPickupContext context)
         {
             if (other.GetComponent<Castlebound.Gameplay.Player.PlayerPickupCollider>() == null)
             {
-                inventory = null;
+                context = default(InventoryPickupContext);
                 return false;
             }
 
-            InventoryStateComponent component = other.GetComponentInParent<InventoryStateComponent>();
-            if (component != null)
+            InventoryStateComponent inventoryComponent = other.GetComponentInParent<InventoryStateComponent>();
+            if (inventoryComponent != null)
             {
-                inventory = component.State;
+                BackpackInventoryStateComponent backpackComponent = other.GetComponentInParent<BackpackInventoryStateComponent>();
+                context = new InventoryPickupContext(
+                    inventoryComponent.State,
+                    backpackComponent != null ? backpackComponent.State : null);
                 return true;
             }
 
-            inventory = null;
+            context = default(InventoryPickupContext);
             return false;
         }
 

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/PickupMagnetField.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/PickupMagnetField.cs
@@ -11,6 +11,7 @@ namespace Castlebound.Gameplay.Player
         [SerializeField] private EnemySpawnerRunner waveRunner;
 
         private InventoryStateComponent inventoryComponent;
+        private BackpackInventoryStateComponent backpackComponent;
         private bool isSweepActive;
 
         public GameBalanceStation BalanceStation
@@ -38,6 +39,7 @@ namespace Castlebound.Gameplay.Player
         private void Awake()
         {
             inventoryComponent = GetComponentInChildren<InventoryStateComponent>();
+            backpackComponent = GetComponentInChildren<BackpackInventoryStateComponent>();
             EnsureWaveRunner();
         }
 
@@ -69,12 +71,20 @@ namespace Castlebound.Gameplay.Player
                 inventoryComponent = GetComponentInChildren<InventoryStateComponent>();
             }
 
+            if (backpackComponent == null)
+            {
+                backpackComponent = GetComponentInChildren<BackpackInventoryStateComponent>();
+            }
+
             if (pickup == null || pickup.IsConsumed || inventoryComponent == null)
             {
                 return false;
             }
 
-            return pickup.CanAutoPickup(inventoryComponent.State);
+            var context = new InventoryPickupContext(
+                inventoryComponent.State,
+                backpackComponent != null ? backpackComponent.State : null);
+            return pickup.CanAutoPickup(context);
         }
 
         public bool IsWithinRange(Vector3 position)

--- a/Assets/_Project/_Tests/EditMode/Inventory/BackpackInventoryStateComponentTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Inventory/BackpackInventoryStateComponentTests.cs
@@ -1,0 +1,31 @@
+using Castlebound.Gameplay.Inventory;
+using NUnit.Framework;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace Castlebound.Tests.Inventory
+{
+    public class BackpackInventoryStateComponentTests
+    {
+        [Test]
+        public void State_ReturnsStableBackpackStateWithAuthoredCapacity()
+        {
+            var go = new GameObject("Backpack");
+
+            try
+            {
+                var component = go.AddComponent<BackpackInventoryStateComponent>();
+                component.MaxItemCount = 1;
+
+                var state = component.State;
+
+                Assert.AreSame(state, component.State);
+                Assert.That(state.MaxItemCount, Is.EqualTo(1));
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+            }
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Inventory/BackpackInventoryStateComponentTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Inventory/BackpackInventoryStateComponentTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e691fb5d0a4042bdad9669db983ee618
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/_Tests/EditMode/Inventory/BackpackInventoryStateTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Inventory/BackpackInventoryStateTests.cs
@@ -1,0 +1,113 @@
+using System.Collections.Generic;
+using Castlebound.Gameplay.Inventory;
+using NUnit.Framework;
+
+namespace Castlebound.Tests.Inventory
+{
+    public class BackpackInventoryStateTests
+    {
+        [Test]
+        public void AddItem_WithCapacity_AddsCountAndRaisesChanged()
+        {
+            var backpack = new BackpackInventoryState(maxItemCount: 2);
+            var recorder = new EventRecorder();
+            backpack.OnInventoryChanged += recorder.Record;
+
+            var added = backpack.AddItem("weapon_sword", 1);
+
+            Assert.IsTrue(added);
+            Assert.That(backpack.GetCount("weapon_sword"), Is.EqualTo(1));
+            Assert.That(backpack.ItemCount, Is.EqualTo(1));
+            Assert.That(backpack.EntryCount, Is.EqualTo(1));
+            Assert.That(recorder.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void AddItem_WhenCapacityExceeded_IsRejectedAndDoesNotRaiseChanged()
+        {
+            var backpack = new BackpackInventoryState(maxItemCount: 1);
+            var recorder = new EventRecorder();
+            backpack.AddItem("weapon_a", 1);
+            backpack.OnInventoryChanged += recorder.Record;
+
+            var added = backpack.AddItem("weapon_b", 1);
+
+            Assert.IsFalse(added);
+            Assert.That(backpack.GetCount("weapon_b"), Is.EqualTo(0));
+            Assert.That(backpack.ItemCount, Is.EqualTo(1));
+            Assert.That(recorder.Count, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void AddItem_InvalidInput_IsRejected()
+        {
+            var backpack = new BackpackInventoryState(maxItemCount: 2);
+
+            Assert.IsFalse(backpack.AddItem(null, 1));
+            Assert.IsFalse(backpack.AddItem("", 1));
+            Assert.IsFalse(backpack.AddItem("   ", 1));
+            Assert.IsFalse(backpack.AddItem("weapon_sword", 0));
+            Assert.IsFalse(backpack.AddItem("weapon_sword", -1));
+            Assert.That(backpack.ItemCount, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void TryRemoveItem_WithEnoughCount_DecrementsCount()
+        {
+            var backpack = new BackpackInventoryState(maxItemCount: 3);
+            backpack.AddItem("weapon_sword", 2);
+
+            var removed = backpack.TryRemoveItem("weapon_sword", 1);
+
+            Assert.IsTrue(removed);
+            Assert.That(backpack.GetCount("weapon_sword"), Is.EqualTo(1));
+            Assert.That(backpack.ItemCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Clear_WithContents_RemovesAllItemsAndRaisesChanged()
+        {
+            var backpack = new BackpackInventoryState(maxItemCount: 3);
+            var recorder = new EventRecorder();
+            backpack.AddItem("weapon_sword", 1);
+            backpack.OnInventoryChanged += recorder.Record;
+
+            var cleared = backpack.Clear();
+
+            Assert.IsTrue(cleared);
+            Assert.That(backpack.ItemCount, Is.EqualTo(0));
+            Assert.That(backpack.EntryCount, Is.EqualTo(0));
+            Assert.That(recorder.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Entries_ReturnSortedSnapshotThatCannotMutateBackpack()
+        {
+            var backpack = new BackpackInventoryState(maxItemCount: 3);
+            backpack.AddItem("weapon_sword", 1);
+            backpack.AddItem("potion_basic", 1);
+
+            var entries = backpack.Entries;
+
+            Assert.That(entries[0].ItemId, Is.EqualTo("potion_basic"));
+            Assert.That(entries[1].ItemId, Is.EqualTo("weapon_sword"));
+
+            var mutableSnapshot = entries as IList<BackpackInventoryEntry>;
+            Assert.NotNull(mutableSnapshot);
+            mutableSnapshot.Clear();
+
+            Assert.That(backpack.EntryCount, Is.EqualTo(2));
+            Assert.That(backpack.ItemCount, Is.EqualTo(2));
+        }
+
+        private sealed class EventRecorder
+        {
+            public int Count { get; private set; }
+
+            public void Record()
+            {
+                Count++;
+            }
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Inventory/BackpackInventoryStateTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Inventory/BackpackInventoryStateTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f2bafb98b9584f8ea48787c45b707ee7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/_Tests/EditMode/Inventory/ItemPickupComponentTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Inventory/ItemPickupComponentTests.cs
@@ -63,6 +63,71 @@ namespace Castlebound.Tests.Inventory
         }
 
         [Test]
+        public void AutoPickup_ConsumesWeaponIntoBackpack_WhenWeaponSlotsFull()
+        {
+            var playerGo = new GameObject("Player");
+            var inventoryComponent = playerGo.AddComponent<InventoryStateComponent>();
+            var backpackComponent = playerGo.AddComponent<BackpackInventoryStateComponent>();
+            var pickupCollider = playerGo.AddComponent<Castlebound.Gameplay.Player.PlayerPickupCollider>();
+            inventoryComponent.State.AddWeapon("weapon_a");
+            inventoryComponent.State.AddWeapon("weapon_b");
+            backpackComponent.MaxItemCount = 1;
+
+            var weapon = ScriptableObject.CreateInstance<WeaponDefinition>();
+            weapon.ItemId = "weapon_c";
+
+            var pickupGo = new GameObject("Pickup");
+            var pickup = pickupGo.AddComponent<ItemPickupComponent>();
+            pickup.Kind = ItemPickupKind.Weapon;
+            pickup.ItemDefinition = weapon;
+            var context = new InventoryPickupContext(inventoryComponent.State, backpackComponent.State);
+
+            var result = pickup.TryAutoPickup(context);
+
+            Assert.IsTrue(result);
+            Assert.IsTrue(pickup.IsConsumed);
+            Assert.AreEqual("weapon_a", inventoryComponent.State.GetWeaponId(0));
+            Assert.AreEqual("weapon_b", inventoryComponent.State.GetWeaponId(1));
+            Assert.That(backpackComponent.State.GetCount("weapon_c"), Is.EqualTo(1));
+
+            Object.DestroyImmediate(pickupGo);
+            Object.DestroyImmediate(playerGo);
+            Object.DestroyImmediate(weapon);
+        }
+
+        [Test]
+        public void AutoPickup_DoesNotConsumeWeapon_WhenInventoryAndBackpackAreFull()
+        {
+            var playerGo = new GameObject("Player");
+            var inventoryComponent = playerGo.AddComponent<InventoryStateComponent>();
+            var backpackComponent = playerGo.AddComponent<BackpackInventoryStateComponent>();
+            var pickupCollider = playerGo.AddComponent<Castlebound.Gameplay.Player.PlayerPickupCollider>();
+            inventoryComponent.State.AddWeapon("weapon_a");
+            inventoryComponent.State.AddWeapon("weapon_b");
+            backpackComponent.MaxItemCount = 1;
+            backpackComponent.State.AddItem("weapon_backpack", 1);
+
+            var weapon = ScriptableObject.CreateInstance<WeaponDefinition>();
+            weapon.ItemId = "weapon_c";
+
+            var pickupGo = new GameObject("Pickup");
+            var pickup = pickupGo.AddComponent<ItemPickupComponent>();
+            pickup.Kind = ItemPickupKind.Weapon;
+            pickup.ItemDefinition = weapon;
+            var context = new InventoryPickupContext(inventoryComponent.State, backpackComponent.State);
+
+            var result = pickup.TryAutoPickup(context);
+
+            Assert.IsFalse(result);
+            Assert.IsFalse(pickup.IsConsumed);
+            Assert.That(backpackComponent.State.GetCount("weapon_c"), Is.EqualTo(0));
+
+            Object.DestroyImmediate(pickupGo);
+            Object.DestroyImmediate(playerGo);
+            Object.DestroyImmediate(weapon);
+        }
+
+        [Test]
         public void AutoPickup_RespectsPickupDelay()
         {
             var playerGo = new GameObject("Player");

--- a/Assets/_Project/_Tests/EditMode/Inventory/ItemPickupTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Inventory/ItemPickupTests.cs
@@ -63,6 +63,56 @@ namespace Castlebound.Tests.Inventory
         }
 
         [Test]
+        public void WeaponAutoPickup_WhenSlotsFullAndBackpackHasCapacity_AddsToBackpack()
+        {
+            var inventory = new InventoryState();
+            inventory.AddWeapon("weapon_a");
+            inventory.AddWeapon("weapon_b");
+            var backpack = new BackpackInventoryState(maxItemCount: 1);
+            var context = new InventoryPickupContext(inventory, backpack);
+            var pickup = ItemPickup.Weapon("weapon_c");
+
+            var result = pickup.TryAutoPickup(context);
+
+            Assert.IsTrue(result);
+            Assert.AreEqual("weapon_a", inventory.GetWeaponId(0));
+            Assert.AreEqual("weapon_b", inventory.GetWeaponId(1));
+            Assert.That(backpack.GetCount("weapon_c"), Is.EqualTo(1));
+        }
+
+        [Test]
+        public void WeaponAutoPickup_WhenSlotsFullAndBackpackFull_IsBlocked()
+        {
+            var inventory = new InventoryState();
+            inventory.AddWeapon("weapon_a");
+            inventory.AddWeapon("weapon_b");
+            var backpack = new BackpackInventoryState(maxItemCount: 1);
+            backpack.AddItem("weapon_backpack", 1);
+            var context = new InventoryPickupContext(inventory, backpack);
+            var pickup = ItemPickup.Weapon("weapon_c");
+
+            var result = pickup.TryAutoPickup(context);
+
+            Assert.IsFalse(result);
+            Assert.That(backpack.GetCount("weapon_c"), Is.EqualTo(0));
+        }
+
+        [Test]
+        public void WeaponAutoPickup_WhenActiveSlotAvailable_UsesActiveInventoryBeforeBackpack()
+        {
+            var inventory = new InventoryState();
+            var backpack = new BackpackInventoryState(maxItemCount: 1);
+            var context = new InventoryPickupContext(inventory, backpack);
+            var pickup = ItemPickup.Weapon("weapon_c");
+
+            var result = pickup.TryAutoPickup(context);
+
+            Assert.IsTrue(result);
+            Assert.AreEqual("weapon_c", inventory.GetWeaponId(0));
+            Assert.That(backpack.ItemCount, Is.EqualTo(0));
+        }
+
+        [Test]
         public void WeaponManualPickup_WhenSlotsFull_SwapsActive_AndEmitsWeaponChange()
         {
             var inventory = new InventoryState();

--- a/Assets/_Project/_Tests/EditMode/Loot/PickupMagnetMotionTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Loot/PickupMagnetMotionTests.cs
@@ -107,6 +107,73 @@ namespace Castlebound.Tests.Loot
             Object.DestroyImmediate(economy);
         }
 
+        [Test]
+        public void Step_AttractsWeapon_WhenInventoryIsFullAndBackpackHasCapacity()
+        {
+            var economy = ScriptableObject.CreateInstance<EconomyBalanceTable>();
+            economy.PickupMagnetRange = 10f;
+            economy.PickupMagnetSpeed = 4f;
+            var station = ScriptableObject.CreateInstance<GameBalanceStation>();
+            station.Economy = economy;
+            var player = new GameObject("Player");
+            var inventory = player.AddComponent<InventoryStateComponent>();
+            var backpack = player.AddComponent<BackpackInventoryStateComponent>();
+            backpack.MaxItemCount = 1;
+            inventory.State.AddWeapon("weapon_a");
+            inventory.State.AddWeapon("weapon_b");
+            var field = player.AddComponent<PickupMagnetField>();
+            field.BalanceStation = station;
+            var definition = ScriptableObject.CreateInstance<WeaponDefinition>();
+            definition.ItemId = "weapon_c";
+            var pickupObject = CreateWeaponPickup(new Vector3(2f, 0f), definition);
+            var motion = pickupObject.AddComponent<PickupMagnetMotion>();
+            motion.MagnetField = field;
+
+            motion.Step(0.25f);
+
+            Assert.AreEqual(1f, pickupObject.transform.position.x, 0.001f);
+
+            Object.DestroyImmediate(pickupObject);
+            Object.DestroyImmediate(definition);
+            Object.DestroyImmediate(player);
+            Object.DestroyImmediate(station);
+            Object.DestroyImmediate(economy);
+        }
+
+        [Test]
+        public void Step_DoesNotAttractWeapon_WhenInventoryAndBackpackAreFull()
+        {
+            var economy = ScriptableObject.CreateInstance<EconomyBalanceTable>();
+            economy.PickupMagnetRange = 10f;
+            economy.PickupMagnetSpeed = 4f;
+            var station = ScriptableObject.CreateInstance<GameBalanceStation>();
+            station.Economy = economy;
+            var player = new GameObject("Player");
+            var inventory = player.AddComponent<InventoryStateComponent>();
+            var backpack = player.AddComponent<BackpackInventoryStateComponent>();
+            backpack.MaxItemCount = 1;
+            inventory.State.AddWeapon("weapon_a");
+            inventory.State.AddWeapon("weapon_b");
+            backpack.State.AddItem("weapon_backpack", 1);
+            var field = player.AddComponent<PickupMagnetField>();
+            field.BalanceStation = station;
+            var definition = ScriptableObject.CreateInstance<WeaponDefinition>();
+            definition.ItemId = "weapon_c";
+            var pickupObject = CreateWeaponPickup(new Vector3(2f, 0f), definition);
+            var motion = pickupObject.AddComponent<PickupMagnetMotion>();
+            motion.MagnetField = field;
+
+            motion.Step(0.25f);
+
+            Assert.AreEqual(2f, pickupObject.transform.position.x, 0.001f);
+
+            Object.DestroyImmediate(pickupObject);
+            Object.DestroyImmediate(definition);
+            Object.DestroyImmediate(player);
+            Object.DestroyImmediate(station);
+            Object.DestroyImmediate(economy);
+        }
+
         private static GameObject CreateGoldPickup(Vector3 position)
         {
             var pickupObject = new GameObject("Gold Pickup");
@@ -114,6 +181,16 @@ namespace Castlebound.Tests.Loot
             var pickup = pickupObject.AddComponent<ItemPickupComponent>();
             pickup.Kind = ItemPickupKind.Gold;
             pickup.Amount = 1;
+            return pickupObject;
+        }
+
+        private static GameObject CreateWeaponPickup(Vector3 position, WeaponDefinition definition)
+        {
+            var pickupObject = new GameObject("Weapon Pickup");
+            pickupObject.transform.position = position;
+            var pickup = pickupObject.AddComponent<ItemPickupComponent>();
+            pickup.Kind = ItemPickupKind.Weapon;
+            pickup.ItemDefinition = definition;
             return pickupObject;
         }
     }

--- a/Assets/_Project/_Tests/EditMode/PrefabSmokeTests.cs
+++ b/Assets/_Project/_Tests/EditMode/PrefabSmokeTests.cs
@@ -44,6 +44,14 @@ public class PrefabSmokeTests
         PrefabTestUtil.Unload(go);
     }
 
+    [Test] public void Player_Has_BackpackInventory() {
+        var go = PrefabTestUtil.Load(PlayerPath);
+        var backpack = go.GetComponent<Castlebound.Gameplay.Inventory.BackpackInventoryStateComponent>();
+        Assert.NotNull(backpack);
+        Assert.That(backpack.MaxItemCount, Is.EqualTo(8));
+        PrefabTestUtil.Unload(go);
+    }
+
     [Test] public void Player_Has_Health() {
         var go = PrefabTestUtil.Load(PlayerPath);
         Assert.NotNull(go.GetComponent<Health>());

--- a/Assets/_Project/_Tests/PlayMode/Loot/PickupMagnetSweepPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/Loot/PickupMagnetSweepPlayTests.cs
@@ -12,6 +12,47 @@ namespace Castlebound.Tests.Loot
     public class PickupMagnetSweepPlayTests
     {
         [UnityTest]
+        public IEnumerator OverflowWeaponPickup_GoesToBackpack_WhenActiveWeaponSlotsAreFull()
+        {
+            var player = new GameObject("Player");
+            var inventory = player.AddComponent<InventoryStateComponent>();
+            var backpack = player.AddComponent<BackpackInventoryStateComponent>();
+            player.AddComponent<PlayerPickupCollider>();
+            var playerCollider = player.AddComponent<CircleCollider2D>();
+            playerCollider.isTrigger = true;
+            inventory.State.AddWeapon("weapon_a");
+            inventory.State.AddWeapon("weapon_b");
+            backpack.MaxItemCount = 1;
+
+            var weapon = ScriptableObject.CreateInstance<WeaponDefinition>();
+            weapon.ItemId = "weapon_c";
+
+            var pickupObject = new GameObject("Weapon Pickup");
+            pickupObject.transform.position = player.transform.position;
+            var body = pickupObject.AddComponent<Rigidbody2D>();
+            body.bodyType = RigidbodyType2D.Kinematic;
+            var pickupCollider = pickupObject.AddComponent<CircleCollider2D>();
+            pickupCollider.isTrigger = true;
+            var pickup = pickupObject.AddComponent<ItemPickupComponent>();
+            pickup.Kind = ItemPickupKind.Weapon;
+            pickup.ItemDefinition = weapon;
+
+            yield return new WaitForFixedUpdate();
+
+            Assert.IsTrue(pickup == null || pickup.IsConsumed);
+            Assert.AreEqual("weapon_a", inventory.State.GetWeaponId(0));
+            Assert.AreEqual("weapon_b", inventory.State.GetWeaponId(1));
+            Assert.That(backpack.State.GetCount("weapon_c"), Is.EqualTo(1));
+
+            Object.Destroy(player);
+            if (pickupObject != null)
+            {
+                Object.Destroy(pickupObject);
+            }
+            Object.Destroy(weapon);
+        }
+
+        [UnityTest]
         public IEnumerator WaveEnd_SweepsDistantGoldThroughWall_IntoInventory()
         {
             var economy = ScriptableObject.CreateInstance<EconomyBalanceTable>();

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,28 @@
 
 ---
 
+## 2026-07-01 - feat(inventory): add Backpack mid-wave carry
+
+### Summary
+- Added a temporary Backpack inventory for mid-wave overflow items.
+- Routed overflow weapon pickups to Backpack when active weapon slots are full.
+- Kept pickup magnet eligibility aligned with actual pickup eligibility so uncollectable items do not pull.
+
+### New or Updated Tests
+**EditMode**
+- `BackpackInventoryStateTests` — validates capacity, valid adds, rejected inputs, removals, clear behavior, change events, sorted entries, and snapshot safety.
+- `BackpackInventoryStateComponentTests` — validates stable component access and authored capacity.
+- `ItemPickupTests` — validates active weapon slot priority, overflow weapon pickup into Backpack, and rejection when Backpack is full.
+- `ItemPickupComponentTests` — validates component pickup consumption into Backpack and rejection when active inventory and Backpack are full.
+- `PickupMagnetMotionTests` — validates overflow weapons attract only when Backpack can accept them.
+- `PrefabSmokeTests` — validates the Player prefab includes authored Backpack inventory capacity.
+
+**PlayMode**
+- `PickupMagnetSweepPlayTests` — validates an overflow weapon pickup is collected into Backpack when active weapon slots are full.
+
+### Notes
+- Potion stack limits remain unchanged and do not overflow to Backpack in this slice.
+
 ## 2026-07-01 - feat(inventory): add Castle Inventory persistent vault
 
 ### Summary


### PR DESCRIPTION
## Why
P4 needs a temporary mid-wave carry container so valid pickups that do not fit active player slots can still be collected without replacing equipped items.

## What changed
- Added Backpack inventory state and component support
- Routed overflow weapon pickups into Backpack when active weapon slots are full
- Kept active weapon slots as the first pickup destination when space is available
- Prevented magnet pull for pickups that neither active inventory nor Backpack can accept
- Added Backpack capacity to the Player prefab
- Added EditMode and PlayMode coverage for Backpack storage, overflow pickup routing, magnet eligibility, and prefab wiring

## How to test
1. Fill both active weapon slots
2. Pick up a third weapon and verify it goes into Backpack
3. Verify a weapon does not pull or collect when active slots and Backpack are full
4. Run tests:
   - EditMode
   - PlayMode

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated (N/A - Player prefab updated, no scene layout changes)
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched (TEST_LOG updated)

## Related
- Closes #91
