### PR TITLE
feat(shop): add real catalog purchasing

### DIFF
--- a/Assets/_Project/Scripts/_Project.Gameplay/Castle/CastleShopCatalog.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Castle/CastleShopCatalog.cs
@@ -6,9 +6,9 @@ namespace Castlebound.Gameplay.Castle
     {
         private static readonly CastleShopOffer[] defaultOffers =
         {
-            new CastleShopOffer("weapon_sword", "Sword"),
-            new CastleShopOffer("weapon_iron_club", "Iron Club"),
-            new CastleShopOffer("potion_basic", "Health Potion")
+            new CastleShopOffer("weapon_sword", "Sword", 250),
+            new CastleShopOffer("weapon_iron_club", "Iron Club", 250),
+            new CastleShopOffer("potion_basic", "Health Potion", 50)
         };
 
         public static IReadOnlyList<CastleShopOffer> DefaultOffers => defaultOffers;

--- a/Assets/_Project/Scripts/_Project.Gameplay/Castle/CastleShopOffer.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Castle/CastleShopOffer.cs
@@ -2,13 +2,15 @@ namespace Castlebound.Gameplay.Castle
 {
     public readonly struct CastleShopOffer
     {
-        public CastleShopOffer(string itemId, string displayName)
+        public CastleShopOffer(string itemId, string displayName, int price)
         {
             ItemId = itemId;
             DisplayName = displayName;
+            Price = price < 0 ? 0 : price;
         }
 
         public string ItemId { get; }
         public string DisplayName { get; }
+        public int Price { get; }
     }
 }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Castle/CastleShopPurchaseResult.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Castle/CastleShopPurchaseResult.cs
@@ -1,0 +1,11 @@
+namespace Castlebound.Gameplay.Castle
+{
+    public enum CastleShopPurchaseResult
+    {
+        Success,
+        InsufficientGold,
+        InventoryFull,
+        InvalidOffer,
+        Unavailable
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Castle/CastleShopPurchaseResult.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Castle/CastleShopPurchaseResult.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f958ed156e0d40faaffc94a3755f1a6e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/_Project.Gameplay/Castle/CastleShopPurchaseService.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Castle/CastleShopPurchaseService.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using Castlebound.Gameplay.Inventory;
+
+namespace Castlebound.Gameplay.Castle
+{
+    public static class CastleShopPurchaseService
+    {
+        public static CastleShopPurchaseResult TryPurchase(
+            IReadOnlyList<CastleShopOffer> offers,
+            string itemId,
+            bool isShopAvailable,
+            InventoryState activeInventory,
+            BackpackInventoryState backpack)
+        {
+            if (!isShopAvailable)
+            {
+                return CastleShopPurchaseResult.Unavailable;
+            }
+
+            if (!TryFindOffer(offers, itemId, out var offer))
+            {
+                return CastleShopPurchaseResult.InvalidOffer;
+            }
+
+            if (activeInventory == null)
+            {
+                return CastleShopPurchaseResult.Unavailable;
+            }
+
+            if (!CanAcceptOffer(offer, activeInventory, backpack))
+            {
+                return CastleShopPurchaseResult.InventoryFull;
+            }
+
+            if (offer.Price > 0 && !activeInventory.TrySpendGold(offer.Price))
+            {
+                return CastleShopPurchaseResult.InsufficientGold;
+            }
+
+            if (ApplyOffer(offer, activeInventory, backpack))
+            {
+                return CastleShopPurchaseResult.Success;
+            }
+
+            if (offer.Price > 0)
+            {
+                activeInventory.AddGold(offer.Price);
+            }
+
+            return CastleShopPurchaseResult.InventoryFull;
+        }
+
+        private static bool TryFindOffer(IReadOnlyList<CastleShopOffer> offers, string itemId, out CastleShopOffer offer)
+        {
+            if (offers != null && !string.IsNullOrWhiteSpace(itemId))
+            {
+                for (int i = 0; i < offers.Count; i++)
+                {
+                    if (string.Equals(offers[i].ItemId, itemId, StringComparison.Ordinal))
+                    {
+                        offer = offers[i];
+                        return true;
+                    }
+                }
+            }
+
+            offer = default(CastleShopOffer);
+            return false;
+        }
+
+        private static bool CanAcceptOffer(CastleShopOffer offer, InventoryState activeInventory, BackpackInventoryState backpack)
+        {
+            switch (offer.ItemId)
+            {
+                case "weapon_sword":
+                case "weapon_iron_club":
+                    return backpack != null && backpack.CanAddItem(offer.ItemId, 1);
+                case "potion_basic":
+                    return activeInventory.PotionCount == 0 ||
+                        string.Equals(activeInventory.PotionId, offer.ItemId, StringComparison.Ordinal);
+                default:
+                    return false;
+            }
+        }
+
+        private static bool ApplyOffer(CastleShopOffer offer, InventoryState activeInventory, BackpackInventoryState backpack)
+        {
+            switch (offer.ItemId)
+            {
+                case "weapon_sword":
+                case "weapon_iron_club":
+                    return backpack != null && backpack.AddItem(offer.ItemId, 1);
+                case "potion_basic":
+                    return activeInventory.TryAddPotion(offer.ItemId, 1);
+                default:
+                    return false;
+            }
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Castle/CastleShopPurchaseService.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Castle/CastleShopPurchaseService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: daa2920a7b944abda56aa61214ad7694
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/_Project.Gameplay/UI/InventoryPanelController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/UI/InventoryPanelController.cs
@@ -35,6 +35,7 @@ namespace Castlebound.Gameplay.UI
         private bool contextMenuHooked;
         private bool castleRegionHooked;
         private bool vaultOpenedFromWorld;
+        private string shopFeedbackMessage;
 
         public bool IsOpen => panelRoot != null && panelRoot.gameObject.activeSelf;
         public InventoryPanelTab ActiveTab => activeTab;
@@ -185,6 +186,7 @@ namespace Castlebound.Gameplay.UI
         public void SetActiveTab(InventoryPanelTab tab)
         {
             vaultOpenedFromWorld = false;
+            shopFeedbackMessage = null;
             if (contextMenu != null)
             {
                 contextMenu.Close();
@@ -660,7 +662,85 @@ namespace Castlebound.Gameplay.UI
             CreateTextRow("Castle Shop");
             foreach (var offer in CastleShopCatalog.DefaultOffers)
             {
-                CreateTextRow(offer.DisplayName);
+                CreateShopOfferRow(offer);
+            }
+
+            if (!string.IsNullOrWhiteSpace(shopFeedbackMessage))
+            {
+                CreateTextRow(shopFeedbackMessage);
+            }
+        }
+
+        private void CreateShopOfferRow(CastleShopOffer offer)
+        {
+            var rowObject = new GameObject("ShopOfferRow", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image), typeof(HorizontalLayoutGroup), typeof(LayoutElement));
+            rowObject.transform.SetParent(contentRoot, false);
+
+            var rect = rowObject.GetComponent<RectTransform>();
+            rect.sizeDelta = new Vector2(0f, 38f);
+
+            var layout = rowObject.GetComponent<LayoutElement>();
+            layout.minHeight = 38f;
+            layout.preferredHeight = 38f;
+            layout.flexibleWidth = 1f;
+
+            var image = rowObject.GetComponent<Image>();
+            image.color = new Color(1f, 1f, 1f, 0.04f);
+            image.raycastTarget = false;
+
+            var rowLayout = rowObject.GetComponent<HorizontalLayoutGroup>();
+            rowLayout.spacing = 8f;
+            rowLayout.padding = new RectOffset(8, 8, 4, 4);
+            rowLayout.childForceExpandHeight = true;
+            rowLayout.childForceExpandWidth = false;
+            rowLayout.childControlHeight = true;
+            rowLayout.childControlWidth = true;
+
+            var labelObject = new GameObject("Label", typeof(RectTransform), typeof(CanvasRenderer), typeof(TextMeshProUGUI), typeof(LayoutElement));
+            labelObject.transform.SetParent(rowObject.transform, false);
+
+            var labelLayout = labelObject.GetComponent<LayoutElement>();
+            labelLayout.flexibleWidth = 1f;
+            labelLayout.minHeight = 30f;
+
+            var text = labelObject.GetComponent<TextMeshProUGUI>();
+            text.text = $"{offer.DisplayName} - {offer.Price} gold";
+            text.fontSize = 16;
+            text.color = Color.white;
+            text.alignment = TextAlignmentOptions.Left;
+            text.raycastTarget = false;
+
+            var buyButton = CreateButton("BuyButton", rowObject.transform, "Buy", new Vector2(70f, 30f), 15);
+            buyButton.onClick.AddListener(() => TryPurchaseShopOffer(offer.ItemId));
+        }
+
+        private void TryPurchaseShopOffer(string itemId)
+        {
+            var result = CastleShopPurchaseService.TryPurchase(
+                CastleShopCatalog.DefaultOffers,
+                itemId,
+                IsShopAccessible(),
+                activeInventorySource != null ? activeInventorySource.State : null,
+                backpack);
+
+            shopFeedbackMessage = GetShopFeedbackMessage(result);
+            Refresh();
+        }
+
+        private static string GetShopFeedbackMessage(CastleShopPurchaseResult result)
+        {
+            switch (result)
+            {
+                case CastleShopPurchaseResult.Success:
+                    return "Purchase complete";
+                case CastleShopPurchaseResult.InsufficientGold:
+                    return "Not enough gold";
+                case CastleShopPurchaseResult.InventoryFull:
+                    return "Inventory full";
+                case CastleShopPurchaseResult.InvalidOffer:
+                    return "Offer unavailable";
+                default:
+                    return "Shop unavailable";
             }
         }
 

--- a/Assets/_Project/_Tests/EditMode/Castle/CastleShopCatalogTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Castle/CastleShopCatalogTests.cs
@@ -24,6 +24,12 @@ namespace Castlebound.Tests.Castle
                 "Iron Club",
                 "Health Potion"
             }));
+            Assert.That(offers.Select(offer => offer.Price), Is.EqualTo(new[]
+            {
+                250,
+                250,
+                50
+            }));
         }
     }
 }

