### PR TITLE
feat(shop): add castle-only shop foundation

### DIFF
--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/CastleRegionTracker.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/CastleRegionTracker.cs
@@ -83,6 +83,24 @@ namespace Castlebound.Gameplay.AI
             Instance = this;
             InstanceReady?.Invoke();
         }
+
+        public void Debug_SetPlayerInsideForTests(bool inside)
+        {
+            if (PlayerInside == inside)
+            {
+                return;
+            }
+
+            PlayerInside = inside;
+            if (PlayerInside)
+            {
+                OnPlayerEntered?.Invoke();
+            }
+            else
+            {
+                OnPlayerExited?.Invoke();
+            }
+        }
 #endif
     }
 }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Castle/CastleShopAccessPolicy.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Castle/CastleShopAccessPolicy.cs
@@ -1,0 +1,12 @@
+using Castlebound.Gameplay.Spawning;
+
+namespace Castlebound.Gameplay.Castle
+{
+    public static class CastleShopAccessPolicy
+    {
+        public static bool CanOpen(bool hasCastleRegionTracker, bool playerInsideCastle, WavePhase phase)
+        {
+            return hasCastleRegionTracker && playerInsideCastle && phase == WavePhase.PreWave;
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Castle/CastleShopAccessPolicy.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Castle/CastleShopAccessPolicy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8291cdef368a45f29ba72b6de3d5901c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/_Project.Gameplay/UI/InventoryPanelController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/UI/InventoryPanelController.cs
@@ -1,3 +1,5 @@
+using Castlebound.Gameplay.AI;
+using Castlebound.Gameplay.Castle;
 using Castlebound.Gameplay.Inventory;
 using Castlebound.Gameplay.Spawning;
 using Castlebound.Gameplay.Combat;
@@ -18,6 +20,7 @@ namespace Castlebound.Gameplay.UI
         [SerializeField] private InventoryStateComponent activeInventorySource;
         [SerializeField] private CastleInventoryStateComponent castleInventorySource;
         [SerializeField] private EnemySpawnerRunner waveRunner;
+        [SerializeField] private CastleRegionTracker castleRegionTracker;
         [SerializeField] private InventoryContextMenuController contextMenu;
         [SerializeField] private BackpackWeaponEquipController equipController;
         [SerializeField] private BackpackItemDropController dropController;
@@ -30,6 +33,7 @@ namespace Castlebound.Gameplay.UI
         private RectTransform tabRoot;
         private InventoryPanelTab activeTab = InventoryPanelTab.Backpack;
         private bool contextMenuHooked;
+        private bool castleRegionHooked;
         private bool vaultOpenedFromWorld;
 
         public bool IsOpen => panelRoot != null && panelRoot.gameObject.activeSelf;
@@ -110,6 +114,19 @@ namespace Castlebound.Gameplay.UI
             SetPhaseTracker(waveRunner != null ? waveRunner.PhaseTracker : null);
         }
 
+        public void SetCastleRegionTracker(CastleRegionTracker tracker)
+        {
+            if (castleRegionTracker == tracker)
+            {
+                return;
+            }
+
+            UnhookCastleRegionTracker();
+            castleRegionTracker = tracker;
+            HookCastleRegionTracker();
+            HandleShopAccessChanged();
+        }
+
         public void SetWeaponDefinitionResolver(IWeaponDefinitionResolver resolver)
         {
             weaponDefinitionResolver = resolver;
@@ -167,11 +184,6 @@ namespace Castlebound.Gameplay.UI
 
         public void SetActiveTab(InventoryPanelTab tab)
         {
-            if (tab == InventoryPanelTab.Shop)
-            {
-                return;
-            }
-
             vaultOpenedFromWorld = false;
             if (contextMenu != null)
             {
@@ -211,6 +223,11 @@ namespace Castlebound.Gameplay.UI
                 waveRunner = FindObjectOfType<EnemySpawnerRunner>();
             }
 
+            if (castleRegionTracker == null)
+            {
+                castleRegionTracker = CastleRegionTracker.Instance;
+            }
+
             backpack = backpackSource != null ? backpackSource.State : null;
             vault = castleInventorySource != null ? castleInventorySource.State : null;
             phaseTracker = waveRunner != null ? waveRunner.PhaseTracker : phaseTracker;
@@ -222,6 +239,9 @@ namespace Castlebound.Gameplay.UI
             HookBackpack();
             HookVault();
             HookPhaseTracker();
+            HookCastleRegionTracker();
+            CastleRegionTracker.InstanceReady -= OnCastleRegionInstanceReady;
+            CastleRegionTracker.InstanceReady += OnCastleRegionInstanceReady;
         }
 
         private void UnhookSources()
@@ -229,6 +249,8 @@ namespace Castlebound.Gameplay.UI
             UnhookBackpack();
             UnhookVault();
             UnhookPhaseTracker();
+            UnhookCastleRegionTracker();
+            CastleRegionTracker.InstanceReady -= OnCastleRegionInstanceReady;
         }
 
         private void HookBackpack()
@@ -287,12 +309,70 @@ namespace Castlebound.Gameplay.UI
                 activeTab = InventoryPanelTab.Backpack;
             }
 
+            HandleShopAccessChanged();
             Refresh();
+        }
+
+        private void OnCastleRegionInstanceReady()
+        {
+            if (castleRegionTracker != null)
+            {
+                return;
+            }
+
+            SetCastleRegionTracker(CastleRegionTracker.Instance);
+        }
+
+        private void HookCastleRegionTracker()
+        {
+            if (castleRegionHooked || castleRegionTracker == null)
+            {
+                return;
+            }
+
+            castleRegionTracker.OnPlayerEntered += OnCastlePlayerRegionChanged;
+            castleRegionTracker.OnPlayerExited += OnCastlePlayerRegionChanged;
+            castleRegionHooked = true;
+        }
+
+        private void UnhookCastleRegionTracker()
+        {
+            if (!castleRegionHooked || castleRegionTracker == null)
+            {
+                castleRegionHooked = false;
+                return;
+            }
+
+            castleRegionTracker.OnPlayerEntered -= OnCastlePlayerRegionChanged;
+            castleRegionTracker.OnPlayerExited -= OnCastlePlayerRegionChanged;
+            castleRegionHooked = false;
+        }
+
+        private void OnCastlePlayerRegionChanged()
+        {
+            HandleShopAccessChanged();
+            Refresh();
+        }
+
+        private void HandleShopAccessChanged()
+        {
+            if (activeTab == InventoryPanelTab.Shop && IsOpen && !IsShopAccessible())
+            {
+                ClosePanel();
+            }
         }
 
         private bool IsVaultAccessible()
         {
             return phaseTracker == null || phaseTracker.CurrentPhase == WavePhase.PreWave;
+        }
+
+        private bool IsShopAccessible()
+        {
+            return CastleShopAccessPolicy.CanOpen(
+                castleRegionTracker != null,
+                castleRegionTracker != null && castleRegionTracker.PlayerInside,
+                phaseTracker != null ? phaseTracker.CurrentPhase : WavePhase.PreWave);
         }
 
         private void ApplyPanelState(bool open)
