### PR TITLE
feat(vault): split vault into dedicated panel

### DIFF
--- a/Assets/_Project/Art/Items/weapon_club_01.png.meta
+++ b/Assets/_Project/Art/Items/weapon_club_01.png.meta
@@ -47,7 +47,7 @@ TextureImporter:
   spriteExtrude: 1
   spriteMeshType: 1
   alignment: 9
-  spritePivot: {x: 0.24, y: 0.24}
+  spritePivot: {x: 0.4698851, y: 0.46155587}
   spritePixelsToUnits: 32
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1

--- a/Assets/_Project/Art/Items/weapon_rusty_dagger_01.png.meta
+++ b/Assets/_Project/Art/Items/weapon_rusty_dagger_01.png.meta
@@ -47,7 +47,7 @@ TextureImporter:
   spriteExtrude: 1
   spriteMeshType: 1
   alignment: 9
-  spritePivot: {x: 0.22, y: 0.22}
+  spritePivot: {x: 0.23767678, y: 0.31511787}
   spritePixelsToUnits: 32
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1

--- a/Assets/_Project/Scripts/_Project.Gameplay/Castle/VaultWorldInteraction.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Castle/VaultWorldInteraction.cs
@@ -7,6 +7,7 @@ namespace Castlebound.Gameplay.Castle
 {
     public class VaultWorldInteraction : MonoBehaviour
     {
+        [SerializeField] private VaultPanelController vaultPanel;
         [SerializeField] private InventoryPanelController inventoryPanel;
         [SerializeField] private EnemySpawnerRunner waveRunner;
         [SerializeField] private VaultOutlinePresenter outlinePresenter;
@@ -53,6 +54,11 @@ namespace Castlebound.Gameplay.Castle
         public void SetInventoryPanel(InventoryPanelController panel)
         {
             inventoryPanel = panel;
+        }
+
+        public void SetVaultPanel(VaultPanelController panel)
+        {
+            vaultPanel = panel;
         }
 
         public void SetPhaseTracker(WavePhaseTracker tracker)
@@ -107,17 +113,17 @@ namespace Castlebound.Gameplay.Castle
             ResolveReferences();
             ApplyVisualState();
 
-            if (!VaultInteractionPolicy.CanOpen(playerInRange, CurrentPhase) || inventoryPanel == null)
+            if (!VaultInteractionPolicy.CanOpen(playerInRange, CurrentPhase) || vaultPanel == null)
             {
                 return false;
             }
 
             if (phaseTracker != null)
             {
-                inventoryPanel.SetPhaseTracker(phaseTracker);
+                vaultPanel.SetPhaseTracker(phaseTracker);
             }
 
-            return inventoryPanel.OpenVaultFromWorld();
+            return vaultPanel.OpenFromWorld();
         }
 
         private bool TryOpenVaultFromHeldScreenPosition(Vector2 screenPosition, float deltaSeconds)
@@ -186,6 +192,20 @@ namespace Castlebound.Gameplay.Castle
                 inventoryPanel = FindObjectOfType<InventoryPanelController>();
             }
 
+            if (vaultPanel == null)
+            {
+                vaultPanel = FindObjectOfType<VaultPanelController>();
+            }
+
+            if (vaultPanel == null && inventoryPanel != null)
+            {
+                vaultPanel = inventoryPanel.GetComponent<VaultPanelController>();
+                if (vaultPanel == null)
+                {
+                    vaultPanel = inventoryPanel.gameObject.AddComponent<VaultPanelController>();
+                }
+            }
+
             if (waveRunner == null && phaseTracker == null)
             {
                 waveRunner = FindObjectOfType<EnemySpawnerRunner>();
@@ -227,6 +247,11 @@ namespace Castlebound.Gameplay.Castle
             if (inventoryPanel != null && phaseTracker != null)
             {
                 inventoryPanel.SetPhaseTracker(phaseTracker);
+            }
+
+            if (vaultPanel != null && phaseTracker != null)
+            {
+                vaultPanel.SetPhaseTracker(phaseTracker);
             }
         }
 

--- a/Assets/_Project/Scripts/_Project.Gameplay/UI/InventoryPanelController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/UI/InventoryPanelController.cs
@@ -34,7 +34,6 @@ namespace Castlebound.Gameplay.UI
         private InventoryPanelTab activeTab = InventoryPanelTab.Backpack;
         private bool contextMenuHooked;
         private bool castleRegionHooked;
-        private bool vaultOpenedFromWorld;
         private string shopFeedbackMessage;
 
         public bool IsOpen => panelRoot != null && panelRoot.gameObject.activeSelf;
