### PR TITLE
feat(shop): add static shop catalog

### DIFF
--- a/Assets/_Project/Scripts/_Project.Gameplay/Castle/CastleShopCatalog.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Castle/CastleShopCatalog.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+
+namespace Castlebound.Gameplay.Castle
+{
+    public static class CastleShopCatalog
+    {
+        private static readonly CastleShopOffer[] defaultOffers =
+        {
+            new CastleShopOffer("weapon_sword", "Sword"),
+            new CastleShopOffer("weapon_iron_club", "Iron Club"),
+            new CastleShopOffer("potion_basic", "Health Potion")
+        };
+
+        public static IReadOnlyList<CastleShopOffer> DefaultOffers => defaultOffers;
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Castle/CastleShopCatalog.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Castle/CastleShopCatalog.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 451a93da98b24274a4d46f12234d9371
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/_Project.Gameplay/Castle/CastleShopOffer.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Castle/CastleShopOffer.cs
@@ -1,0 +1,14 @@
+namespace Castlebound.Gameplay.Castle
+{
+    public readonly struct CastleShopOffer
+    {
+        public CastleShopOffer(string itemId, string displayName)
+        {
+            ItemId = itemId;
+            DisplayName = displayName;
+        }
+
+        public string ItemId { get; }
+        public string DisplayName { get; }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Castle/CastleShopOffer.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Castle/CastleShopOffer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 425e45ab441142d392575cb09571c708
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/_Project.Gameplay/UI/InventoryPanelController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/UI/InventoryPanelController.cs
@@ -658,8 +658,10 @@ namespace Castlebound.Gameplay.UI
             }
 
             CreateTextRow("Castle Shop");
-            CreateTextRow("Repair Kit - Coming soon");
-            CreateTextRow("Wall Supplies - Coming soon");
+            foreach (var offer in CastleShopCatalog.DefaultOffers)
+            {
+                CreateTextRow(offer.DisplayName);
+            }
         }
 
         private void CreateTextRow(string value)

--- a/Assets/_Project/_Tests/EditMode/Castle/CastleShopCatalogTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Castle/CastleShopCatalogTests.cs
@@ -1,0 +1,29 @@
+using Castlebound.Gameplay.Castle;
+using NUnit.Framework;
+using System.Linq;
+
+namespace Castlebound.Tests.Castle
+{
+    public class CastleShopCatalogTests
+    {
+        [Test]
+        public void DefaultOffers_ContainOnlySwordIronClubAndHealthPotion()
+        {
+            var offers = CastleShopCatalog.DefaultOffers;
+
+            Assert.That(offers.Count, Is.EqualTo(3));
+            Assert.That(offers.Select(offer => offer.ItemId), Is.EqualTo(new[]
+            {
+                "weapon_sword",
+                "weapon_iron_club",
+                "potion_basic"
+            }));
+            Assert.That(offers.Select(offer => offer.DisplayName), Is.EqualTo(new[]
+            {
+                "Sword",
+                "Iron Club",
+                "Health Potion"
+            }));
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Castle/CastleShopCatalogTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Castle/CastleShopCatalogTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2524c6881fbb4761839a965fcd13a459
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/_Tests/EditMode/UI/InventoryPanelControllerTests.cs
+++ b/Assets/_Project/_Tests/EditMode/UI/InventoryPanelControllerTests.cs
@@ -125,8 +125,13 @@ namespace Castlebound.Tests.UI
 
             Assert.That(panel.ActiveTab, Is.EqualTo(InventoryPanelTab.Shop));
             AssertTextExists("Castle Shop");
-            AssertTextExists("Repair Kit - Coming soon");
-            AssertTextExists("Wall Supplies - Coming soon");
+            AssertTextExists("Sword");
+            AssertTextExists("Iron Club");
+            AssertTextExists("Health Potion");
+            AssertTextMissing("Club");
+            AssertTextMissing("Rusty Dagger");
+            AssertTextMissing("Repair Kit - Coming soon");
+            AssertTextMissing("Wall Supplies - Coming soon");
         }
 
         [Test]

--- a/Assets/_Project/_Tests/PlayMode/UI/InventoryPanelControllerPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/UI/InventoryPanelControllerPlayTests.cs
@@ -102,7 +102,6 @@ namespace Castlebound.Tests.UI
         public IEnumerator InventoryPanel_ShopRendersInCastle_AndClosesOnWaveStart()
         {
             var root = new GameObject("InventoryPanelShopPlayRoot", typeof(Canvas));
-            GameObject player = null;
 
             try
             {
@@ -114,9 +113,7 @@ namespace Castlebound.Tests.UI
                 panel.SetPhaseTracker(phase);
                 panel.SetCastleRegionTracker(castleRegion);
 
-                player = new GameObject("Player", typeof(BoxCollider2D));
-                player.tag = "Player";
-                castleRegion.SendMessage("OnTriggerEnter2D", player.GetComponent<Collider2D>());
+                castleRegion.Debug_SetPlayerInsideForTests(true);
 
                 panel.TogglePanel();
                 panel.ShopTabButton.onClick.Invoke();
@@ -124,6 +121,9 @@ namespace Castlebound.Tests.UI
 
                 Assert.That(panel.ActiveTab, Is.EqualTo(InventoryPanelTab.Shop));
                 AssertTextExists(root, "Castle Shop");
+                AssertTextExists(root, "Sword");
+                AssertTextExists(root, "Iron Club");
+                AssertTextExists(root, "Health Potion");
 
                 phase.SetPhase(WavePhase.InWave);
                 yield return null;
@@ -132,7 +132,6 @@ namespace Castlebound.Tests.UI
             }
             finally
             {
-                Object.Destroy(player);
                 Object.Destroy(root);
             }
         }

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,25 @@
 
 ---
 
+## 2026-07-10 - feat-p4-static-shop-catalog
+
+### Summary
+- Added a static castle shop catalog.
+- Limited the initial Shop offers to Sword, Iron Club, and Health Potion.
+- Updated the Shop tab to render catalog offers instead of placeholder supply rows.
+
+### New or Updated Tests
+**EditMode**
+- `CastleShopCatalogTests` — validates the default catalog contains only Sword, Iron Club, and Health Potion.
+- `InventoryPanelControllerTests` — validates the allowed Shop tab renders the approved catalog offers and excludes old placeholder rows.
+
+**PlayMode**
+- `InventoryPanelControllerPlayTests` — validates the runtime Shop smoke renders the approved catalog offers.
+
+### Notes
+- EditMode, PlayMode, and manual validation passed.
+- Manual validation confirmed Shop renders Sword, Iron Club, and Health Potion only.
+
 ## 2026-07-10 - feat-p4-castle-shop-foundation
 
 ### Summary


### PR DESCRIPTION
## Why
The castle-only Shop tab needs a deterministic prototype catalog before buy/economy behavior is added.

## What changed
- Added a static castle shop catalog model.
- Limited the initial Shop offers to Sword, Iron Club, and Health Potion.
- Updated the Shop tab to render catalog offers instead of placeholder supply rows.
- Added EditMode and PlayMode coverage for catalog contents and runtime rendering.

## How to test
1. Open `Assets/_Project/Scenes/MainPrototype.unity`.
2. Press Play, enter the castle between waves, open Bag, and select Shop.
3. Verify Shop renders only Sword, Iron Club, and Health Potion.
4. Run tests:
   - EditMode
   - PlayMode

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated (N/A - no scene changes required)
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched (TEST_LOG updated)

## Related
- Refs N/A