@@ -526,7 +606,7 @@ namespace Castlebound.Gameplay.UI
             }
             else
             {
-                CreateTextRow("Shop coming soon");
+                CreateShopRows();
             }
 
             if (contextMenu != null)
@@ -567,6 +647,19 @@ namespace Castlebound.Gameplay.UI
             {
                 CreateInventoryRow(entry.ItemId, entry.Count, InventoryContextSource.Vault);
             }
+        }
+
+        private void CreateShopRows()
+        {
+            if (!IsShopAccessible())
+            {
+                CreateTextRow("Shop opens inside castle between waves");
+                return;
+            }
+
+            CreateTextRow("Castle Shop");
+            CreateTextRow("Repair Kit - Coming soon");
+            CreateTextRow("Wall Supplies - Coming soon");
         }
 
         private void CreateTextRow(string value)

--- a/Assets/_Project/_Tests/EditMode/Castle/CastleShopAccessPolicyTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Castle/CastleShopAccessPolicyTests.cs
@@ -1,0 +1,23 @@
+using Castlebound.Gameplay.Castle;
+using Castlebound.Gameplay.Spawning;
+using NUnit.Framework;
+
+namespace Castlebound.Tests.Castle
+{
+    public class CastleShopAccessPolicyTests
+    {
+        [Test]
+        public void CanOpen_AllowsOnlyInsideCastleDuringPreWave()
+        {
+            Assert.IsTrue(CastleShopAccessPolicy.CanOpen(true, true, WavePhase.PreWave));
+            Assert.IsFalse(CastleShopAccessPolicy.CanOpen(true, false, WavePhase.PreWave));
+            Assert.IsFalse(CastleShopAccessPolicy.CanOpen(true, true, WavePhase.InWave));
+        }
+
+        [Test]
+        public void CanOpen_BlocksWhenCastleRegionTrackerIsUnavailable()
+        {
+            Assert.IsFalse(CastleShopAccessPolicy.CanOpen(false, true, WavePhase.PreWave));
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Castle/CastleShopAccessPolicyTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Castle/CastleShopAccessPolicyTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f6fc1e8c87ff4a3a971ecb62e62a255d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/_Tests/EditMode/UI/InventoryPanelControllerTests.cs
+++ b/Assets/_Project/_Tests/EditMode/UI/InventoryPanelControllerTests.cs
@@ -1,3 +1,4 @@
+using Castlebound.Gameplay.AI;
 using Castlebound.Gameplay.Inventory;
 using Castlebound.Gameplay.Combat;
 using Castlebound.Gameplay.Spawning;
@@ -18,6 +19,7 @@ namespace Castlebound.Tests.UI
         private InventoryStateComponent activeInventory;
         private CastleInventoryStateComponent vault;
         private WavePhaseTracker phase;
+        private CastleRegionTracker castleRegion;
         private TestWeaponResolver weaponResolver;
         private WeaponDefinition weapon;
         private WeaponDefinition dagger;
@@ -98,16 +100,63 @@ namespace Castlebound.Tests.UI
         }
 
         [Test]
-        public void ShopTab_IsInert_AndDoesNotRenderVaultEntries()
+        public void ShopTab_RendersBlockedState_WhenAccessDenied()
         {
             vault.State.AddItem("potion_health", 3);
             panel.TogglePanel();
 
             panel.ShopTabButton.onClick.Invoke();
 
-            Assert.That(panel.ActiveTab, Is.EqualTo(InventoryPanelTab.Backpack));
-            AssertTextExists("Backpack is empty");
+            Assert.That(panel.ActiveTab, Is.EqualTo(InventoryPanelTab.Shop));
+            AssertTextExists("Shop opens inside castle between waves");
             AssertTextMissing("potion_health x3");
+        }
+
+        [Test]
+        public void ShopTab_RendersPrototypeRows_WhenInsideCastleAndBetweenWaves()
+        {
+            var tracker = CreateCastleRegionTracker();
+            tracker.Debug_SetPlayerInsideForTests(true);
+            phase.SetPhase(WavePhase.PreWave);
+            panel.SetCastleRegionTracker(tracker);
+            panel.TogglePanel();
+
+            panel.ShopTabButton.onClick.Invoke();
+
+            Assert.That(panel.ActiveTab, Is.EqualTo(InventoryPanelTab.Shop));
+            AssertTextExists("Castle Shop");
+            AssertTextExists("Repair Kit - Coming soon");
+            AssertTextExists("Wall Supplies - Coming soon");
+        }
+
+        [Test]
+        public void ShopTab_ClosesPanel_WhenAccessIsLost()
+        {
+            var tracker = CreateCastleRegionTracker();
+            tracker.Debug_SetPlayerInsideForTests(true);
+            phase.SetPhase(WavePhase.PreWave);
+            panel.SetCastleRegionTracker(tracker);
+            panel.TogglePanel();
+            panel.ShopTabButton.onClick.Invoke();
+
+            tracker.Debug_SetPlayerInsideForTests(false);
+
+            Assert.IsFalse(panel.IsOpen);
+        }
+
+        [Test]
+        public void ShopTab_ClosesPanel_WhenWaveStarts()
+        {
+            var tracker = CreateCastleRegionTracker();
+            tracker.Debug_SetPlayerInsideForTests(true);
+            phase.SetPhase(WavePhase.PreWave);
+            panel.SetCastleRegionTracker(tracker);
+            panel.TogglePanel();
+            panel.ShopTabButton.onClick.Invoke();
+
+            phase.SetPhase(WavePhase.InWave);
+
+            Assert.IsFalse(panel.IsOpen);
         }
 
         [Test]
@@ -389,6 +438,13 @@ namespace Castlebound.Tests.UI
             }
 
             return null;
+        }
+
+        private CastleRegionTracker CreateCastleRegionTracker()
+        {
+            castleRegion = root.AddComponent<CastleRegionTracker>();
+            panel.SetCastleRegionTracker(castleRegion);
+            return castleRegion;
         }
 
         private sealed class TestWeaponResolver : MonoBehaviour, IWeaponDefinitionResolver