@@ -141,7 +140,6 @@ namespace Castlebound.Gameplay.UI
         public void TogglePanel()
         {
             ApplyPanelState(!IsOpen);
-            vaultOpenedFromWorld = false;
             if (IsOpen)
             {
                 if (contextMenu != null)
@@ -155,21 +153,7 @@ namespace Castlebound.Gameplay.UI
 
         public bool OpenVaultFromWorld()
         {
-            if (!IsVaultAccessible())
-            {
-                return false;
-            }
-
-            EnsureRuntimeUi();
-            vaultOpenedFromWorld = true;
-            if (contextMenu != null && contextMenu.ActiveSource != InventoryContextSource.Vault)
-            {
-                contextMenu.Close();
-            }
-
-            ApplyPanelState(true);
-            Refresh();
-            return true;
+            return false;
         }
 
         public void ClosePanel()
@@ -179,13 +163,11 @@ namespace Castlebound.Gameplay.UI
                 contextMenu.Close();
             }
 
-            vaultOpenedFromWorld = false;
             ApplyPanelState(false);
         }
 
         public void SetActiveTab(InventoryPanelTab tab)
         {
-            vaultOpenedFromWorld = false;
             shopFeedbackMessage = null;
             if (contextMenu != null)
             {
@@ -305,12 +287,6 @@ namespace Castlebound.Gameplay.UI
 
         private void OnPhaseChanged(WavePhase phase)
         {
-            if (phase == WavePhase.InWave && vaultOpenedFromWorld)
-            {
-                vaultOpenedFromWorld = false;
-                activeTab = InventoryPanelTab.Backpack;
-            }
-
             HandleShopAccessChanged();
             Refresh();
         }
@@ -362,11 +338,6 @@ namespace Castlebound.Gameplay.UI
             {
                 ClosePanel();
             }
-        }
-
-        private bool IsVaultAccessible()
-        {
-            return phaseTracker == null || phaseTracker.CurrentPhase == WavePhase.PreWave;
         }
 
         private bool IsShopAccessible()
@@ -556,7 +527,7 @@ namespace Castlebound.Gameplay.UI
         {
             if (backpackTabButton != null)
             {
-                backpackTabButton.interactable = vaultOpenedFromWorld || activeTab != InventoryPanelTab.Backpack;
+                backpackTabButton.interactable = activeTab != InventoryPanelTab.Backpack;
             }
 
             if (vaultTabButton != null)
@@ -592,17 +563,7 @@ namespace Castlebound.Gameplay.UI
                 DestroyChild(contentRoot.GetChild(i).gameObject);
             }
 
-            if (vaultOpenedFromWorld && !IsVaultAccessible())
-            {
-                vaultOpenedFromWorld = false;
-                activeTab = InventoryPanelTab.Backpack;
-            }
-
-            if (vaultOpenedFromWorld)
-            {
-                CreateVaultRows();
-            }
-            else if (activeTab == InventoryPanelTab.Backpack)
+            if (activeTab == InventoryPanelTab.Backpack)
             {
                 CreateBackpackRows();
             }
@@ -628,26 +589,6 @@ namespace Castlebound.Gameplay.UI
             foreach (var entry in backpack.Entries)
             {
                 CreateBackpackRow(entry);
-            }
-        }
-
-        private void CreateVaultRows()
-        {
-            if (!IsVaultAccessible())
-            {
-                CreateTextRow("Vault opens between waves");
-                return;
-            }
-
-            if (vault == null || vault.EntryCount == 0)
-            {
-                CreateTextRow("Vault is empty");
-                return;
-            }
-
-            foreach (var entry in vault.Entries)
-            {
-                CreateInventoryRow(entry.ItemId, entry.Count, InventoryContextSource.Vault);
             }
         }
 

