### PR TITLE
feat(inventory): transfer backpack to castle vault

### DIFF
--- a/Assets/_Project/Prefabs/Player.prefab
+++ b/Assets/_Project/Prefabs/Player.prefab
@@ -110,6 +110,8 @@ GameObject:
   - component: {fileID: -5784453068084145222}
   - component: {fileID: -4357144976434651652}
   - component: {fileID: 9150000000000000501}
+  - component: {fileID: 9150000000000000601}
+  - component: {fileID: 9150000000000000602}
   - component: {fileID: -4056653655764099198}
   - component: {fileID: -6994024940450972999}
   - component: {fileID: 7777777777777777777}
@@ -440,6 +442,33 @@ MonoBehaviour:
   m_Name:
   m_EditorClassIdentifier:
   maxItemCount: 8
+--- !u!114 &9150000000000000601
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8325390509751579795}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 70bc9d27b3ee42a98d972f4180fde0da, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+--- !u!114 &9150000000000000602
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8325390509751579795}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4f1f6d8c328e4f74bcf5b7f56de0a091, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  backpackSource: {fileID: 9150000000000000501}
+  castleInventorySource: {fileID: 9150000000000000601}
+  waveRunner: {fileID: 0}
 --- !u!114 &-4056653655764099198
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/_Project/Scripts/_Project.Gameplay/Inventory/BackpackVaultTransfer.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Inventory/BackpackVaultTransfer.cs
@@ -1,0 +1,129 @@
+using Castlebound.Gameplay.Spawning;
+using UnityEngine;
+
+namespace Castlebound.Gameplay.Inventory
+{
+    public class BackpackVaultTransfer : MonoBehaviour
+    {
+        [SerializeField] private BackpackInventoryStateComponent backpackSource;
+        [SerializeField] private CastleInventoryStateComponent castleInventorySource;
+        [SerializeField] private EnemySpawnerRunner waveRunner;
+
+        private EnemySpawnerRunner hookedWaveRunner;
+
+        public BackpackInventoryStateComponent BackpackSource => backpackSource;
+        public CastleInventoryStateComponent CastleInventorySource => castleInventorySource;
+
+        private void Reset()
+        {
+            EnsureReferences();
+        }
+
+        private void Awake()
+        {
+            EnsureReferences();
+        }
+
+        private void OnEnable()
+        {
+            EnsureReferences();
+            HookWaveRunner();
+        }
+
+        private void OnDisable()
+        {
+            UnhookWaveRunner();
+        }
+
+        public void Configure(
+            BackpackInventoryStateComponent backpack,
+            CastleInventoryStateComponent castleInventory,
+            EnemySpawnerRunner runner = null)
+        {
+            UnhookWaveRunner();
+            backpackSource = backpack;
+            castleInventorySource = castleInventory;
+            waveRunner = runner;
+
+            if (isActiveAndEnabled)
+            {
+                HookWaveRunner();
+            }
+        }
+
+        public void HandleWaveEnded()
+        {
+            TransferBackpackToVault();
+        }
+
+        public bool TransferBackpackToVault()
+        {
+            EnsureReferences();
+
+            if (backpackSource == null || castleInventorySource == null)
+            {
+                return false;
+            }
+
+            var backpack = backpackSource.State;
+            if (backpack.ItemCount == 0)
+            {
+                return false;
+            }
+
+            var entries = backpack.Entries;
+            var transferred = false;
+            for (var i = 0; i < entries.Count; i++)
+            {
+                transferred |= castleInventorySource.State.AddItem(entries[i].ItemId, entries[i].Count);
+            }
+
+            if (transferred)
+            {
+                backpack.Clear();
+            }
+
+            return transferred;
+        }
+
+        private void EnsureReferences()
+        {
+            if (backpackSource == null)
+            {
+                backpackSource = GetComponent<BackpackInventoryStateComponent>();
+            }
+
+            if (castleInventorySource == null)
+            {
+                castleInventorySource = GetComponent<CastleInventoryStateComponent>();
+            }
+
+            if (waveRunner == null)
+            {
+                waveRunner = FindObjectOfType<EnemySpawnerRunner>();
+            }
+        }
+
+        private void HookWaveRunner()
+        {
+            if (waveRunner == null || hookedWaveRunner == waveRunner)
+            {
+                return;
+            }
+
+            hookedWaveRunner = waveRunner;
+            hookedWaveRunner.OnWaveEnded += HandleWaveEnded;
+        }
+
+        private void UnhookWaveRunner()
+        {
+            if (hookedWaveRunner == null)
+            {
+                return;
+            }
+
+            hookedWaveRunner.OnWaveEnded -= HandleWaveEnded;
+            hookedWaveRunner = null;
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Inventory/BackpackVaultTransfer.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Inventory/BackpackVaultTransfer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4f1f6d8c328e4f74bcf5b7f56de0a091
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/EditMode/Inventory/BackpackVaultTransferTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Inventory/BackpackVaultTransferTests.cs
@@ -1,0 +1,129 @@
+using Castlebound.Gameplay.Inventory;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Castlebound.Tests.Inventory
+{
+    public class BackpackVaultTransferTests
+    {
+        [Test]
+        public void TransferBackpackToVault_MovesEntriesAndClearsBackpack()
+        {
+            var go = CreateTransfer(out var backpack, out var vault, out var transfer);
+
+            try
+            {
+                backpack.State.AddItem("weapon_sword", 1);
+                backpack.State.AddItem("weapon_axe", 1);
+
+                var transferred = transfer.TransferBackpackToVault();
+
+                Assert.IsTrue(transferred);
+                Assert.That(vault.State.GetCount("weapon_sword"), Is.EqualTo(1));
+                Assert.That(vault.State.GetCount("weapon_axe"), Is.EqualTo(1));
+                Assert.That(backpack.State.ItemCount, Is.EqualTo(0));
+                Assert.That(backpack.State.EntryCount, Is.EqualTo(0));
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+            }
+        }
+
+        [Test]
+        public void TransferBackpackToVault_EmptyBackpack_IsNoOp()
+        {
+            var go = CreateTransfer(out var backpack, out var vault, out var transfer);
+
+            try
+            {
+                var transferred = transfer.TransferBackpackToVault();
+
+                Assert.IsFalse(transferred);
+                Assert.That(vault.State.EntryCount, Is.EqualTo(0));
+                Assert.That(backpack.State.ItemCount, Is.EqualTo(0));
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+            }
+        }
+
+        [Test]
+        public void TransferBackpackToVault_RepeatedAfterClear_DoesNotDuplicate()
+        {
+            var go = CreateTransfer(out var backpack, out var vault, out var transfer);
+
+            try
+            {
+                backpack.State.AddItem("weapon_sword", 1);
+
+                Assert.IsTrue(transfer.TransferBackpackToVault());
+                Assert.IsFalse(transfer.TransferBackpackToVault());
+
+                Assert.That(vault.State.GetCount("weapon_sword"), Is.EqualTo(1));
+                Assert.That(backpack.State.ItemCount, Is.EqualTo(0));
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+            }
+        }
+
+        [Test]
+        public void TransferBackpackToVault_LeavesActiveInventorySlotsUntouched()
+        {
+            var go = CreateTransfer(out var backpack, out var vault, out var transfer);
+            var activeInventory = go.AddComponent<InventoryStateComponent>();
+
+            try
+            {
+                activeInventory.State.AddWeapon("weapon_equipped");
+                backpack.State.AddItem("weapon_backpack", 1);
+
+                transfer.TransferBackpackToVault();
+
+                Assert.That(activeInventory.State.GetWeaponId(0), Is.EqualTo("weapon_equipped"));
+                Assert.That(vault.State.GetCount("weapon_backpack"), Is.EqualTo(1));
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+            }
+        }
+
+        [Test]
+        public void Configure_AssignsSources()
+        {
+            var go = new GameObject("Transfer");
+            var backpack = go.AddComponent<BackpackInventoryStateComponent>();
+            var vault = go.AddComponent<CastleInventoryStateComponent>();
+            var transfer = go.AddComponent<BackpackVaultTransfer>();
+
+            try
+            {
+                transfer.Configure(backpack, vault);
+
+                Assert.AreSame(backpack, transfer.BackpackSource);
+                Assert.AreSame(vault, transfer.CastleInventorySource);
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+            }
+        }
+
+        private static GameObject CreateTransfer(
+            out BackpackInventoryStateComponent backpack,
+            out CastleInventoryStateComponent vault,
+            out BackpackVaultTransfer transfer)
+        {
+            var go = new GameObject("PlayerInventory");
+            backpack = go.AddComponent<BackpackInventoryStateComponent>();
+            vault = go.AddComponent<CastleInventoryStateComponent>();
+            transfer = go.AddComponent<BackpackVaultTransfer>();
+            transfer.Configure(backpack, vault);
+            return go;
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Inventory/BackpackVaultTransferTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Inventory/BackpackVaultTransferTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3a0d9f89c5764d699e4b7328efb91445
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/EditMode/PrefabSmokeTests.cs
+++ b/Assets/_Project/_Tests/EditMode/PrefabSmokeTests.cs
@@ -52,6 +52,15 @@ public class PrefabSmokeTests
         PrefabTestUtil.Unload(go);
     }
 
+    [Test] public void Player_Has_BackpackVaultTransfer() {
+        var go = PrefabTestUtil.Load(PlayerPath);
+        var transfer = go.GetComponent<Castlebound.Gameplay.Inventory.BackpackVaultTransfer>();
+        Assert.NotNull(transfer);
+        Assert.NotNull(transfer.BackpackSource);
+        Assert.NotNull(transfer.CastleInventorySource);
+        PrefabTestUtil.Unload(go);
+    }
+
     [Test] public void Player_Has_Health() {
         var go = PrefabTestUtil.Load(PlayerPath);
         Assert.NotNull(go.GetComponent<Health>());

--- a/Assets/_Project/_Tests/PlayMode/Inventory.meta
+++ b/Assets/_Project/_Tests/PlayMode/Inventory.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e08c1980a5534783a25ff292fdf7e385
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/PlayMode/Inventory/BackpackVaultTransferPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/Inventory/BackpackVaultTransferPlayTests.cs
@@ -1,0 +1,53 @@
+using System.Collections;
+using System.Reflection;
+using Castlebound.Gameplay.Inventory;
+using Castlebound.Gameplay.Spawning;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Castlebound.Tests.Inventory
+{
+    public class BackpackVaultTransferPlayTests
+    {
+        [UnityTest]
+        public IEnumerator WaveEndEvent_TransfersBackpackToVault()
+        {
+            var runnerObject = new GameObject("WaveRunner");
+            var playerObject = new GameObject("PlayerInventory");
+
+            try
+            {
+                var runner = runnerObject.AddComponent<EnemySpawnerRunner>();
+                _ = runner.PhaseTracker;
+
+                var backpack = playerObject.AddComponent<BackpackInventoryStateComponent>();
+                var vault = playerObject.AddComponent<CastleInventoryStateComponent>();
+                var transfer = playerObject.AddComponent<BackpackVaultTransfer>();
+                transfer.Configure(backpack, vault, runner);
+                backpack.State.AddItem("weapon_sword", 1);
+
+                InvokeWaveEnded(runner);
+
+                Assert.That(vault.State.GetCount("weapon_sword"), Is.EqualTo(1));
+                Assert.That(backpack.State.ItemCount, Is.EqualTo(0));
+            }
+            finally
+            {
+                Object.DestroyImmediate(runnerObject);
+                Object.DestroyImmediate(playerObject);
+            }
+
+            yield break;
+        }
+
+        private static void InvokeWaveEnded(EnemySpawnerRunner runner)
+        {
+            var method = typeof(EnemySpawnerRunner).GetMethod(
+                "HandleWaveEnded",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(method, "Expected EnemySpawnerRunner.HandleWaveEnded for wave-end event contract.");
+            method.Invoke(runner, null);
+        }
+    }
+}

--- a/Assets/_Project/_Tests/PlayMode/Inventory/BackpackVaultTransferPlayTests.cs.meta
+++ b/Assets/_Project/_Tests/PlayMode/Inventory/BackpackVaultTransferPlayTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 25148a70b970405e80b79717a7d0e85d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,24 @@
 
 ---
 
+## 2026-07-01 - feat(inventory): transfer Backpack to Castle Vault
+
+### Summary
+- Added wave-end Backpack transfer into the persistent Castle Inventory vault.
+- Cleared Backpack contents after successful transfer to keep it mid-wave-only storage.
+- Wired the Player prefab with Castle Inventory and Backpack transfer components.
+
+### New or Updated Tests
+**EditMode**
+- `BackpackVaultTransferTests` - validates transfer, Backpack clearing, empty no-op behavior, repeated transfer safety, active inventory preservation, and source configuration.
+- `PrefabSmokeTests` - validates the Player prefab includes Backpack-to-vault transfer wiring.
+
+**PlayMode**
+- `BackpackVaultTransferPlayTests` - validates the wave-end event hook transfers Backpack contents into the Castle Vault.
+
+### Notes
+- Transfer listens to `EnemySpawnerRunner.OnWaveEnded` when a wave runner is present.
+
 ## 2026-07-01 - feat(inventory): add Backpack mid-wave carry
 
 ### Summary


### PR DESCRIPTION
## Why
Backpack is temporary mid-wave overflow storage. Its contents need to move into the persistent Castle Vault when a wave ends so collected overflow items are retained between waves.

## What changed
- Added a Backpack-to-Castle-Vault transfer component
- Transfer Backpack contents into Castle Inventory on wave end
- Clear Backpack after successful transfer
- Wire the Player prefab with Castle Inventory and transfer components
- Add EditMode and PlayMode coverage for transfer behavior and wave-end hook

## How to test
1. Fill active weapon slots and collect an overflow weapon into Backpack
2. End the wave and verify the Backpack clears while Castle Vault receives the item
3. Run tests:
   - EditMode
   - PlayMode

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated (N/A - Player prefab updated, no scene layout changes)
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched (TEST_LOG updated)

## Related
- Closes #92
- Closes #95
- Refs #91