--- a/Assets/_Project/_Tests/EditMode/Castle/CastleShopPurchaseServiceTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Castle/CastleShopPurchaseServiceTests.cs
@@ -1,0 +1,145 @@
+using Castlebound.Gameplay.Castle;
+using Castlebound.Gameplay.Inventory;
+using NUnit.Framework;
+
+namespace Castlebound.Tests.Castle
+{
+    public class CastleShopPurchaseServiceTests
+    {
+        [Test]
+        public void TryPurchase_Sword_SpendsGoldAndRoutesToBackpack()
+        {
+            var inventory = CreateInventory(300);
+            var backpack = new BackpackInventoryState();
+
+            var result = CastleShopPurchaseService.TryPurchase(
+                CastleShopCatalog.DefaultOffers,
+                "weapon_sword",
+                true,
+                inventory,
+                backpack);
+
+            Assert.That(result, Is.EqualTo(CastleShopPurchaseResult.Success));
+            Assert.That(inventory.Gold, Is.EqualTo(50));
+            Assert.That(backpack.GetCount("weapon_sword"), Is.EqualTo(1));
+            Assert.That(inventory.GetWeaponId(0), Is.Null);
+        }
+
+        [Test]
+        public void TryPurchase_IronClub_RoutesToBackpack()
+        {
+            var inventory = CreateInventory(250);
+            var backpack = new BackpackInventoryState();
+
+            var result = CastleShopPurchaseService.TryPurchase(
+                CastleShopCatalog.DefaultOffers,
+                "weapon_iron_club",
+                true,
+                inventory,
+                backpack);
+
+            Assert.That(result, Is.EqualTo(CastleShopPurchaseResult.Success));
+            Assert.That(inventory.Gold, Is.EqualTo(0));
+            Assert.That(backpack.GetCount("weapon_iron_club"), Is.EqualTo(1));
+        }
+
+        [Test]
+        public void TryPurchase_HealthPotion_SpendsGoldAndRoutesToActivePotionInventory()
+        {
+            var inventory = CreateInventory(75);
+            var backpack = new BackpackInventoryState();
+
+            var result = CastleShopPurchaseService.TryPurchase(
+                CastleShopCatalog.DefaultOffers,
+                "potion_basic",
+                true,
+                inventory,
+                backpack);
+
+            Assert.That(result, Is.EqualTo(CastleShopPurchaseResult.Success));
+            Assert.That(inventory.Gold, Is.EqualTo(25));
+            Assert.That(inventory.PotionId, Is.EqualTo("potion_basic"));
+            Assert.That(inventory.PotionCount, Is.EqualTo(1));
+            Assert.That(backpack.ItemCount, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void TryPurchase_FailsWithoutShopAccess()
+        {
+            var inventory = CreateInventory(300);
+            var backpack = new BackpackInventoryState();
+
+            var result = CastleShopPurchaseService.TryPurchase(
+                CastleShopCatalog.DefaultOffers,
+                "weapon_sword",
+                false,
+                inventory,
+                backpack);
+
+            Assert.That(result, Is.EqualTo(CastleShopPurchaseResult.Unavailable));
+            Assert.That(inventory.Gold, Is.EqualTo(300));
+            Assert.That(backpack.ItemCount, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void TryPurchase_FailsWithInsufficientGoldWithoutMutatingInventory()
+        {
+            var inventory = CreateInventory(249);
+            var backpack = new BackpackInventoryState();
+
+            var result = CastleShopPurchaseService.TryPurchase(
+                CastleShopCatalog.DefaultOffers,
+                "weapon_sword",
+                true,
+                inventory,
+                backpack);
+
+            Assert.That(result, Is.EqualTo(CastleShopPurchaseResult.InsufficientGold));
+            Assert.That(inventory.Gold, Is.EqualTo(249));
+            Assert.That(backpack.ItemCount, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void TryPurchase_FailsForUnknownOffer()
+        {
+            var inventory = CreateInventory(300);
+            var backpack = new BackpackInventoryState();
+
+            var result = CastleShopPurchaseService.TryPurchase(
+                CastleShopCatalog.DefaultOffers,
+                "weapon_missing",
+                true,
+                inventory,
+                backpack);
+
+            Assert.That(result, Is.EqualTo(CastleShopPurchaseResult.InvalidOffer));
+            Assert.That(inventory.Gold, Is.EqualTo(300));
+            Assert.That(backpack.ItemCount, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void TryPurchase_FailsWhenBackpackIsFullWithoutSpendingGold()
+        {
+            var inventory = CreateInventory(300);
+            var backpack = new BackpackInventoryState(maxItemCount: 0);
+
+            var result = CastleShopPurchaseService.TryPurchase(
+                CastleShopCatalog.DefaultOffers,
+                "weapon_sword",
+                true,
+                inventory,
+                backpack);
+
+            Assert.That(result, Is.EqualTo(CastleShopPurchaseResult.InventoryFull));
+            Assert.That(inventory.Gold, Is.EqualTo(300));
+            Assert.That(backpack.ItemCount, Is.EqualTo(0));
+        }
+
+        private static InventoryState CreateInventory(int gold)
+        {
+            var inventory = new InventoryState();
+            inventory.AddGold(gold);
+            return inventory;
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Castle/CastleShopPurchaseServiceTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Castle/CastleShopPurchaseServiceTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4f57813699e3425d826d34421526394a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/_Tests/EditMode/UI/InventoryPanelControllerTests.cs
+++ b/Assets/_Project/_Tests/EditMode/UI/InventoryPanelControllerTests.cs
@@ -125,13 +125,49 @@ namespace Castlebound.Tests.UI
 
             Assert.That(panel.ActiveTab, Is.EqualTo(InventoryPanelTab.Shop));
             AssertTextExists("Castle Shop");
-            AssertTextExists("Sword");
-            AssertTextExists("Iron Club");
-            AssertTextExists("Health Potion");
+            AssertTextExists("Sword - 250 gold");
+            AssertTextExists("Iron Club - 250 gold");
+            AssertTextExists("Health Potion - 50 gold");
+            AssertButtonCount("Buy", 3);
             AssertTextMissing("Club");
             AssertTextMissing("Rusty Dagger");
             AssertTextMissing("Repair Kit - Coming soon");
             AssertTextMissing("Wall Supplies - Coming soon");
+        }
+
+        [Test]
+        public void ShopTab_BuySword_SpendsGoldAndAddsToBackpack()
+        {
+            var tracker = CreateCastleRegionTracker();
+            tracker.Debug_SetPlayerInsideForTests(true);
+            phase.SetPhase(WavePhase.PreWave);
+            activeInventory.State.AddGold(300);
+            panel.SetCastleRegionTracker(tracker);
+            panel.TogglePanel();
+            panel.ShopTabButton.onClick.Invoke();
+
+            ClickButton("Buy");
+
+            Assert.That(activeInventory.State.Gold, Is.EqualTo(50));
+            Assert.That(backpack.State.GetCount("weapon_sword"), Is.EqualTo(1));
+            AssertTextExists("Purchase complete");
+        }
+
+        [Test]
+        public void ShopTab_BuyWithoutGold_ShowsFailureAndDoesNotMutateBackpack()
+        {
+            var tracker = CreateCastleRegionTracker();
+            tracker.Debug_SetPlayerInsideForTests(true);
+            phase.SetPhase(WavePhase.PreWave);
+            panel.SetCastleRegionTracker(tracker);
+            panel.TogglePanel();
+            panel.ShopTabButton.onClick.Invoke();
+
+            ClickButton("Buy");
+
+            Assert.That(activeInventory.State.Gold, Is.EqualTo(0));
+            Assert.That(backpack.State.ItemCount, Is.EqualTo(0));
+            AssertTextExists("Not enough gold");
         }
 
         [Test]
@@ -429,6 +465,22 @@ namespace Castlebound.Tests.UI
             }
 
             Assert.Fail($"Expected button '{label}'.");
+        }
+
+        private void AssertButtonCount(string label, int expectedCount)
+        {
+            int count = 0;
+            var buttons = root.GetComponentsInChildren<Button>(true);
+            foreach (var button in buttons)
+            {
+                var text = button.GetComponentInChildren<TextMeshProUGUI>(true);
+                if (text != null && text.text == label)
+                {
+                    count++;
+                }
+            }
+
+            Assert.That(count, Is.EqualTo(expectedCount));
         }
 
         private RectTransform FindRectTransform(string objectName)

--- a/Assets/_Project/_Tests/PlayMode/UI/InventoryPanelControllerPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/UI/InventoryPanelControllerPlayTests.cs
@@ -121,14 +121,52 @@ namespace Castlebound.Tests.UI
 
                 Assert.That(panel.ActiveTab, Is.EqualTo(InventoryPanelTab.Shop));
                 AssertTextExists(root, "Castle Shop");
-                AssertTextExists(root, "Sword");
-                AssertTextExists(root, "Iron Club");
-                AssertTextExists(root, "Health Potion");
+                AssertTextExists(root, "Sword - 250 gold");
+                AssertTextExists(root, "Iron Club - 250 gold");
+                AssertTextExists(root, "Health Potion - 50 gold");
 
                 phase.SetPhase(WavePhase.InWave);
                 yield return null;
 
                 Assert.IsFalse(panel.IsOpen);
+            }
+            finally
+            {
+                Object.Destroy(root);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator InventoryPanel_ShopBuy_SpendsGoldAndAddsItem()
+        {
+            var root = new GameObject("InventoryPanelShopBuyPlayRoot", typeof(Canvas));
+
+            try
+            {
+                var backpack = root.AddComponent<BackpackInventoryStateComponent>();
+                var activeInventory = root.AddComponent<InventoryStateComponent>();
+                root.AddComponent<CastleInventoryStateComponent>();
+                var phase = new WavePhaseTracker();
+                var castleRegion = root.AddComponent<CastleRegionTracker>();
+                var panel = root.AddComponent<InventoryPanelController>();
+                panel.SetBackpackSource(backpack);
+                panel.SetActiveInventorySource(activeInventory);
+                panel.SetPhaseTracker(phase);
+                panel.SetCastleRegionTracker(castleRegion);
+
+                castleRegion.Debug_SetPlayerInsideForTests(true);
+                activeInventory.State.AddGold(300);
+
+                panel.TogglePanel();
+                panel.ShopTabButton.onClick.Invoke();
+                yield return null;
+
+                ClickButton(root, "Buy");
+                yield return null;
+
+                Assert.That(activeInventory.State.Gold, Is.EqualTo(50));
+                Assert.That(backpack.State.GetCount("weapon_sword"), Is.EqualTo(1));
+                AssertTextExists(root, "Purchase complete");
             }
             finally
             {

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,26 @@
 
 ---
 
+## 2026-07-10 - codex-shop-purchasing
+
+### Summary
+- Added fixed-price Shop purchasing for Sword, Iron Club, and Health Potion.
+- Routed weapon purchases to Backpack and Health Potion purchases to the active potion inventory.
+- Wired Shop Buy buttons to existing gold spending with success and failure feedback.
+
+### New or Updated Tests
+**EditMode**
+- `CastleShopCatalogTests` — validates fixed Shop prices for Sword, Iron Club, and Health Potion.
+- `CastleShopPurchaseServiceTests` — validates purchase success, access denial, insufficient gold, invalid offers, full inventory, and item routing.
+- `InventoryPanelControllerTests` — validates Buy affordance rendering, successful purchase feedback, and insufficient-gold feedback.
+
+**PlayMode**
+- `InventoryPanelControllerPlayTests` — validates runtime Shop offer price rendering, wave-start close behavior, and a buy flow that spends gold and adds a Backpack item.
+
+### Notes
+- EditMode, PlayMode, and manual validation passed.
+- Manual validation confirmed purchasing works in game.
+
 ## 2026-07-10 - feat-p4-static-shop-catalog
 
 ### Summary


### PR DESCRIPTION
## Why
Shop catalog offers were display-only. This adds real purchasing for the current Sword, Iron Club, and Health Potion offers using the existing gold and inventory systems.

## What changed
- Added fixed Shop prices: Sword 250, Iron Club 250, Health Potion 50
- Added a Shop purchase service with explicit purchase outcomes
- Routes weapon purchases to Backpack and Health Potion to active potion inventory
- Wires Shop Buy buttons to spend existing gold and show success/failure feedback
- Adds EditMode and PlayMode coverage for purchasing behavior

## How to test
1. Open the relevant scene or demo
2. Press Play → enter castle between waves, open Shop, buy an item, verify gold and inventory update
3. Run tests:
   - EditMode
   - PlayMode

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated (N/A - runtime UI only)
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched (TEST_LOG.md updated)

## Related
- Closes #<issue> or Refs #<issue> (if applicable)