--- a/Assets/_Project/Scripts/_Project.Gameplay/UI/VaultPanelController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/UI/VaultPanelController.cs
@@ -1,0 +1,482 @@
+using Castlebound.Gameplay.Combat;
+using Castlebound.Gameplay.Inventory;
+using Castlebound.Gameplay.Spawning;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Castlebound.Gameplay.UI
+{
+    public class VaultPanelController : MonoBehaviour
+    {
+        [SerializeField] private RectTransform panelRoot;
+        [SerializeField] private RectTransform contentRoot;
+        [SerializeField] private Button closeButton;
+        [SerializeField] private CastleInventoryStateComponent castleInventorySource;
+        [SerializeField] private BackpackInventoryStateComponent backpackSource;
+        [SerializeField] private InventoryStateComponent activeInventorySource;
+        [SerializeField] private InventoryContextMenuController contextMenu;
+        [SerializeField] private MonoBehaviour weaponDefinitionResolverSource;
+
+        private CastleInventoryState vault;
+        private WavePhaseTracker phaseTracker;
+        private IWeaponDefinitionResolver weaponDefinitionResolver;
+        private bool contextMenuHooked;
+
+        public bool IsOpen => panelRoot != null && panelRoot.gameObject.activeSelf;
+
+        private void OnEnable()
+        {
+            ResolveReferences();
+            EnsureRuntimeUi();
+            HookVault();
+            HookPhaseTracker();
+            ApplyPanelState(false);
+            Refresh();
+        }
+
+        private void OnDisable()
+        {
+            UnhookVault();
+            UnhookPhaseTracker();
+            UnhookContextMenu();
+        }
+
+        public void SetCastleInventorySource(CastleInventoryStateComponent source)
+        {
+            if (castleInventorySource == source)
+            {
+                return;
+            }
+
+            UnhookVault();
+            castleInventorySource = source;
+            vault = castleInventorySource != null ? castleInventorySource.State : null;
+            HookVault();
+            Refresh();
+        }
+
+        public void SetInventorySources(
+            BackpackInventoryStateComponent backpack,
+            CastleInventoryStateComponent castleInventory,
+            InventoryStateComponent activeInventory)
+        {
+            backpackSource = backpack;
+            activeInventorySource = activeInventory;
+            SetCastleInventorySource(castleInventory);
+            ConfigureContextMenu();
+        }
+
+        public void SetPhaseTracker(WavePhaseTracker tracker)
+        {
+            if (phaseTracker == tracker)
+            {
+                return;
+            }
+
+            UnhookPhaseTracker();
+            phaseTracker = tracker;
+            HookPhaseTracker();
+            Refresh();
+        }
+
+        public void SetWeaponDefinitionResolver(IWeaponDefinitionResolver resolver)
+        {
+            weaponDefinitionResolver = resolver;
+            weaponDefinitionResolverSource = resolver as MonoBehaviour;
+        }
+
+        public bool OpenFromWorld()
+        {
+            if (!IsVaultAccessible())
+            {
+                return false;
+            }
+
+            EnsureRuntimeUi();
+            ApplyPanelState(true);
+            Refresh();
+            return true;
+        }
+
+        public void ClosePanel()
+        {
+            if (contextMenu != null)
+            {
+                contextMenu.Close();
+            }
+
+            ApplyPanelState(false);
+        }
+
+        public void Refresh()
+        {
+            EnsureRuntimeUi();
+            RefreshRows();
+        }
+
+        private void ResolveReferences()
+        {
+            if (castleInventorySource == null)
+            {
+                castleInventorySource = FindObjectOfType<CastleInventoryStateComponent>();
+            }
+
+            if (backpackSource == null)
+            {
+                backpackSource = FindObjectOfType<BackpackInventoryStateComponent>();
+            }
+
+            if (activeInventorySource == null)
+            {
+                activeInventorySource = FindObjectOfType<InventoryStateComponent>();
+            }
+
+            vault = castleInventorySource != null ? castleInventorySource.State : null;
+            weaponDefinitionResolver = weaponDefinitionResolverSource as IWeaponDefinitionResolver ?? weaponDefinitionResolver ?? FindWeaponDefinitionResolver();
+        }
+
+        private void HookVault()
+        {
+            if (vault != null)
+            {
+                vault.OnInventoryChanged += Refresh;
+            }
+        }
+
+        private void UnhookVault()
+        {
+            if (vault != null)
+            {
+                vault.OnInventoryChanged -= Refresh;
+            }
+        }
+
+        private void HookPhaseTracker()
+        {
+            if (phaseTracker != null)
+            {
+                phaseTracker.PhaseChanged += OnPhaseChanged;
+            }
+        }
+
+        private void UnhookPhaseTracker()
+        {
+            if (phaseTracker != null)
+            {
+                phaseTracker.PhaseChanged -= OnPhaseChanged;
+            }
+        }
+
+        private void OnPhaseChanged(WavePhase phase)
+        {
+            if (phase == WavePhase.InWave)
+            {
+                ClosePanel();
+            }
+
+            Refresh();
+        }
+
+        private bool IsVaultAccessible()
+        {
+            return phaseTracker == null || phaseTracker.CurrentPhase == WavePhase.PreWave;
+        }
+
+        private void EnsureRuntimeUi()
+        {
+            var canvas = GetComponentInParent<Canvas>();
+            var parent = canvas != null ? canvas.transform : transform;
+
+            if (panelRoot == null)
+            {
+                panelRoot = CreatePanel(parent);
+            }
+
+            if (contentRoot == null)
+            {
+                var rows = new GameObject("VaultRows", typeof(RectTransform), typeof(VerticalLayoutGroup));
+                rows.transform.SetParent(panelRoot, false);
+                contentRoot = rows.GetComponent<RectTransform>();
+                contentRoot.anchorMin = Vector2.zero;
+                contentRoot.anchorMax = Vector2.one;
+                contentRoot.offsetMin = new Vector2(14f, 14f);
+                contentRoot.offsetMax = new Vector2(-14f, -44f);
+
+                var layout = rows.GetComponent<VerticalLayoutGroup>();
+                layout.spacing = 6f;
+                layout.childForceExpandHeight = false;
+                layout.childForceExpandWidth = true;
+                layout.childControlHeight = true;
+                layout.childControlWidth = true;
+            }
+
+            if (closeButton == null)
+            {
+                closeButton = CreateCloseButton(panelRoot);
+                closeButton.onClick.AddListener(ClosePanel);
+            }
+
+            ConfigureContextMenu();
+        }
+
+        private void ConfigureContextMenu()
+        {
+            if (contextMenu == null)
+            {
+                contextMenu = GetComponent<InventoryContextMenuController>();
+                if (contextMenu == null)
+                {
+                    contextMenu = gameObject.AddComponent<InventoryContextMenuController>();
+                }
+            }
+
+            HookContextMenu();
+            contextMenu.SetParentRoot(panelRoot);
+            contextMenu.SetInventorySources(backpackSource, castleInventorySource, activeInventorySource);
+        }
+
+        private void HookContextMenu()
+        {
+            if (contextMenu == null || contextMenuHooked)
+            {
+                return;
+            }
+
+            contextMenu.ActionCompleted += Refresh;
+            contextMenuHooked = true;
+        }
+
+        private void UnhookContextMenu()
+        {
+            if (contextMenu == null || !contextMenuHooked)
+            {
+                return;
+            }
+
+            contextMenu.ActionCompleted -= Refresh;
+            contextMenuHooked = false;
+        }
+
+        private RectTransform CreatePanel(Transform parent)
+        {
+            var panel = new GameObject("VaultPanel", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image));
+            panel.transform.SetParent(parent, false);
+            panel.SetActive(false);
+
+            var rect = panel.GetComponent<RectTransform>();
+            rect.anchorMin = new Vector2(0f, 1f);
+            rect.anchorMax = new Vector2(0f, 1f);
+            rect.pivot = new Vector2(0f, 1f);
+            rect.anchoredPosition = new Vector2(392f, -78f);
+            rect.sizeDelta = new Vector2(300f, 310f);
+
+            var image = panel.GetComponent<Image>();
+            image.color = new Color(0.08f, 0.09f, 0.1f, 0.92f);
+            image.raycastTarget = false;
+
+            CreateHeader(rect);
+            return rect;
+        }
+
+        private static Button CreateCloseButton(Transform parent)
+        {
+            var buttonObject = new GameObject("VaultCloseButton", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image), typeof(Button), typeof(LayoutElement));
+            buttonObject.transform.SetParent(parent, false);
+
+            var rect = buttonObject.GetComponent<RectTransform>();
+            rect.anchorMin = new Vector2(1f, 1f);
+            rect.anchorMax = new Vector2(1f, 1f);
+            rect.pivot = new Vector2(1f, 1f);
+            rect.anchoredPosition = new Vector2(-10f, -10f);
+            rect.sizeDelta = new Vector2(30f, 30f);
+
+            var image = buttonObject.GetComponent<Image>();
+            image.color = new Color(0.15f, 0.17f, 0.2f, 0.95f);
+
+            var button = buttonObject.GetComponent<Button>();
+            var colors = button.colors;
+            colors.normalColor = new Color(0.15f, 0.17f, 0.2f, 0.95f);
+            colors.highlightedColor = new Color(0.24f, 0.27f, 0.31f, 1f);
+            colors.pressedColor = new Color(0.1f, 0.12f, 0.15f, 1f);
+            button.colors = colors;
+
+            var labelObject = new GameObject("Label", typeof(RectTransform), typeof(CanvasRenderer), typeof(TextMeshProUGUI));
+            labelObject.transform.SetParent(buttonObject.transform, false);
+            var labelRect = labelObject.GetComponent<RectTransform>();
+            labelRect.anchorMin = Vector2.zero;
+            labelRect.anchorMax = Vector2.one;
+            labelRect.offsetMin = Vector2.zero;
+            labelRect.offsetMax = Vector2.zero;
+
+            var text = labelObject.GetComponent<TextMeshProUGUI>();
+            text.text = "X";
+            text.fontSize = 16;
+            text.alignment = TextAlignmentOptions.Center;
+            text.color = Color.white;
+            text.raycastTarget = false;
+
+            return button;
+        }
+
+        private static void CreateHeader(Transform parent)
+        {
+            var header = new GameObject("Header", typeof(RectTransform), typeof(CanvasRenderer), typeof(TextMeshProUGUI));
+            header.transform.SetParent(parent, false);
+
+            var rect = header.GetComponent<RectTransform>();
+            rect.anchorMin = new Vector2(0f, 1f);
+            rect.anchorMax = new Vector2(1f, 1f);
+            rect.pivot = new Vector2(0f, 1f);
+            rect.offsetMin = new Vector2(14f, -38f);
+            rect.offsetMax = new Vector2(-14f, -10f);
+
+            var text = header.GetComponent<TextMeshProUGUI>();
+            text.text = "Vault";
+            text.fontSize = 18;
+            text.color = Color.white;
+            text.alignment = TextAlignmentOptions.Left;
+            text.raycastTarget = false;
+        }
+
+        private void RefreshRows()
+        {
+            if (contentRoot == null)
+            {
+                return;
+            }
+
+            for (int i = contentRoot.childCount - 1; i >= 0; i--)
+            {
+                DestroyChild(contentRoot.GetChild(i).gameObject);
+            }
+
+            if (!IsVaultAccessible())
+            {
+                CreateTextRow("Vault opens between waves");
+                CloseContextMenuIfActiveItemMissing();
+                return;
+            }
+
+            if (vault == null || vault.EntryCount == 0)
+            {
+                CreateTextRow("Vault is empty");
+                CloseContextMenuIfActiveItemMissing();
+                return;
+            }
+
+            foreach (var entry in vault.Entries)
+            {
+                CreateVaultRow(entry);
+            }
+
+            CloseContextMenuIfActiveItemMissing();
+        }
+
+        private void CloseContextMenuIfActiveItemMissing()
+        {
+            if (contextMenu != null)
+            {
+                contextMenu.CloseIfActiveItemMissing();
+            }
+        }
+
+        private void CreateVaultRow(CastleInventoryEntry entry)
+        {
+            var rowObject = new GameObject("VaultRow", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image), typeof(Button), typeof(LayoutElement));
+            rowObject.transform.SetParent(contentRoot, false);
+
+            var rect = rowObject.GetComponent<RectTransform>();
+            rect.sizeDelta = new Vector2(0f, 34f);
+
+            var layout = rowObject.GetComponent<LayoutElement>();
+            layout.minHeight = 34f;
+            layout.preferredHeight = 34f;
+            layout.flexibleWidth = 1f;
+
+            var image = rowObject.GetComponent<Image>();
+            image.color = new Color(1f, 1f, 1f, 0.04f);
+            image.raycastTarget = true;
+
+            var button = rowObject.GetComponent<Button>();
+            button.targetGraphic = image;
+            button.onClick.AddListener(() => contextMenu.ShowForItem(entry.ItemId, IsWeaponItem(entry.ItemId), InventoryContextSource.Vault, rect));
+
+            var labelObject = new GameObject("Label", typeof(RectTransform), typeof(CanvasRenderer), typeof(TextMeshProUGUI));
+            labelObject.transform.SetParent(rowObject.transform, false);
+
+            var labelRect = labelObject.GetComponent<RectTransform>();
+            labelRect.anchorMin = Vector2.zero;
+            labelRect.anchorMax = Vector2.one;
+            labelRect.offsetMin = new Vector2(8f, 0f);
+            labelRect.offsetMax = new Vector2(-8f, 0f);
+
+            var text = labelObject.GetComponent<TextMeshProUGUI>();
+            text.text = $"{entry.ItemId} x{entry.Count}";
+            text.fontSize = 16;
+            text.color = Color.white;
+            text.alignment = TextAlignmentOptions.Left;
+            text.raycastTarget = false;
+
+            var trigger = rowObject.AddComponent<InventoryContextMenuTrigger>();
+            trigger.Configure(contextMenu, entry.ItemId, IsWeaponItem(entry.ItemId), InventoryContextSource.Vault);
+        }
+
+        private void CreateTextRow(string value)
+        {
+            var label = new GameObject("VaultRow", typeof(RectTransform), typeof(CanvasRenderer), typeof(TextMeshProUGUI));
+            label.transform.SetParent(contentRoot, false);
+
+            var rect = label.GetComponent<RectTransform>();
+            rect.sizeDelta = new Vector2(0f, 28f);
+
+            var text = label.GetComponent<TextMeshProUGUI>();
+            text.text = value;
+            text.fontSize = 16;
+            text.color = Color.white;
+            text.alignment = TextAlignmentOptions.Left;
+            text.raycastTarget = false;
+        }
+
+        private bool IsWeaponItem(string itemId)
+        {
+            var resolver = weaponDefinitionResolverSource as IWeaponDefinitionResolver ?? weaponDefinitionResolver ?? FindWeaponDefinitionResolver();
+            return resolver != null && resolver.Resolve(itemId) != null;
+        }
+
+        private IWeaponDefinitionResolver FindWeaponDefinitionResolver()
+        {
+            var behaviours = FindObjectsOfType<MonoBehaviour>();
+            for (int i = 0; i < behaviours.Length; i++)
+            {
+                if (behaviours[i] is IWeaponDefinitionResolver resolver)
+                {
+                    return resolver;
+                }
+            }
+
+            return null;
+        }
+
+        private void ApplyPanelState(bool open)
+        {
+            if (panelRoot != null)
+            {
+                panelRoot.gameObject.SetActive(open);
+            }
+        }
+
+        private static void DestroyChild(GameObject child)
+        {
+            if (Application.isPlaying)
+            {
+                child.SetActive(false);
+                Destroy(child);
+            }
+            else
+            {
+                DestroyImmediate(child);
+            }
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/UI/VaultPanelController.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/UI/VaultPanelController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9c6d9faf5efd4485a990d677f621a90b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/_Tests/EditMode/Castle/VaultWorldInteractionTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Castle/VaultWorldInteractionTests.cs
@@ -13,7 +13,10 @@ namespace Castlebound.Tests.Castle
     {
         private GameObject root;
         private InventoryPanelController panel;
+        private VaultPanelController vaultPanel;
+        private BackpackInventoryStateComponent backpack;
         private CastleInventoryStateComponent vault;
+        private InventoryStateComponent activeInventory;
         private WavePhaseTracker phase;
         private VaultWorldInteraction interaction;
 
@@ -21,15 +24,22 @@ namespace Castlebound.Tests.Castle
         public void SetUp()
         {
             root = new GameObject("VaultInteractionRoot", typeof(Canvas));
-            root.AddComponent<BackpackInventoryStateComponent>();
+            backpack = root.AddComponent<BackpackInventoryStateComponent>();
+            activeInventory = root.AddComponent<InventoryStateComponent>();
             vault = root.AddComponent<CastleInventoryStateComponent>();
             panel = root.AddComponent<InventoryPanelController>();
+            vaultPanel = root.AddComponent<VaultPanelController>();
             phase = new WavePhaseTracker();
+            panel.SetBackpackSource(backpack);
+            panel.SetActiveInventorySource(activeInventory);
             panel.SetCastleInventorySource(vault);
             panel.SetPhaseTracker(phase);
+            vaultPanel.SetInventorySources(backpack, vault, activeInventory);
+            vaultPanel.SetPhaseTracker(phase);
 
             interaction = root.AddComponent<VaultWorldInteraction>();
             interaction.SetInventoryPanel(panel);
+            interaction.SetVaultPanel(vaultPanel);
             interaction.SetPhaseTracker(phase);
         }
 
@@ -52,8 +62,26 @@ namespace Castlebound.Tests.Castle
 
             phase.SetPhase(WavePhase.PreWave);
             Assert.IsTrue(interaction.TryOpenVault());
-            Assert.IsTrue(panel.IsOpen);
+            Assert.IsFalse(panel.IsOpen);
+            Assert.IsTrue(vaultPanel.IsOpen);
             AssertTextExists("potion_health x2");
+        }
+
+        [Test]
+        public void TryOpenVault_KeepsBackpackPanelVisibleBesideVaultPanel()
+        {
+            backpack.State.AddItem("weapon_sword", 1);
+            vault.State.AddItem("potion_health", 1);
+            panel.TogglePanel();
+            interaction.SetPlayerInRange(true);
+            phase.SetPhase(WavePhase.PreWave);
+
+            Assert.IsTrue(interaction.TryOpenVault());
+
+            Assert.IsTrue(panel.IsOpen);
+            Assert.IsTrue(vaultPanel.IsOpen);
+            AssertTextExists("weapon_sword x1");
+            AssertTextExists("potion_health x1");
         }
 
         [Test]
@@ -114,7 +142,7 @@ namespace Castlebound.Tests.Castle
             vault.State.AddItem("potion_health", 1);
 
             Assert.IsTrue(interaction.TryOpenVault());
-            Assert.IsTrue(panel.IsOpen);
+            Assert.IsTrue(vaultPanel.IsOpen);
             AssertTextExists("potion_health x1");
         }
 