--- a/Assets/_Project/_Tests/PlayMode/UI/InventoryPanelControllerPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/UI/InventoryPanelControllerPlayTests.cs
@@ -1,3 +1,4 @@
+using Castlebound.Gameplay.AI;
 using Castlebound.Gameplay.Inventory;
 using Castlebound.Gameplay.Combat;
 using Castlebound.Gameplay.Spawning;
@@ -97,6 +98,45 @@ namespace Castlebound.Tests.UI
             }
         }
 
+        [UnityTest]
+        public IEnumerator InventoryPanel_ShopRendersInCastle_AndClosesOnWaveStart()
+        {
+            var root = new GameObject("InventoryPanelShopPlayRoot", typeof(Canvas));
+            GameObject player = null;
+
+            try
+            {
+                root.AddComponent<BackpackInventoryStateComponent>();
+                root.AddComponent<CastleInventoryStateComponent>();
+                var phase = new WavePhaseTracker();
+                var castleRegion = root.AddComponent<CastleRegionTracker>();
+                var panel = root.AddComponent<InventoryPanelController>();
+                panel.SetPhaseTracker(phase);
+                panel.SetCastleRegionTracker(castleRegion);
+
+                player = new GameObject("Player", typeof(BoxCollider2D));
+                player.tag = "Player";
+                castleRegion.SendMessage("OnTriggerEnter2D", player.GetComponent<Collider2D>());
+
+                panel.TogglePanel();
+                panel.ShopTabButton.onClick.Invoke();
+                yield return null;
+
+                Assert.That(panel.ActiveTab, Is.EqualTo(InventoryPanelTab.Shop));
+                AssertTextExists(root, "Castle Shop");
+
+                phase.SetPhase(WavePhase.InWave);
+                yield return null;
+
+                Assert.IsFalse(panel.IsOpen);
+            }
+            finally
+            {
+                Object.Destroy(player);
+                Object.Destroy(root);
+            }
+        }
+
         private static void ClickButton(GameObject root, string label)
         {
             var buttons = root.GetComponentsInChildren<Button>(true);
@@ -111,6 +151,20 @@ namespace Castlebound.Tests.UI
             }
 
             Assert.Fail($"Expected button '{label}'.");
