### PR TITLE
feat(inventory): add backpack context actions

### DIFF
--- a/Assets/_Project/Scripts/_Project.Gameplay/Inventory/BackpackItemDropController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Inventory/BackpackItemDropController.cs
@@ -1,0 +1,148 @@
+using Castlebound.Gameplay.Combat;
+using Castlebound.Gameplay.Loot;
+using UnityEngine;
+
+namespace Castlebound.Gameplay.Inventory
+{
+    public class BackpackItemDropController : MonoBehaviour
+    {
+        [SerializeField] private BackpackInventoryStateComponent backpackSource;
+        [SerializeField] private Transform dropOrigin;
+        [SerializeField] private MonoBehaviour weaponDefinitionResolverSource;
+        [SerializeField] private float dropStartDistance = 0.45f;
+        [SerializeField] private float dropSlideDistance = 3f;
+        [SerializeField] private float dropSlideDuration = 0.35f;
+        [SerializeField] private float dropScatterDegrees = 14f;
+        [SerializeField] private float pickupDelaySeconds = 5f;
+
+        private IWeaponDefinitionResolver weaponDefinitionResolver;
+
+        public ItemPickupComponent LastSpawnedPickup { get; private set; }
+
+        public void SetBackpackSource(BackpackInventoryStateComponent source)
+        {
+            backpackSource = source;
+        }
+
+        public void SetDropOrigin(Transform origin)
+        {
+            dropOrigin = origin;
+        }
+
+        public void SetWeaponDefinitionResolver(IWeaponDefinitionResolver resolver)
+        {
+            weaponDefinitionResolver = resolver;
+            weaponDefinitionResolverSource = resolver as MonoBehaviour;
+        }
+
+        public bool TryDrop(string itemId)
+        {
+            BackpackInventoryState backpack = backpackSource != null ? backpackSource.State : null;
+            if (backpack == null || string.IsNullOrWhiteSpace(itemId) || backpack.GetCount(itemId) <= 0)
+            {
+                return false;
+            }
+
+            WeaponDefinition weapon = ResolveWeapon(itemId);
+            if (weapon == null)
+            {
+                return false;
+            }
+
+            ItemPickupComponent pickup = CreateWeaponPickup(weapon);
+            if (pickup == null)
+            {
+                return false;
+            }
+
+            if (!backpack.TryRemoveItem(itemId, 1))
+            {
+                DestroyPickup(pickup.gameObject);
+                return false;
+            }
+
+            LastSpawnedPickup = pickup;
+            return true;
+        }
+
+        private WeaponDefinition ResolveWeapon(string itemId)
+        {
+            if (weaponDefinitionResolver == null)
+            {
+                weaponDefinitionResolver = weaponDefinitionResolverSource as IWeaponDefinitionResolver ?? FindWeaponDefinitionResolver();
+            }
+
+            return weaponDefinitionResolver != null ? weaponDefinitionResolver.Resolve(itemId) : null;
+        }
+
+        private IWeaponDefinitionResolver FindWeaponDefinitionResolver()
+        {
+            var behaviours = FindObjectsOfType<MonoBehaviour>();
+            for (int i = 0; i < behaviours.Length; i++)
+            {
+                if (behaviours[i] is IWeaponDefinitionResolver resolver)
+                {
+                    return resolver;
+                }
+            }
+
+            return null;
+        }
+
+        private ItemPickupComponent CreateWeaponPickup(WeaponDefinition weapon)
+        {
+            var pickupObject = new GameObject("Dropped_" + weapon.ItemId, typeof(SpriteRenderer), typeof(Rigidbody2D), typeof(CircleCollider2D));
+            ResolveDropPositions(out Vector3 startPosition, out Vector3 targetPosition);
+            pickupObject.transform.position = startPosition;
+
+            var renderer = pickupObject.GetComponent<SpriteRenderer>();
+            renderer.sprite = weapon.Icon;
+            renderer.sortingOrder = 12;
+
+            var body = pickupObject.GetComponent<Rigidbody2D>();
+            body.gravityScale = 0f;
+            body.constraints = RigidbodyConstraints2D.FreezeRotation;
+
+            var collider = pickupObject.GetComponent<CircleCollider2D>();
+            collider.isTrigger = true;
+            collider.radius = 0.25f;
+
+            var pickup = pickupObject.AddComponent<ItemPickupComponent>();
+            pickup.Kind = ItemPickupKind.Weapon;
+            pickup.ItemDefinition = weapon;
+            pickup.Amount = 1;
+            pickup.SetPickupDelay(pickupDelaySeconds);
+
+            pickupObject.AddComponent<ItemPickupVisual>();
+            var spillMotion = pickupObject.AddComponent<LootSpillMotion>();
+            spillMotion.Initialize(targetPosition, dropSlideDuration);
+            return pickup;
+        }
+
+        private void ResolveDropPositions(out Vector3 startPosition, out Vector3 targetPosition)
+        {
+            Transform origin = dropOrigin != null ? dropOrigin : transform;
+            Vector3 facingOffset = -origin.up;
+            if (facingOffset.sqrMagnitude <= 0.0001f)
+            {
+                facingOffset = Vector3.down;
+            }
+
+            Vector3 direction = Quaternion.Euler(0f, 0f, Random.Range(-dropScatterDegrees, dropScatterDegrees)) * facingOffset.normalized;
+            startPosition = origin.position + direction * Mathf.Max(0f, dropStartDistance);
+            targetPosition = origin.position + direction * Mathf.Max(dropStartDistance, dropSlideDistance);
+        }
+
+        private static void DestroyPickup(GameObject pickupObject)
+        {
+            if (Application.isPlaying)
+            {
+                Destroy(pickupObject);
+            }
+            else
+            {
+                DestroyImmediate(pickupObject);
+            }
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Inventory/BackpackItemDropController.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Inventory/BackpackItemDropController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2f7a8b9c0d1e4f5a8b6c7d8e9f102a3b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/_Project.Gameplay/Inventory/BackpackWeaponEquipController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Inventory/BackpackWeaponEquipController.cs
@@ -1,0 +1,65 @@
+using UnityEngine;
+
+namespace Castlebound.Gameplay.Inventory
+{
+    public class BackpackWeaponEquipController : MonoBehaviour
+    {
+        [SerializeField] private InventoryStateComponent activeInventorySource;
+        [SerializeField] private BackpackInventoryStateComponent backpackSource;
+
+        public void SetActiveInventorySource(InventoryStateComponent source)
+        {
+            activeInventorySource = source;
+        }
+
+        public void SetBackpackSource(BackpackInventoryStateComponent source)
+        {
+            backpackSource = source;
+        }
+
+        public bool TryEquip(string weaponId, int slotIndex)
+        {
+            InventoryState activeInventory = activeInventorySource != null ? activeInventorySource.State : null;
+            BackpackInventoryState backpack = backpackSource != null ? backpackSource.State : null;
+            return TryEquip(activeInventory, backpack, weaponId, slotIndex);
+        }
+
+        public static bool TryEquip(InventoryState activeInventory, BackpackInventoryState backpack, string weaponId, int slotIndex)
+        {
+            if (activeInventory == null || backpack == null || string.IsNullOrWhiteSpace(weaponId))
+            {
+                return false;
+            }
+
+            if (slotIndex < 0 || slotIndex >= InventoryState.WeaponSlotCount || backpack.GetCount(weaponId) <= 0)
+            {
+                return false;
+            }
+
+            if (!backpack.TryRemoveItem(weaponId, 1))
+            {
+                return false;
+            }
+
+            if (!activeInventory.TrySetWeaponAtSlot(slotIndex, weaponId, out string displacedWeaponId))
+            {
+                backpack.AddItem(weaponId, 1);
+                return false;
+            }
+
+            if (string.IsNullOrEmpty(displacedWeaponId))
+            {
+                return true;
+            }
+
+            if (backpack.AddItem(displacedWeaponId, 1))
+            {
+                return true;
+            }
+
+            activeInventory.TrySetWeaponAtSlot(slotIndex, displacedWeaponId, out _);
+            backpack.AddItem(weaponId, 1);
+            return false;
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Inventory/BackpackWeaponEquipController.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Inventory/BackpackWeaponEquipController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9e1c6f34a5d64c2d8f9a1b2c3d4e5f60
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/_Project.Gameplay/Inventory/InventoryState.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Inventory/InventoryState.cs
@@ -80,6 +80,25 @@ namespace Castlebound.Gameplay.Inventory
             return true;
         }
 
+        public bool TrySetWeaponAtSlot(int slotIndex, string weaponId, out string previousWeaponId)
+        {
+            previousWeaponId = null;
+            if (!IsValidSlotIndex(slotIndex) || string.IsNullOrEmpty(weaponId))
+            {
+                return false;
+            }
+
+            previousWeaponId = weaponIds[slotIndex];
+            if (string.Equals(previousWeaponId, weaponId, StringComparison.Ordinal))
+            {
+                return true;
+            }
+
+            weaponIds[slotIndex] = weaponId;
+            RaiseChanged(InventoryChangeFlags.Weapons);
+            return true;
+        }
+
         public bool TryAddPotion(string potionId, int amount)
         {
             if (string.IsNullOrEmpty(potionId) || amount <= 0)

--- a/Assets/_Project/Scripts/_Project.Gameplay/UI/InventoryContextMenuController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/UI/InventoryContextMenuController.cs
@@ -1,0 +1,241 @@
+using System;
+using Castlebound.Gameplay.Inventory;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Castlebound.Gameplay.UI
+{
+    public class InventoryContextMenuController : MonoBehaviour
+    {
+        [SerializeField] private RectTransform menuRoot;
+        [SerializeField] private BackpackWeaponEquipController equipController;
+        [SerializeField] private BackpackItemDropController dropController;
+
+        private RectTransform parentRoot;
+        private string activeItemId;
+        private bool activeItemIsWeapon;
+        private bool isChoosingEquipSlot;
+
+        public event Action ActionCompleted;
+
+        public bool IsOpen => menuRoot != null && menuRoot.gameObject.activeSelf;
+        public string ActiveItemId => activeItemId;
+        public bool IsChoosingEquipSlot => isChoosingEquipSlot;
+
+        public void SetParentRoot(RectTransform root)
+        {
+            parentRoot = root;
+        }
+
+        public void SetEquipController(BackpackWeaponEquipController controller)
+        {
+            equipController = controller;
+        }
+
+        public void SetDropController(BackpackItemDropController controller)
+        {
+            dropController = controller;
+        }
+
+        public void ShowForItem(string itemId, bool isWeapon, RectTransform anchor)
+        {
+            if (string.IsNullOrWhiteSpace(itemId))
+            {
+                Close();
+                return;
+            }
+
+            activeItemId = itemId;
+            activeItemIsWeapon = isWeapon;
+            isChoosingEquipSlot = false;
+            EnsureMenuRoot();
+            PositionNear(anchor);
+            RebuildRootActions();
+            menuRoot.gameObject.SetActive(true);
+        }
+
+        public void Close()
+        {
+            activeItemId = null;
+            activeItemIsWeapon = false;
+            isChoosingEquipSlot = false;
+            if (menuRoot != null)
+            {
+                menuRoot.gameObject.SetActive(false);
+            }
+        }
+
+        private void RebuildRootActions()
+        {
+            ClearMenu();
+            CreateMenuButton("Drop", TryDropActiveItem);
+            if (activeItemIsWeapon)
+            {
+                CreateMenuButton("Equip", ShowEquipSlots);
+            }
+
+            RefreshMenuSize();
+        }
+
+        private void ShowEquipSlots()
+        {
+            if (!activeItemIsWeapon)
+            {
+                return;
+            }
+
+            isChoosingEquipSlot = true;
+            ClearMenu();
+            CreateMenuButton("Drop", TryDropActiveItem);
+            CreateMenuButton("Main", () => TryEquipActiveItem(0));
+            CreateMenuButton("Secondary", () => TryEquipActiveItem(1));
+            RefreshMenuSize();
+        }
+
+        private void TryDropActiveItem()
+        {
+            if (dropController != null && dropController.TryDrop(activeItemId))
+            {
+                CompleteAction();
+            }
+        }
+
+        private void TryEquipActiveItem(int slotIndex)
+        {
+            if (equipController != null && equipController.TryEquip(activeItemId, slotIndex))
+            {
+                CompleteAction();
+            }
+        }
+
+        private void CompleteAction()
+        {
+            Close();
+            ActionCompleted?.Invoke();
+        }
+
+        private void EnsureMenuRoot()
+        {
+            if (menuRoot != null)
+            {
+                return;
+            }
+
+            Transform parent = parentRoot != null ? parentRoot : transform;
+            var menuObject = new GameObject("InventoryContextMenu", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image), typeof(VerticalLayoutGroup));
+            menuObject.transform.SetParent(parent, false);
+            menuRoot = menuObject.GetComponent<RectTransform>();
+            menuRoot.anchorMin = new Vector2(0f, 1f);
+            menuRoot.anchorMax = new Vector2(0f, 1f);
+            menuRoot.pivot = new Vector2(0f, 1f);
+            menuRoot.sizeDelta = new Vector2(116f, 0f);
+
+            var image = menuObject.GetComponent<Image>();
+            image.color = new Color(0.06f, 0.07f, 0.08f, 0.98f);
+
+            var layout = menuObject.GetComponent<VerticalLayoutGroup>();
+            layout.spacing = 4f;
+            layout.padding = new RectOffset(4, 4, 4, 4);
+            layout.childForceExpandHeight = false;
+            layout.childForceExpandWidth = true;
+            layout.childControlHeight = true;
+            layout.childControlWidth = true;
+
+            menuObject.SetActive(false);
+        }
+
+        private void PositionNear(RectTransform anchor)
+        {
+            if (menuRoot == null)
+            {
+                return;
+            }
+
+            if (anchor == null || parentRoot == null)
+            {
+                menuRoot.anchoredPosition = new Vector2(212f, -62f);
+                return;
+            }
+
+            Vector3 worldPosition = anchor.TransformPoint(new Vector3(anchor.rect.xMax, anchor.rect.yMax, 0f));
+            Vector3 localPosition = parentRoot.InverseTransformPoint(worldPosition);
+            menuRoot.anchoredPosition = new Vector2(localPosition.x + 8f, localPosition.y);
+        }
+
+        private void ClearMenu()
+        {
+            if (menuRoot == null)
+            {
+                return;
+            }
+
+            for (int i = menuRoot.childCount - 1; i >= 0; i--)
+            {
+                DestroyChild(menuRoot.GetChild(i).gameObject);
+            }
+        }
+
+        private void CreateMenuButton(string label, UnityEngine.Events.UnityAction action)
+        {
+            var buttonObject = new GameObject(label + "Button", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image), typeof(Button), typeof(LayoutElement));
+            buttonObject.transform.SetParent(menuRoot, false);
+
+            var rect = buttonObject.GetComponent<RectTransform>();
+            rect.sizeDelta = new Vector2(108f, 30f);
+
+            var layout = buttonObject.GetComponent<LayoutElement>();
+            layout.minHeight = 30f;
+            layout.preferredHeight = 30f;
+
+            var image = buttonObject.GetComponent<Image>();
+            image.color = new Color(0.16f, 0.18f, 0.21f, 1f);
+
+            var button = buttonObject.GetComponent<Button>();
+            button.onClick.AddListener(action);
+
+            var labelObject = new GameObject("Label", typeof(RectTransform), typeof(CanvasRenderer), typeof(TextMeshProUGUI));
+            labelObject.transform.SetParent(buttonObject.transform, false);
+            var labelRect = labelObject.GetComponent<RectTransform>();
+            labelRect.anchorMin = Vector2.zero;
+            labelRect.anchorMax = Vector2.one;
+            labelRect.offsetMin = Vector2.zero;
+            labelRect.offsetMax = Vector2.zero;
+
+            var text = labelObject.GetComponent<TextMeshProUGUI>();
+            text.text = label;
+            text.fontSize = 14;
+            text.alignment = TextAlignmentOptions.Center;
+            text.color = Color.white;
+            text.raycastTarget = false;
+            text.enableAutoSizing = true;
+            text.fontSizeMin = 10;
+            text.fontSizeMax = 14;
+        }
+
+        private void RefreshMenuSize()
+        {
+            if (menuRoot == null)
+            {
+                return;
+            }
+
+            int count = menuRoot.childCount;
+            float height = 8f + count * 30f + Mathf.Max(0, count - 1) * 4f;
+            menuRoot.sizeDelta = new Vector2(116f, height);
+        }
+
+        private static void DestroyChild(GameObject child)
+        {
+            if (Application.isPlaying)
+            {
+                child.SetActive(false);
+                Destroy(child);
+            }
+            else
+            {
+                DestroyImmediate(child);
+            }
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/UI/InventoryContextMenuController.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/UI/InventoryContextMenuController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 41b2c3d4e5f6478a9b0c1d2e3f405162
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/_Project.Gameplay/UI/InventoryContextMenuTrigger.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/UI/InventoryContextMenuTrigger.cs
@@ -1,0 +1,75 @@
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+namespace Castlebound.Gameplay.UI
+{
+    public class InventoryContextMenuTrigger : MonoBehaviour, IPointerClickHandler, IPointerDownHandler, IPointerUpHandler, IPointerExitHandler
+    {
+        [SerializeField] private float longPressSeconds = 0.45f;
+
+        private InventoryContextMenuController menu;
+        private string itemId;
+        private bool isWeapon;
+        private bool isPressing;
+        private bool hasOpenedFromPress;
+        private float pressStartTime;
+
+        public float LongPressSeconds
+        {
+            get => longPressSeconds;
+            set => longPressSeconds = Mathf.Max(0f, value);
+        }
+
+        public void Configure(InventoryContextMenuController targetMenu, string targetItemId, bool targetIsWeapon)
+        {
+            menu = targetMenu;
+            itemId = targetItemId;
+            isWeapon = targetIsWeapon;
+        }
+
+        public void OnPointerClick(PointerEventData eventData)
+        {
+            if (eventData != null && eventData.button == PointerEventData.InputButton.Right)
+            {
+                OpenMenu();
+            }
+        }
+
+        public void OnPointerDown(PointerEventData eventData)
+        {
+            isPressing = true;
+            hasOpenedFromPress = false;
+            pressStartTime = Time.unscaledTime;
+        }
+
+        public void OnPointerUp(PointerEventData eventData)
+        {
+            isPressing = false;
+        }
+
+        public void OnPointerExit(PointerEventData eventData)
+        {
+            isPressing = false;
+        }
+
+        private void Update()
+        {
+            if (!isPressing || hasOpenedFromPress || Time.unscaledTime - pressStartTime < longPressSeconds)
+            {
+                return;
+            }
+
+            hasOpenedFromPress = true;
+            OpenMenu();
+        }
+
+        private void OpenMenu()
+        {
+            RectTransform anchor = transform as RectTransform;
+            if (menu != null)
+            {
+                menu.ShowForItem(itemId, isWeapon, anchor);
+            }
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/UI/InventoryContextMenuTrigger.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/UI/InventoryContextMenuTrigger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7a6b5c4d3e2f4a1b9c8d7e6f501234ab
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/_Project.Gameplay/UI/InventoryPanelController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/UI/InventoryPanelController.cs
@@ -1,5 +1,6 @@
 using Castlebound.Gameplay.Inventory;
 using Castlebound.Gameplay.Spawning;
+using Castlebound.Gameplay.Combat;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -14,14 +15,21 @@ namespace Castlebound.Gameplay.UI
         [SerializeField] private Button vaultTabButton;
         [SerializeField] private RectTransform contentRoot;
         [SerializeField] private BackpackInventoryStateComponent backpackSource;
+        [SerializeField] private InventoryStateComponent activeInventorySource;
         [SerializeField] private CastleInventoryStateComponent castleInventorySource;
         [SerializeField] private EnemySpawnerRunner waveRunner;
+        [SerializeField] private InventoryContextMenuController contextMenu;
+        [SerializeField] private BackpackWeaponEquipController equipController;
+        [SerializeField] private BackpackItemDropController dropController;
+        [SerializeField] private MonoBehaviour weaponDefinitionResolverSource;
 
         private BackpackInventoryState backpack;
         private CastleInventoryState vault;
         private WavePhaseTracker phaseTracker;
+        private IWeaponDefinitionResolver weaponDefinitionResolver;
         private RectTransform tabRoot;
         private InventoryPanelTab activeTab = InventoryPanelTab.Backpack;
+        private bool contextMenuHooked;
 
         public bool IsOpen => panelRoot != null && panelRoot.gameObject.activeSelf;
         public InventoryPanelTab ActiveTab => activeTab;
@@ -41,6 +49,7 @@ namespace Castlebound.Gameplay.UI
         private void OnDisable()
         {
             UnhookSources();
+            UnhookContextMenu();
         }
 
         public void SetBackpackSource(BackpackInventoryStateComponent source)
@@ -55,6 +64,15 @@ namespace Castlebound.Gameplay.UI
             backpack = backpackSource != null ? backpackSource.State : null;
             HookBackpack();
             Refresh();
+        }
+
+        public void SetActiveInventorySource(InventoryStateComponent source)
+        {
+            activeInventorySource = source;
+            if (equipController != null)
+            {
+                equipController.SetActiveInventorySource(activeInventorySource);
+            }
         }
 
         public void SetCastleInventorySource(CastleInventoryStateComponent source)
@@ -90,6 +108,16 @@ namespace Castlebound.Gameplay.UI
             SetPhaseTracker(waveRunner != null ? waveRunner.PhaseTracker : null);
         }
 
+        public void SetWeaponDefinitionResolver(IWeaponDefinitionResolver resolver)
+        {
+            weaponDefinitionResolver = resolver;
+            weaponDefinitionResolverSource = resolver as MonoBehaviour;
+            if (dropController != null)
+            {
+                dropController.SetWeaponDefinitionResolver(resolver);
+            }
+        }
+
         public void TogglePanel()
         {
             ApplyPanelState(!IsOpen);
@@ -101,6 +129,11 @@ namespace Castlebound.Gameplay.UI
 
         public void ClosePanel()
         {
+            if (contextMenu != null)
+            {
+                contextMenu.Close();
+            }
+
             ApplyPanelState(false);
         }
 
@@ -132,6 +165,11 @@ namespace Castlebound.Gameplay.UI
                 backpackSource = FindObjectOfType<BackpackInventoryStateComponent>();
             }
 
+            if (activeInventorySource == null)
+            {
+                activeInventorySource = FindObjectOfType<InventoryStateComponent>();
+            }
+
             if (castleInventorySource == null)
             {
                 castleInventorySource = FindObjectOfType<CastleInventoryStateComponent>();
@@ -145,6 +183,7 @@ namespace Castlebound.Gameplay.UI
             backpack = backpackSource != null ? backpackSource.State : null;
             vault = castleInventorySource != null ? castleInventorySource.State : null;
             phaseTracker = waveRunner != null ? waveRunner.PhaseTracker : phaseTracker;
+            weaponDefinitionResolver = weaponDefinitionResolverSource as IWeaponDefinitionResolver ?? weaponDefinitionResolver ?? FindWeaponDefinitionResolver();
         }
 
         private void HookSources()
@@ -287,6 +326,71 @@ namespace Castlebound.Gameplay.UI
                 layout.childControlHeight = true;
                 layout.childControlWidth = true;
             }
+
+            EnsureContextActionComponents();
+        }
+
+        private void EnsureContextActionComponents()
+        {
+            if (equipController == null)
+            {
+                equipController = GetComponent<BackpackWeaponEquipController>();
+                if (equipController == null)
+                {
+                    equipController = gameObject.AddComponent<BackpackWeaponEquipController>();
+                }
+            }
+
+            if (dropController == null)
+            {
+                dropController = GetComponent<BackpackItemDropController>();
+                if (dropController == null)
+                {
+                    dropController = gameObject.AddComponent<BackpackItemDropController>();
+                }
+            }
+
+            if (contextMenu == null)
+            {
+                contextMenu = GetComponent<InventoryContextMenuController>();
+                if (contextMenu == null)
+                {
+                    contextMenu = gameObject.AddComponent<InventoryContextMenuController>();
+                }
+            }
+
+            HookContextMenu();
+
+            equipController.SetActiveInventorySource(activeInventorySource);
+            equipController.SetBackpackSource(backpackSource);
+            dropController.SetBackpackSource(backpackSource);
+            dropController.SetDropOrigin(activeInventorySource != null ? activeInventorySource.transform : transform);
+            dropController.SetWeaponDefinitionResolver(weaponDefinitionResolverSource as IWeaponDefinitionResolver ?? weaponDefinitionResolver ?? FindWeaponDefinitionResolver());
+            contextMenu.SetParentRoot(panelRoot);
+            contextMenu.SetEquipController(equipController);
+            contextMenu.SetDropController(dropController);
+        }
+
+        private void HookContextMenu()
+        {
+            if (contextMenu == null || contextMenuHooked)
+            {
+                return;
+            }
+
+            contextMenu.ActionCompleted += Refresh;
+            contextMenuHooked = true;
+        }
+
+        private void UnhookContextMenu()
+        {
+            if (contextMenu == null || !contextMenuHooked)
+            {
+                return;
+            }
+
+            contextMenu.ActionCompleted -= Refresh;
+            contextMenuHooked = false;
         }
 
         private RectTransform CreatePanel(Transform parent)
@@ -351,6 +455,11 @@ namespace Castlebound.Gameplay.UI
                 return;
             }
 
+            if (contextMenu != null)
+            {
+                contextMenu.Close();
+            }
+
             for (int i = contentRoot.childCount - 1; i >= 0; i--)
             {
                 DestroyChild(contentRoot.GetChild(i).gameObject);
@@ -381,7 +490,7 @@ namespace Castlebound.Gameplay.UI
 
             foreach (var entry in backpack.Entries)
             {
-                CreateTextRow($"{entry.ItemId} x{entry.Count}");
+                CreateBackpackRow(entry);
             }
         }
 
@@ -419,6 +528,67 @@ namespace Castlebound.Gameplay.UI
             text.color = Color.white;
             text.alignment = TextAlignmentOptions.Left;
             text.raycastTarget = false;
+        }
+
+        private void CreateBackpackRow(BackpackInventoryEntry entry)
+        {
+            var rowObject = new GameObject("InventoryRow", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image), typeof(Button), typeof(LayoutElement));
+            rowObject.transform.SetParent(contentRoot, false);
+
+            var rect = rowObject.GetComponent<RectTransform>();
+            rect.sizeDelta = new Vector2(0f, 34f);
+
+            var layout = rowObject.GetComponent<LayoutElement>();
+            layout.minHeight = 34f;
+            layout.preferredHeight = 34f;
+            layout.flexibleWidth = 1f;
+
+            var image = rowObject.GetComponent<Image>();
+            image.color = new Color(1f, 1f, 1f, 0.04f);
+            image.raycastTarget = true;
+
+            var button = rowObject.GetComponent<Button>();
+            button.targetGraphic = image;
+            button.onClick.AddListener(() => contextMenu.ShowForItem(entry.ItemId, IsWeaponItem(entry.ItemId), rect));
+
+            var labelObject = new GameObject("Label", typeof(RectTransform), typeof(CanvasRenderer), typeof(TextMeshProUGUI));
+            labelObject.transform.SetParent(rowObject.transform, false);
+
+            var labelRect = labelObject.GetComponent<RectTransform>();
+            labelRect.anchorMin = Vector2.zero;
+            labelRect.anchorMax = Vector2.one;
+            labelRect.offsetMin = new Vector2(8f, 0f);
+            labelRect.offsetMax = new Vector2(-8f, 0f);
+
+            var text = labelObject.GetComponent<TextMeshProUGUI>();
+            text.text = $"{entry.ItemId} x{entry.Count}";
+            text.fontSize = 16;
+            text.color = Color.white;
+            text.alignment = TextAlignmentOptions.Left;
+            text.raycastTarget = false;
+
+            var trigger = rowObject.AddComponent<InventoryContextMenuTrigger>();
+            trigger.Configure(contextMenu, entry.ItemId, IsWeaponItem(entry.ItemId));
+        }
+
+        private bool IsWeaponItem(string itemId)
+        {
+            IWeaponDefinitionResolver resolver = weaponDefinitionResolverSource as IWeaponDefinitionResolver ?? weaponDefinitionResolver ?? FindWeaponDefinitionResolver();
+            return resolver != null && resolver.Resolve(itemId) != null;
+        }
+
+        private IWeaponDefinitionResolver FindWeaponDefinitionResolver()
+        {
+            var behaviours = FindObjectsOfType<MonoBehaviour>();
+            for (int i = 0; i < behaviours.Length; i++)
+            {
+                if (behaviours[i] is IWeaponDefinitionResolver resolver)
+                {
+                    return resolver;
+                }
+            }
+
+            return null;
         }
 
         private static Button CreateButton(string name, Transform parent, string label, Vector2 size, int fontSize)
@@ -473,6 +643,7 @@ namespace Castlebound.Gameplay.UI
         {
             if (Application.isPlaying)
             {
+                child.SetActive(false);
                 Object.Destroy(child);
             }
             else

--- a/Assets/_Project/_Tests/EditMode/Inventory/BackpackItemDropControllerTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Inventory/BackpackItemDropControllerTests.cs
@@ -1,0 +1,88 @@
+using Castlebound.Gameplay.Combat;
+using Castlebound.Gameplay.Inventory;
+using Castlebound.Gameplay.Loot;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Castlebound.Tests.Inventory
+{
+    public class BackpackItemDropControllerTests
+    {
+        private GameObject root;
+        private BackpackInventoryStateComponent backpack;
+        private BackpackItemDropController dropController;
+        private TestWeaponResolver resolver;
+        private WeaponDefinition weapon;
+
+        [SetUp]
+        public void SetUp()
+        {
+            root = new GameObject("DropRoot");
+            backpack = root.AddComponent<BackpackInventoryStateComponent>();
+            resolver = root.AddComponent<TestWeaponResolver>();
+            dropController = root.AddComponent<BackpackItemDropController>();
+            dropController.SetBackpackSource(backpack);
+            dropController.SetDropOrigin(root.transform);
+            dropController.SetWeaponDefinitionResolver(resolver);
+
+            weapon = ScriptableObject.CreateInstance<WeaponDefinition>();
+            weapon.ItemId = "weapon_dagger";
+            resolver.Weapon = weapon;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (dropController != null && dropController.LastSpawnedPickup != null)
+            {
+                Object.DestroyImmediate(dropController.LastSpawnedPickup.gameObject);
+            }
+
+            Object.DestroyImmediate(weapon);
+            Object.DestroyImmediate(root);
+        }
+
+        [Test]
+        public void TryDrop_WeaponInBackpack_SpawnsPickupAndRemovesOneItem()
+        {
+            backpack.State.AddItem("weapon_dagger", 1);
+
+            var result = dropController.TryDrop("weapon_dagger");
+
+            Assert.IsTrue(result);
+            Assert.That(backpack.State.GetCount("weapon_dagger"), Is.EqualTo(0));
+            Assert.NotNull(dropController.LastSpawnedPickup);
+            Assert.That(dropController.LastSpawnedPickup.Kind, Is.EqualTo(ItemPickupKind.Weapon));
+            Assert.That(dropController.LastSpawnedPickup.ItemDefinition, Is.SameAs(weapon));
+            var motion = dropController.LastSpawnedPickup.GetComponent<LootSpillMotion>();
+            Assert.NotNull(motion);
+            var start = dropController.LastSpawnedPickup.transform.position;
+            motion.Step(1f);
+            Assert.That(dropController.LastSpawnedPickup.transform.position.y, Is.LessThan(start.y));
+            Assert.That(Vector3.Distance(start, dropController.LastSpawnedPickup.transform.position), Is.GreaterThan(2f));
+            Assert.IsFalse(dropController.LastSpawnedPickup.CanAutoPickup(new InventoryState()));
+        }
+
+        [Test]
+        public void TryDrop_UnknownItem_DoesNotRemoveFromBackpack()
+        {
+            backpack.State.AddItem("not_weapon", 1);
+
+            var result = dropController.TryDrop("not_weapon");
+
+            Assert.IsFalse(result);
+            Assert.That(backpack.State.GetCount("not_weapon"), Is.EqualTo(1));
+            Assert.IsNull(dropController.LastSpawnedPickup);
+        }
+
+        private sealed class TestWeaponResolver : MonoBehaviour, IWeaponDefinitionResolver
+        {
+            public WeaponDefinition Weapon { get; set; }
+
+            public WeaponDefinition Resolve(string weaponId)
+            {
+                return Weapon != null && Weapon.ItemId == weaponId ? Weapon : null;
+            }
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Inventory/BackpackItemDropControllerTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Inventory/BackpackItemDropControllerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a1b2c3d4e5f64789a0b1c2d3e4f50618
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/EditMode/Inventory/BackpackWeaponEquipControllerTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Inventory/BackpackWeaponEquipControllerTests.cs
@@ -1,0 +1,56 @@
+using Castlebound.Gameplay.Inventory;
+using NUnit.Framework;
+
+namespace Castlebound.Tests.Inventory
+{
+    public class BackpackWeaponEquipControllerTests
+    {
+        [Test]
+        public void TryEquip_BackpackWeaponToMainSlot_DisplacesExistingWeaponToBackpack()
+        {
+            var activeInventory = new InventoryState();
+            var backpack = new BackpackInventoryState(maxItemCount: 2);
+            activeInventory.AddWeapon("weapon_sword");
+            backpack.AddItem("weapon_dagger", 1);
+
+            var result = BackpackWeaponEquipController.TryEquip(activeInventory, backpack, "weapon_dagger", 0);
+
+            Assert.IsTrue(result);
+            Assert.That(activeInventory.GetWeaponId(0), Is.EqualTo("weapon_dagger"));
+            Assert.That(backpack.GetCount("weapon_dagger"), Is.EqualTo(0));
+            Assert.That(backpack.GetCount("weapon_sword"), Is.EqualTo(1));
+        }
+
+        [Test]
+        public void TryEquip_InvalidSlot_DoesNotMutateBackpackOrActiveInventory()
+        {
+            var activeInventory = new InventoryState();
+            var backpack = new BackpackInventoryState(maxItemCount: 2);
+            activeInventory.AddWeapon("weapon_sword");
+            backpack.AddItem("weapon_dagger", 1);
+
+            var result = BackpackWeaponEquipController.TryEquip(activeInventory, backpack, "weapon_dagger", 2);
+
+            Assert.IsFalse(result);
+            Assert.That(activeInventory.GetWeaponId(0), Is.EqualTo("weapon_sword"));
+            Assert.That(backpack.GetCount("weapon_dagger"), Is.EqualTo(1));
+        }
+
+        [Test]
+        public void TryEquip_RepeatedSwapsBetweenBackpackAndMainSlot_RemainsAllowed()
+        {
+            var activeInventory = new InventoryState();
+            var backpack = new BackpackInventoryState(maxItemCount: 2);
+            activeInventory.AddWeapon("weapon_sword");
+            backpack.AddItem("weapon_dagger", 1);
+
+            Assert.IsTrue(BackpackWeaponEquipController.TryEquip(activeInventory, backpack, "weapon_dagger", 0));
+            Assert.IsTrue(BackpackWeaponEquipController.TryEquip(activeInventory, backpack, "weapon_sword", 0));
+            Assert.IsTrue(BackpackWeaponEquipController.TryEquip(activeInventory, backpack, "weapon_dagger", 0));
+
+            Assert.That(activeInventory.GetWeaponId(0), Is.EqualTo("weapon_dagger"));
+            Assert.That(backpack.GetCount("weapon_sword"), Is.EqualTo(1));
+            Assert.That(backpack.GetCount("weapon_dagger"), Is.EqualTo(0));
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Inventory/BackpackWeaponEquipControllerTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Inventory/BackpackWeaponEquipControllerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d9c8b7a6f5e44321a0b1c2d3e4f50617
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/EditMode/Inventory/InventoryStateTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Inventory/InventoryStateTests.cs
@@ -114,6 +114,24 @@ namespace Castlebound.Tests.Inventory
         }
 
         [Test]
+        public void TrySetWeaponAtSlot_ReplacesRequestedSlotAndReturnsPreviousWeapon()
+        {
+            var state = new InventoryState();
+            var recorder = new EventRecorder();
+            state.OnInventoryChanged += recorder.Record;
+            state.AddWeapon("weapon_a");
+            state.AddWeapon("weapon_b");
+
+            var result = state.TrySetWeaponAtSlot(1, "weapon_c", out string previousWeapon);
+
+            Assert.IsTrue(result);
+            Assert.That(previousWeapon, Is.EqualTo("weapon_b"));
+            Assert.That(state.GetWeaponId(0), Is.EqualTo("weapon_a"));
+            Assert.That(state.GetWeaponId(1), Is.EqualTo("weapon_c"));
+            Assert.AreEqual(InventoryChangeFlags.Weapons, recorder.LastFlags);
+        }
+
+        [Test]
         public void AddPotion_EmptyStack_AddsTypeAndCount_AndEmitsPotionChange()
         {
             var state = new InventoryState();

--- a/Assets/_Project/_Tests/EditMode/UI/InventoryContextMenuControllerTests.cs
+++ b/Assets/_Project/_Tests/EditMode/UI/InventoryContextMenuControllerTests.cs
@@ -1,0 +1,125 @@
+using Castlebound.Gameplay.Combat;
+using Castlebound.Gameplay.Inventory;
+using Castlebound.Gameplay.UI;
+using NUnit.Framework;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Castlebound.Tests.UI
+{
+    public class InventoryContextMenuControllerTests
+    {
+        private GameObject root;
+        private BackpackInventoryStateComponent backpack;
+        private InventoryStateComponent activeInventory;
+        private InventoryContextMenuController menu;
+        private BackpackWeaponEquipController equipController;
+        private BackpackItemDropController dropController;
+        private WeaponDefinition weapon;
+
+        [SetUp]
+        public void SetUp()
+        {
+            root = new GameObject("MenuRoot", typeof(Canvas), typeof(RectTransform));
+            backpack = root.AddComponent<BackpackInventoryStateComponent>();
+            activeInventory = root.AddComponent<InventoryStateComponent>();
+            var resolver = root.AddComponent<TestWeaponResolver>();
+            equipController = root.AddComponent<BackpackWeaponEquipController>();
+            dropController = root.AddComponent<BackpackItemDropController>();
+            menu = root.AddComponent<InventoryContextMenuController>();
+
+            weapon = ScriptableObject.CreateInstance<WeaponDefinition>();
+            weapon.ItemId = "weapon_dagger";
+            resolver.Weapon = weapon;
+
+            equipController.SetActiveInventorySource(activeInventory);
+            equipController.SetBackpackSource(backpack);
+            dropController.SetBackpackSource(backpack);
+            dropController.SetWeaponDefinitionResolver(resolver);
+            dropController.SetDropOrigin(root.transform);
+            menu.SetParentRoot(root.GetComponent<RectTransform>());
+            menu.SetEquipController(equipController);
+            menu.SetDropController(dropController);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (dropController != null && dropController.LastSpawnedPickup != null)
+            {
+                Object.DestroyImmediate(dropController.LastSpawnedPickup.gameObject);
+            }
+
+            Object.DestroyImmediate(weapon);
+            Object.DestroyImmediate(root);
+        }
+
+        [Test]
+        public void ShowForWeapon_EquipButtonTransformsIntoMainAndSecondaryChoices()
+        {
+            menu.ShowForItem("weapon_dagger", true, null);
+
+            ClickButton("Equip");
+
+            Assert.IsTrue(menu.IsChoosingEquipSlot);
+            AssertTextExists("Main");
+            AssertTextExists("Secondary");
+        }
+
+        [Test]
+        public void ClickingMain_EquipsBackpackWeaponIntoMainSlot()
+        {
+            backpack.State.AddItem("weapon_dagger", 1);
+            activeInventory.State.AddWeapon("weapon_sword");
+            menu.ShowForItem("weapon_dagger", true, null);
+            ClickButton("Equip");
+
+            ClickButton("Main");
+
+            Assert.IsFalse(menu.IsOpen);
+            Assert.That(activeInventory.State.GetWeaponId(0), Is.EqualTo("weapon_dagger"));
+            Assert.That(backpack.State.GetCount("weapon_sword"), Is.EqualTo(1));
+        }
+
+        private void ClickButton(string label)
+        {
+            var buttons = root.GetComponentsInChildren<Button>(true);
+            for (int i = 0; i < buttons.Length; i++)
+            {
+                var text = buttons[i].GetComponentInChildren<TextMeshProUGUI>(true);
+                if (text != null && text.text == label)
+                {
+                    buttons[i].onClick.Invoke();
+                    return;
+                }
+            }
+
+            Assert.Fail($"Expected button '{label}'.");
+        }
+
+        private void AssertTextExists(string expected)
+        {
+            var labels = root.GetComponentsInChildren<TextMeshProUGUI>(true);
+            for (int i = 0; i < labels.Length; i++)
+            {
+                if (labels[i].text == expected)
+                {
+                    return;
+                }
+            }
+
+            Assert.Fail($"Expected text '{expected}'.");
+        }
+
+        private sealed class TestWeaponResolver : MonoBehaviour, IWeaponDefinitionResolver
+        {
+            public WeaponDefinition Weapon { get; set; }
+
+            public WeaponDefinition Resolve(string weaponId)
+            {
+                return Weapon != null && Weapon.ItemId == weaponId ? Weapon : null;
+            }
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/UI/InventoryContextMenuControllerTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/UI/InventoryContextMenuControllerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f0e1d2c3b4a546789a0b1c2d3e4f5061
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/_Tests/EditMode/UI/InventoryPanelControllerTests.cs
+++ b/Assets/_Project/_Tests/EditMode/UI/InventoryPanelControllerTests.cs
@@ -1,9 +1,11 @@
 using Castlebound.Gameplay.Inventory;
+using Castlebound.Gameplay.Combat;
 using Castlebound.Gameplay.Spawning;
 using Castlebound.Gameplay.UI;
 using NUnit.Framework;
 using TMPro;
 using UnityEngine;
+using UnityEngine.EventSystems;
 using UnityEngine.UI;
 
 namespace Castlebound.Tests.UI
@@ -13,25 +15,41 @@ namespace Castlebound.Tests.UI
         private GameObject root;
         private InventoryPanelController panel;
         private BackpackInventoryStateComponent backpack;
+        private InventoryStateComponent activeInventory;
         private CastleInventoryStateComponent vault;
         private WavePhaseTracker phase;
+        private TestWeaponResolver weaponResolver;
+        private WeaponDefinition weapon;
+        private WeaponDefinition dagger;
 
         [SetUp]
         public void SetUp()
         {
             root = new GameObject("InventoryPanelRoot", typeof(Canvas));
             backpack = root.AddComponent<BackpackInventoryStateComponent>();
+            activeInventory = root.AddComponent<InventoryStateComponent>();
             vault = root.AddComponent<CastleInventoryStateComponent>();
+            weaponResolver = root.AddComponent<TestWeaponResolver>();
+            weapon = ScriptableObject.CreateInstance<WeaponDefinition>();
+            weapon.ItemId = "weapon_sword";
+            weaponResolver.Weapon = weapon;
+            dagger = ScriptableObject.CreateInstance<WeaponDefinition>();
+            dagger.ItemId = "weapon_dagger";
+            weaponResolver.ExtraWeapon = dagger;
             phase = new WavePhaseTracker();
             panel = root.AddComponent<InventoryPanelController>();
             panel.SetBackpackSource(backpack);
+            panel.SetActiveInventorySource(activeInventory);
             panel.SetCastleInventorySource(vault);
             panel.SetPhaseTracker(phase);
+            panel.SetWeaponDefinitionResolver(weaponResolver);
         }
 
         [TearDown]
         public void TearDown()
         {
+            Object.DestroyImmediate(weapon);
+            Object.DestroyImmediate(dagger);
             Object.DestroyImmediate(root);
         }
 
@@ -148,6 +166,78 @@ namespace Castlebound.Tests.UI
             Assert.IsTrue(panel.VaultTabButton.GetComponent<Image>().raycastTarget);
         }
 
+        [Test]
+        public void BackpackRow_RightClickOpensContextMenu_WithDropAndEquipActions()
+        {
+            backpack.State.AddItem("weapon_sword", 1);
+            panel.TogglePanel();
+
+            var trigger = root.GetComponentInChildren<InventoryContextMenuTrigger>(true);
+            var rowButton = trigger.GetComponent<Button>();
+            var eventData = new PointerEventData(EventSystem.current) { button = PointerEventData.InputButton.Right };
+
+            Assert.NotNull(rowButton);
+            trigger.OnPointerClick(eventData);
+
+            AssertTextExists("Drop");
+            AssertTextExists("Equip");
+        }
+
+        [Test]
+        public void BackpackRow_ButtonClickOpensContextMenu()
+        {
+            backpack.State.AddItem("weapon_sword", 1);
+            panel.TogglePanel();
+
+            var trigger = root.GetComponentInChildren<InventoryContextMenuTrigger>(true);
+            var rowButton = trigger.GetComponent<Button>();
+
+            Assert.NotNull(rowButton);
+            rowButton.onClick.Invoke();
+
+            AssertTextExists("Drop");
+            AssertTextExists("Equip");
+        }
+
+        [Test]
+        public void BackpackRow_ContextMenu_AllowsRepeatedWeaponSwapsAfterRefresh()
+        {
+            activeInventory.State.AddWeapon("weapon_sword");
+            backpack.State.AddItem("weapon_dagger", 1);
+            panel.TogglePanel();
+
+            OpenFirstBackpackRowContextMenu();
+            ClickButton("Equip");
+            ClickButton("Main");
+
+            Assert.That(activeInventory.State.GetWeaponId(0), Is.EqualTo("weapon_dagger"));
+            Assert.That(backpack.State.GetCount("weapon_sword"), Is.EqualTo(1));
+
+            OpenFirstBackpackRowContextMenu();
+            ClickButton("Equip");
+            ClickButton("Main");
+
+            Assert.That(activeInventory.State.GetWeaponId(0), Is.EqualTo("weapon_sword"));
+            Assert.That(backpack.State.GetCount("weapon_dagger"), Is.EqualTo(1));
+        }
+
+        [Test]
+        public void BackpackChange_ClosesOpenContextMenu_WhenRowsRefresh()
+        {
+            backpack.State.AddItem("weapon_sword", 1);
+            panel.TogglePanel();
+            OpenFirstBackpackRowContextMenu();
+            var menu = root.GetComponent<InventoryContextMenuController>();
+
+            Assert.NotNull(menu);
+            Assert.IsTrue(menu.IsOpen);
+
+            backpack.State.Clear();
+
+            Assert.IsFalse(menu.IsOpen);
+            AssertTextExists("Backpack is empty");
+        }
+
         private void AssertTextExists(string expected)
         {
             var labels = root.GetComponentsInChildren<TextMeshProUGUI>(true);
@@ -162,6 +252,30 @@ namespace Castlebound.Tests.UI
             Assert.Fail($"Expected inventory panel text '{expected}'.");
         }
 
+        private void OpenFirstBackpackRowContextMenu()
+        {
+            var trigger = root.GetComponentInChildren<InventoryContextMenuTrigger>(true);
+            Assert.NotNull(trigger);
+            var eventData = new PointerEventData(EventSystem.current) { button = PointerEventData.InputButton.Right };
+            trigger.OnPointerClick(eventData);
+        }
+
+        private void ClickButton(string label)
+        {
+            var buttons = root.GetComponentsInChildren<Button>(true);
+            foreach (var button in buttons)
+            {
+                var text = button.GetComponentInChildren<TextMeshProUGUI>(true);
+                if (text != null && text.text == label)
+                {
+                    button.onClick.Invoke();
+                    return;
+                }
+            }
+
+            Assert.Fail($"Expected button '{label}'.");
+        }
+
         private RectTransform FindRectTransform(string objectName)
         {
             var rects = root.GetComponentsInChildren<RectTransform>(true);
@@ -174,6 +288,22 @@ namespace Castlebound.Tests.UI
             }
 
             return null;
+        }
+
+        private sealed class TestWeaponResolver : MonoBehaviour, IWeaponDefinitionResolver
+        {
+            public WeaponDefinition Weapon { get; set; }
+            public WeaponDefinition ExtraWeapon { get; set; }
+
+            public WeaponDefinition Resolve(string weaponId)
+            {
+                if (Weapon != null && Weapon.ItemId == weaponId)
+                {
+                    return Weapon;
+                }
+
+                return ExtraWeapon != null && ExtraWeapon.ItemId == weaponId ? ExtraWeapon : null;
+            }
         }
     }
 }

--- a/Assets/_Project/_Tests/PlayMode/UI/InventoryPanelControllerPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/UI/InventoryPanelControllerPlayTests.cs
@@ -1,10 +1,14 @@
 using Castlebound.Gameplay.Inventory;
+using Castlebound.Gameplay.Combat;
 using Castlebound.Gameplay.Spawning;
 using Castlebound.Gameplay.UI;
 using NUnit.Framework;
 using System.Collections;
+using TMPro;
 using UnityEngine;
+using UnityEngine.EventSystems;
 using UnityEngine.TestTools;
+using UnityEngine.UI;
 
 namespace Castlebound.Tests.UI
 {
@@ -43,6 +47,80 @@ namespace Castlebound.Tests.UI
             finally
             {
                 Object.Destroy(root);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator InventoryPanel_BackpackContextMenu_EquipsWeaponToMainSlot()
+        {
+            var root = new GameObject("InventoryPanelContextPlayRoot", typeof(Canvas));
+
+            try
+            {
+                var backpack = root.AddComponent<BackpackInventoryStateComponent>();
+                var activeInventory = root.AddComponent<InventoryStateComponent>();
+                var vault = root.AddComponent<CastleInventoryStateComponent>();
+                var resolver = root.AddComponent<TestWeaponResolver>();
+                var weapon = ScriptableObject.CreateInstance<WeaponDefinition>();
+                weapon.ItemId = "weapon_dagger";
+                resolver.Weapon = weapon;
+
+                var panel = root.AddComponent<InventoryPanelController>();
+                panel.SetBackpackSource(backpack);
+                panel.SetActiveInventorySource(activeInventory);
+                panel.SetCastleInventorySource(vault);
+                panel.SetWeaponDefinitionResolver(resolver);
+
+                activeInventory.State.AddWeapon("weapon_sword");
+                backpack.State.AddItem("weapon_dagger", 1);
+                panel.TogglePanel();
+                yield return null;
+
+                var trigger = root.GetComponentInChildren<InventoryContextMenuTrigger>(true);
+                Assert.NotNull(trigger);
+                trigger.OnPointerClick(new PointerEventData(EventSystem.current) { button = PointerEventData.InputButton.Right });
+                yield return null;
+
+                ClickButton(root, "Equip");
+                yield return null;
+
+                ClickButton(root, "Main");
+                yield return null;
+
+                Assert.That(activeInventory.State.GetWeaponId(0), Is.EqualTo("weapon_dagger"));
+                Assert.That(backpack.State.GetCount("weapon_sword"), Is.EqualTo(1));
+
+                Object.Destroy(weapon);
+            }
+            finally
+            {
+                Object.Destroy(root);
+            }
+        }
+
+        private static void ClickButton(GameObject root, string label)
+        {
+            var buttons = root.GetComponentsInChildren<Button>(true);
+            for (int i = 0; i < buttons.Length; i++)
+            {
+                var text = buttons[i].GetComponentInChildren<TextMeshProUGUI>(true);
+                if (text != null && text.text == label)
+                {
+                    buttons[i].onClick.Invoke();
+                    return;
+                }
+            }
+
+            Assert.Fail($"Expected button '{label}'.");
+        }
+
+        private sealed class TestWeaponResolver : MonoBehaviour, IWeaponDefinitionResolver
+        {
+            public WeaponDefinition Weapon { get; set; }
+
+            public WeaponDefinition Resolve(string weaponId)
+            {
+                return Weapon != null && Weapon.ItemId == weaponId ? Weapon : null;
             }
         }
     }

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,34 @@
 
 ---
 
+## 2026-07-07 - feat-p4-backpack-context-actions
+
+### Summary
+- Added Backpack row context actions for weapon inventory flow.
+- Added right-click and long-press row triggers that open Drop / Equip actions.
+- Made each Backpack item row a full-width button that opens the context menu on click/tap.
+- Added Equip slot choices for Main and Secondary active weapon slots.
+- Added drop-to-world behavior that removes one Backpack weapon and spawns a pickup near the player.
+- Fixed repeated Backpack weapon swaps after panel refresh by immediately deactivating stale runtime UI rows/menu buttons before deferred destruction.
+- Updated dropped weapon behavior to slide farther forward with slight scatter using `LootSpillMotion` and block pickup for 5 seconds.
+- Closed the open item context menu when Backpack rows refresh so round-end Backpack clearing cannot strand a stale menu.
+
+### New or Updated Tests
+**EditMode**
+- `InventoryStateTests` - validates direct active weapon slot replacement.
+- `BackpackWeaponEquipControllerTests` - validates Backpack weapon equip and displaced weapon return behavior.
+- `BackpackWeaponEquipControllerTests` - validates repeated Backpack-to-active weapon swaps remain allowed.
+- `BackpackItemDropControllerTests` - validates Backpack weapon drop spawning, outward slide motion, pickup cooldown blocking, and failure without mutation for unmapped ids.
+- `InventoryContextMenuControllerTests` - validates Equip transforming into Main / Secondary and Main slot equip action.
+- `InventoryPanelControllerTests` - validates button click and right-click opening Drop / Equip for weapon Backpack rows, repeated context-menu swaps after refresh, and closing stale menus when Backpack contents clear.
+
+**PlayMode**
+- `InventoryPanelControllerPlayTests` - smoke-validates Backpack context menu equip into the main weapon slot.
+
+### Notes
+- Local EditMode execution was attempted through the Unity CI entrypoint, but Unity exited through the project-already-open crash path and produced no NUnit XML.
+- `git diff --check` passed.
+
 ## 2026-07-05 - issue-209-prototype-weapon-variety
 
 ### Summary


### PR DESCRIPTION
## Why
Backpack weapons need direct item actions before the Backpack/shop loop can feel usable. This adds a small context menu for equipping or dropping carried weapons without expanding the inventory panel into a god controller.

## What changed
- Added full-row Backpack context actions for click/tap, right-click, and mobile long-press.
- Added Drop and Equip actions, with Equip expanding into Main and Secondary weapon slots.
- Added safe Backpack-to-active-slot swaps that return displaced weapons to Backpack.
- Added drop-to-world behavior with forward slide scatter and a 5 second pickup delay.
- Closed stale item menus when Backpack contents refresh, including round-end Backpack clearing.
- Added focused EditMode and PlayMode coverage for equip, drop, menu, and panel flows.

## How to test
1. Open `Assets/_Project/Scenes/MainPrototype.unity`.
2. Press Play, collect overflow weapons into Backpack, then open Bag.
3. Click/tap or right-click a Backpack weapon row and verify Drop / Equip actions.
4. Equip into Main and Secondary, repeat swaps, and verify displaced weapons return to Backpack.
5. Drop a weapon and verify it slides forward with slight scatter, cannot be picked up for 5 seconds, and does not magnet back.
6. End a round with the item menu open and verify the Backpack clears and the menu closes.
7. Run tests:
   - EditMode
   - PlayMode

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated (N/A - runtime UI creates the needed controls)
- [x] Prefab links, tags, and layers validated (N/A - no new prefab, tag, or layer required)
- [x] README / Docs touched (N/A - TEST_LOG updated; README not needed)

## Related
- Refs #209