@@ -129,7 +157,7 @@ namespace Castlebound.Tests.Castle
             vault.State.AddItem("potion_health", 1);
 
             Assert.IsTrue(interaction.TryOpenVault());
-            Assert.IsTrue(panel.IsOpen);
+            Assert.IsTrue(vaultPanel.IsOpen);
             AssertTextExists("potion_health x1");
         }
 
@@ -148,7 +176,7 @@ namespace Castlebound.Tests.Castle
             vault.State.AddItem("potion_health", 1);
 
             Assert.IsTrue(interaction.TryOpenVault());
-            Assert.IsTrue(panel.IsOpen);
+            Assert.IsTrue(vaultPanel.IsOpen);
             AssertTextExists("potion_health x1");
 
             Object.DestroyImmediate(runnerObject);
@@ -166,7 +194,7 @@ namespace Castlebound.Tests.Castle
             vault.State.AddItem("potion_health", 1);
 
             Assert.IsTrue(interaction.TryOpenVault());
-            Assert.IsTrue(panel.IsOpen);
+            Assert.IsTrue(vaultPanel.IsOpen);
             AssertTextExists("potion_health x1");
 
             Object.DestroyImmediate(runnerObject);

--- a/Assets/_Project/_Tests/EditMode/UI/InventoryPanelControllerTests.cs
+++ b/Assets/_Project/_Tests/EditMode/UI/InventoryPanelControllerTests.cs
@@ -77,18 +77,7 @@ namespace Castlebound.Tests.UI
         }
 
         [Test]