+        }
+
+        private static void AssertTextExists(GameObject root, string expected)
+        {
+            var labels = root.GetComponentsInChildren<TextMeshProUGUI>(true);
+            foreach (var label in labels)
+            {
+                if (label.text == expected)
+                {
+                    return;
+                }
+            }
+
+            Assert.Fail($"Expected text '{expected}'.");
         }
 
         private sealed class TestWeaponResolver : MonoBehaviour, IWeaponDefinitionResolver

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,26 @@
 
 ---
 
+## 2026-07-10 - feat-p4-castle-shop-foundation
+
+### Summary
+- Added castle shop access policy for castle-region plus pre-wave gating.
+- Made the Inventory panel Shop tab render blocked or prototype static shop rows based on access.
+- Auto-closes an active Shop panel when the player exits the castle region or the wave phase changes to active.
+- Stabilized Shop EditMode tests by using an editor-only castle-region test hook instead of private trigger message dispatch.
+
+### New or Updated Tests
+**EditMode**
+- `CastleShopAccessPolicyTests` — validates shop access requires an available castle tracker, player inside castle, and pre-wave phase.
+- `InventoryPanelControllerTests` — validates blocked Shop state, prototype Shop rows, and Shop auto-close on castle exit or wave start.
+
+**PlayMode**
+- `InventoryPanelControllerPlayTests` — smoke-validates Shop rows inside the castle and panel close on wave start.
+
+### Notes
+- EditMode, PlayMode, and manual validation passed.
+- Manual validation confirmed Shop opens between waves only and shows a blocked message when unavailable.
+
 ## 2026-07-07 - feat-p4-castle-vault-world-interaction
 
 ### Summary


### PR DESCRIPTION
## Why
The Inventory panel has a Shop tab, but it needed a foundation that only functions in the intended castle-safe window before waves.

## What changed
- Added a pure castle shop access policy for castle-region plus pre-wave gating.
- Made the Shop tab render either a blocked message or static prototype shop rows.
- Auto-closes an active Shop view when the player leaves the castle region or a wave starts.
- Added EditMode and PlayMode coverage for the shop access foundation.

## How to test
1. Open `Assets/_Project/Scenes/MainPrototype.unity`.
2. Press Play, open the Bag, and verify Shop opens while inside the castle between waves.
3. Leave the castle region or start a wave and verify an active Shop panel closes.
4. Verify Shop shows a blocked message when unavailable.
5. Run tests:
   - EditMode
   - PlayMode

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated (N/A - no scene changes required)
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched (TEST_LOG updated)

## Related
- Refs N/A