-        public void OpenVaultFromWorld_RendersVaultEntries_BetweenWaves()
-        {
-            phase.SetPhase(WavePhase.PreWave);
-            vault.State.AddItem("potion_health", 3);
-
-            Assert.IsTrue(panel.OpenVaultFromWorld());
-
-            AssertTextExists("potion_health x3");
-        }
-
-        [Test]
-        public void OpenVaultFromWorld_IsDenied_MidWave()
+        public void OpenVaultFromWorld_IsNotOwnedByInventoryPanel()
         {
             phase.SetPhase(WavePhase.InWave);
 
@@ -350,61 +339,6 @@ namespace Castlebound.Tests.UI
             Assert.IsTrue(menu.IsOpen);
             Assert.That(menu.ActiveItemId, Is.EqualTo("weapon_sword"));
             AssertTextExists("weapon_sword x1");
-        }
-
-        [Test]
-        public void VaultRow_ButtonClickOpensContextMenu_WithMoveAndEquipActions()
-        {
-            phase.SetPhase(WavePhase.PreWave);
-            vault.State.AddItem("weapon_sword", 1);
-            panel.OpenVaultFromWorld();
-
-            var trigger = root.GetComponentInChildren<InventoryContextMenuTrigger>(true);
-            var rowButton = trigger.GetComponent<Button>();
-
-            Assert.NotNull(rowButton);
-            rowButton.onClick.Invoke();
-
-            AssertTextExists("Move to Backpack");
-            AssertTextExists("Equip");
-        }
-
-        [Test]
-        public void VaultContextMenu_MoveToBackpack_RefreshesVaultRowsWithoutClosingWhenMoreRemain()
-        {
-            phase.SetPhase(WavePhase.PreWave);
-            vault.State.AddItem("weapon_sword", 2);
-            panel.OpenVaultFromWorld();
-
-            OpenFirstInventoryRowContextMenu();
-            ClickButton("Move to Backpack");
-            var menu = root.GetComponent<InventoryContextMenuController>();
-
-            Assert.IsTrue(menu.IsOpen);
-            Assert.That(menu.ActiveSource, Is.EqualTo(InventoryContextSource.Vault));
-            Assert.That(vault.State.GetCount("weapon_sword"), Is.EqualTo(1));
-            Assert.That(backpack.State.GetCount("weapon_sword"), Is.EqualTo(1));
-            AssertTextExists("weapon_sword x1");
-        }
-
-        [Test]
-        public void VaultContextMenu_EquipWeapon_ReturnsDisplacedWeaponToVault()
-        {
-            phase.SetPhase(WavePhase.PreWave);
-            activeInventory.State.AddWeapon("weapon_dagger");
-            vault.State.AddItem("weapon_sword", 1);
-            panel.OpenVaultFromWorld();
-
-            OpenFirstInventoryRowContextMenu();
-            var menu = root.GetComponent<InventoryContextMenuController>();
-            Assert.That(menu.ActiveSource, Is.EqualTo(InventoryContextSource.Vault));
-            Assert.That(menu.ActiveItemId, Is.EqualTo("weapon_sword"));
-
-            ClickButton("Equip");
-            ClickButton("Main");
-
-            Assert.That(activeInventory.State.GetWeaponId(0), Is.EqualTo("weapon_sword"));
-            Assert.That(vault.State.GetCount("weapon_dagger"), Is.EqualTo(1));
         }
 
         private void AssertTextExists(string expected)

--- a/Assets/_Project/_Tests/EditMode/UI/VaultPanelControllerTests.cs
+++ b/Assets/_Project/_Tests/EditMode/UI/VaultPanelControllerTests.cs
@@ -1,0 +1,212 @@
+using Castlebound.Gameplay.Combat;
+using Castlebound.Gameplay.Inventory;
+using Castlebound.Gameplay.Spawning;
+using Castlebound.Gameplay.UI;
+using NUnit.Framework;
+using TMPro;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+
+namespace Castlebound.Tests.UI
+{
+    public class VaultPanelControllerTests
+    {
+        private GameObject root;
+        private VaultPanelController panel;
+        private BackpackInventoryStateComponent backpack;
+        private CastleInventoryStateComponent vault;
+        private InventoryStateComponent activeInventory;
+        private WavePhaseTracker phase;
+        private WeaponDefinition weapon;
+
+        [SetUp]
+        public void SetUp()
+        {
+            root = new GameObject("VaultPanelRoot", typeof(Canvas));
+            backpack = root.AddComponent<BackpackInventoryStateComponent>();
+            vault = root.AddComponent<CastleInventoryStateComponent>();
+            activeInventory = root.AddComponent<InventoryStateComponent>();
+            var resolver = root.AddComponent<TestWeaponResolver>();
+            weapon = ScriptableObject.CreateInstance<WeaponDefinition>();
+            weapon.ItemId = "weapon_sword";
+            resolver.Weapon = weapon;
+            phase = new WavePhaseTracker();
+            panel = root.AddComponent<VaultPanelController>();
+            panel.SetInventorySources(backpack, vault, activeInventory);
+            panel.SetPhaseTracker(phase);
+            panel.SetWeaponDefinitionResolver(resolver);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(weapon);
+            Object.DestroyImmediate(root);
+        }
+
+        [Test]
+        public void OpenFromWorld_RendersVaultEntries_BetweenWaves()
+        {
+            phase.SetPhase(WavePhase.PreWave);
+            vault.State.AddItem("potion_basic", 3);
+
+            Assert.IsTrue(panel.OpenFromWorld());
+
+            Assert.IsTrue(panel.IsOpen);
+            AssertTextExists("Vault");
+            AssertTextExists("potion_basic x3");
+        }
+
+        [Test]
+        public void OpenFromWorld_IsDenied_MidWave()
+        {
+            phase.SetPhase(WavePhase.InWave);
+            vault.State.AddItem("potion_basic", 3);
+
+            Assert.IsFalse(panel.OpenFromWorld());
+
+            Assert.IsFalse(panel.IsOpen);
+            AssertTextMissing("potion_basic x3");
+        }
+
+        [Test]
+        public void VaultChanges_RefreshVisibleRows()
+        {
+            phase.SetPhase(WavePhase.PreWave);
+            Assert.IsTrue(panel.OpenFromWorld());
+
+            vault.State.AddItem("weapon_sword", 1);
+
+            AssertTextExists("weapon_sword x1");
+        }
+
+        [Test]
+        public void CloseButton_ClosesVaultPanel()
+        {
+            phase.SetPhase(WavePhase.PreWave);
+            Assert.IsTrue(panel.OpenFromWorld());
+
+            ClickButton("X");
+
+            Assert.IsFalse(panel.IsOpen);
+        }
+
+        [Test]
+        public void VaultRow_ButtonClickOpensContextMenu_WithMoveAndEquipActions()
+        {
+            phase.SetPhase(WavePhase.PreWave);
+            vault.State.AddItem("weapon_sword", 1);
+            Assert.IsTrue(panel.OpenFromWorld());
+
+            var trigger = root.GetComponentInChildren<InventoryContextMenuTrigger>(true);
+            var rowButton = trigger.GetComponent<Button>();
+
+            Assert.NotNull(rowButton);
+            rowButton.onClick.Invoke();
+
+            AssertTextExists("Move to Backpack");
+            AssertTextExists("Equip");
+        }
+
+        [Test]
+        public void VaultContextMenu_MoveToBackpack_RefreshesVaultRowsWithoutClosingWhenMoreRemain()
+        {
+            phase.SetPhase(WavePhase.PreWave);
+            vault.State.AddItem("weapon_sword", 2);
+            Assert.IsTrue(panel.OpenFromWorld());
+
+            OpenFirstVaultRowContextMenu();
+            ClickButton("Move to Backpack");
+            var menu = root.GetComponent<InventoryContextMenuController>();
+
+            Assert.IsTrue(menu.IsOpen);
+            Assert.That(menu.ActiveSource, Is.EqualTo(InventoryContextSource.Vault));
+            Assert.That(vault.State.GetCount("weapon_sword"), Is.EqualTo(1));
+            Assert.That(backpack.State.GetCount("weapon_sword"), Is.EqualTo(1));
+            AssertTextExists("weapon_sword x1");
+        }
+
+        [Test]
+        public void VaultContextMenu_EquipWeapon_ReturnsDisplacedWeaponToVault()
+        {
+            phase.SetPhase(WavePhase.PreWave);
+            activeInventory.State.AddWeapon("weapon_dagger");
+            vault.State.AddItem("weapon_sword", 1);
+            Assert.IsTrue(panel.OpenFromWorld());
+
+            OpenFirstVaultRowContextMenu();
+
+            ClickButton("Equip");
+            ClickButton("Main");
+
+            Assert.That(activeInventory.State.GetWeaponId(0), Is.EqualTo("weapon_sword"));
+            Assert.That(vault.State.GetCount("weapon_dagger"), Is.EqualTo(1));
+        }
+
+        private void OpenFirstVaultRowContextMenu()
+        {
+            var trigger = root.GetComponentInChildren<InventoryContextMenuTrigger>(true);
+            Assert.NotNull(trigger);
+            var eventData = new PointerEventData(EventSystem.current) { button = PointerEventData.InputButton.Right };
+            trigger.OnPointerClick(eventData);
+        }
+
+        private void ClickButton(string label)
+        {
+            var buttons = root.GetComponentsInChildren<Button>(true);
+            foreach (var button in buttons)
+            {
+                if (!button.gameObject.activeInHierarchy)
+                {
+                    continue;
+                }
+
+                var text = button.GetComponentInChildren<TextMeshProUGUI>(true);
+                if (text != null && text.text == label)
+                {
+                    button.onClick.Invoke();
+                    return;
+                }
+            }
+
+            Assert.Fail($"Expected button '{label}'.");
+        }
+
+        private void AssertTextExists(string expected)
+        {
+            var labels = root.GetComponentsInChildren<TextMeshProUGUI>(true);
+            foreach (var label in labels)
+            {
+                if (label.text == expected)
+                {
+                    return;
+                }
+            }
+
+            Assert.Fail($"Expected vault panel text '{expected}'.");
+        }
+
+        private void AssertTextMissing(string expected)
+        {
+            var labels = root.GetComponentsInChildren<TextMeshProUGUI>(true);
+            foreach (var label in labels)
+            {
+                if (label.text == expected)
+                {
+                    Assert.Fail($"Did not expect vault panel text '{expected}'.");
+                }
+            }
+        }
+
+        private sealed class TestWeaponResolver : MonoBehaviour, IWeaponDefinitionResolver
+        {
+            public WeaponDefinition Weapon { get; set; }
+
+            public WeaponDefinition Resolve(string weaponId)
+            {
+                return Weapon != null && Weapon.ItemId == weaponId ? Weapon : null;
+            }
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/UI/VaultPanelControllerTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/UI/VaultPanelControllerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e76cac1f769e43f481962760f4c8fe8b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/_Tests/PlayMode/Castle/VaultWorldInteractionPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/Castle/VaultWorldInteractionPlayTests.cs
@@ -13,37 +13,67 @@ namespace Castlebound.Tests.PlayMode.Castle
     public class VaultWorldInteractionPlayTests
     {
         [UnityTest]
-        public IEnumerator TryOpenVault_OpensInventoryPanelVaultView_WhenPreWaveAndInRange()
+        public IEnumerator TryOpenVault_OpensDedicatedVaultPanel_WhenPreWaveAndInRange()
         {
             var root = new GameObject("VaultWorldInteractionPlayRoot", typeof(Canvas));
 
             try
             {
-                root.AddComponent<BackpackInventoryStateComponent>();
+                var backpack = root.AddComponent<BackpackInventoryStateComponent>();
                 var vault = root.AddComponent<CastleInventoryStateComponent>();
                 var panel = root.AddComponent<InventoryPanelController>();
+                var vaultPanel = root.AddComponent<VaultPanelController>();
                 var phase = new WavePhaseTracker();
                 var interaction = root.AddComponent<VaultWorldInteraction>();
 
+                panel.SetBackpackSource(backpack);
                 panel.SetCastleInventorySource(vault);
                 panel.SetPhaseTracker(phase);
+                vaultPanel.SetInventorySources(backpack, vault, root.AddComponent<InventoryStateComponent>());
+                vaultPanel.SetPhaseTracker(phase);
                 interaction.SetInventoryPanel(panel);
+                interaction.SetVaultPanel(vaultPanel);
                 interaction.SetPhaseTracker(phase);
                 interaction.SetPlayerInRange(true);
+                backpack.State.AddItem("weapon_sword", 1);
                 vault.State.AddItem("potion_health", 1);
 
+                panel.TogglePanel();
                 yield return null;
 
                 Assert.IsTrue(interaction.TryOpenVault());
                 yield return null;
 
                 Assert.IsTrue(panel.IsOpen);
+                Assert.IsTrue(vaultPanel.IsOpen);
+                AssertTextExists(root, "weapon_sword x1");
                 AssertTextExists(root, "potion_health x1");
+
+                ClickButton(root, "X");
+                yield return null;
+
+                Assert.IsFalse(vaultPanel.IsOpen);
             }
             finally
             {
                 Object.Destroy(root);
             }
+        }
+
+        private static void ClickButton(GameObject root, string label)
+        {
+            var buttons = root.GetComponentsInChildren<UnityEngine.UI.Button>(true);
+            for (int i = 0; i < buttons.Length; i++)
+            {
+                var text = buttons[i].GetComponentInChildren<TextMeshProUGUI>(true);
+                if (text != null && text.text == label)
+                {
+                    buttons[i].onClick.Invoke();
+                    return;
+                }
+            }
+
+            Assert.Fail($"Expected button '{label}'.");
         }
 
         private static void AssertTextExists(GameObject root, string expected)

--- a/Assets/_Project/_Tests/PlayMode/UI/InventoryPanelControllerPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/UI/InventoryPanelControllerPlayTests.cs
@@ -16,7 +16,7 @@ namespace Castlebound.Tests.UI
     public class InventoryPanelControllerPlayTests
     {
         [UnityTest]
-        public IEnumerator InventoryPanel_OpensBackpack_AndDeniesWorldVaultMidWave()
+        public IEnumerator InventoryPanel_OpensBackpack_AndDoesNotOwnWorldVaultView()
         {
             var root = new GameObject("InventoryPanelPlayRoot", typeof(Canvas));
 
@@ -38,7 +38,6 @@ namespace Castlebound.Tests.UI
                 Assert.IsTrue(panel.IsOpen);
                 Assert.That(panel.ActiveTab, Is.EqualTo(InventoryPanelTab.Backpack));
 
-                phase.SetPhase(WavePhase.InWave);
                 Assert.IsFalse(panel.OpenVaultFromWorld());
                 yield return null;
 

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,27 @@
 
 ---
 
+## 2026-07-10 - codex-vault-dedicated-panel
+
+### Summary
+- Added a dedicated Vault panel separate from the Inventory panel with a close button.
+- Routed world Vault interaction to open the dedicated Vault panel while allowing Backpack to remain visible.
+- Kept Shop and Backpack behavior unchanged, with club/dagger art metadata cleanup carried into the branch.
+
+### New or Updated Tests
+**EditMode**
+- `VaultPanelControllerTests` — validates dedicated Vault rendering, close button behavior, blocked state, refresh, Vault context menu actions, and Vault weapon equip behavior.
+- `VaultWorldInteractionTests` — validates world Vault interaction opens the dedicated panel and preserves Backpack visibility.
+- `InventoryPanelControllerTests` — validates Inventory no longer owns the world Vault view.
+
+**PlayMode**
+- `VaultWorldInteractionPlayTests` — validates runtime Vault opening shows the dedicated Vault panel while Backpack remains visible and the close button closes it.
+- `InventoryPanelControllerPlayTests` — validates Inventory panel no longer owns the world Vault view.
+
+### Notes
+- EditMode, PlayMode, and manual validation passed.
+- Manual validation confirmed the dedicated Vault panel, Backpack side-by-side visibility, and X close button work in game.
+
 ## 2026-07-10 - codex-shop-purchasing
 
 ### Summary


### PR DESCRIPTION
## Why
Vault access reused the Inventory panel content view, so Backpack and Vault contents could not be viewed side-by-side. P4 needs a clearer stewardship view where the player can inspect carried items and castle storage at the same time.

## What changed
- Added a dedicated `VaultPanelController` for Vault UI rendering and context actions
- Routed world Vault interaction to open the dedicated Vault panel instead of switching the Inventory panel into Vault mode
- Kept Backpack visible while Vault is open
- Added a temporary `X` close button on the Vault panel; world-input toggle close remains scoped to #218
- Preserved Shop and Backpack behavior
- Included club/dagger art metadata cleanup carried forward from the local branch

## How to test
1. Open `Assets/_Project/Scenes/MainPrototype.unity`
2. Press Play, open Backpack, then open the Vault between waves and verify both panels are visible
3. Click `X` on the Vault panel and verify it closes
4. Verify Shop still opens only inside castle between waves
5. Run tests:
   - EditMode
   - PlayMode

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated (N/A - runtime UI/controller split only)
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched (TEST_LOG.md updated)

## Related
- Closes #217
- Refs #218