### PR TITLE
feat(vault): toggle world vault interaction

### DIFF
--- a/Assets/_Project/Scripts/_Project.Gameplay/Castle/VaultWorldInteraction.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Castle/VaultWorldInteraction.cs
@@ -19,7 +19,7 @@ namespace Castlebound.Gameplay.Castle
         private WavePhaseTracker phaseTracker;
         private bool playerInRange;
         private float touchHoldTimer;
-        private bool touchOpenedThisPress;
+        private bool touchToggledThisPress;
         private bool phaseHooked;
         private readonly Collider2D[] rangeHits = new Collider2D[8];
 
@@ -45,7 +45,7 @@ namespace Castlebound.Gameplay.Castle
 
             if (Keyboard.current != null && Keyboard.current.eKey.wasPressedThisFrame)
             {
-                TryOpenVault();
+                TryToggleVault();
             }
 
             UpdateTouchHold();
@@ -126,7 +126,21 @@ namespace Castlebound.Gameplay.Castle
             return vaultPanel.OpenFromWorld();
         }
 
-        private bool TryOpenVaultFromHeldScreenPosition(Vector2 screenPosition, float deltaSeconds)
+        public bool TryToggleVault()
+        {
+            ResolveReferences();
+            ApplyVisualState();
+
+            if (vaultPanel != null && vaultPanel.IsOpen && playerInRange)
+            {
+                vaultPanel.ClosePanel();
+                return true;
+            }
+
+            return TryOpenVault();
+        }
+
+        private bool TryToggleVaultFromHeldScreenPosition(Vector2 screenPosition, float deltaSeconds)
         {
             if (!playerInRange || !IsScreenPositionOverTouchTarget(screenPosition))
             {
@@ -134,7 +148,7 @@ namespace Castlebound.Gameplay.Castle
                 return false;
             }
 
-            if (touchOpenedThisPress)
+            if (touchToggledThisPress)
             {
                 return false;
             }
@@ -145,12 +159,12 @@ namespace Castlebound.Gameplay.Castle
                 return false;
             }
 
-            if (!TryOpenVault())
+            if (!TryToggleVault())
             {
                 return false;
             }
 
-            touchOpenedThisPress = true;
+            touchToggledThisPress = true;
             return true;
         }
 
@@ -327,12 +341,12 @@ namespace Castlebound.Gameplay.Castle
                 return;
             }
 
-            if (touchOpenedThisPress)
+            if (touchToggledThisPress)
             {
                 return;
             }
 
-            TryOpenVaultFromHeldScreenPosition(screenPosition, Time.deltaTime);
+            TryToggleVaultFromHeldScreenPosition(screenPosition, Time.deltaTime);
         }
 
         private bool TryReadPressedPointerPosition(out Vector2 screenPosition)
@@ -384,7 +398,7 @@ namespace Castlebound.Gameplay.Castle
         private void ResetTouchHold()
         {
             touchHoldTimer = 0f;
-            touchOpenedThisPress = false;
+            touchToggledThisPress = false;
         }
     }
 }

--- a/Assets/_Project/Scripts/_Project.Gameplay/UI/InventoryContextMenuController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/UI/InventoryContextMenuController.cs
@@ -77,8 +77,8 @@ namespace Castlebound.Gameplay.UI
             activeSource = source;
             isChoosingEquipSlot = false;
             EnsureMenuRoot();
-            PositionNear(anchor);
             RebuildRootActions();
+            PositionNear(anchor);
             menuRoot.gameObject.SetActive(true);
         }
 
@@ -291,13 +291,30 @@ namespace Castlebound.Gameplay.UI
 
             if (anchor == null || parentRoot == null)
             {
-                menuRoot.anchoredPosition = new Vector2(212f, -62f);
+                menuRoot.anchoredPosition = ClampToParent(new Vector2(212f, -62f));
                 return;
             }
 
             Vector3 worldPosition = anchor.TransformPoint(new Vector3(anchor.rect.xMax, anchor.rect.yMax, 0f));
             Vector3 localPosition = parentRoot.InverseTransformPoint(worldPosition);
-            menuRoot.anchoredPosition = new Vector2(localPosition.x + 8f, localPosition.y);
+            menuRoot.anchoredPosition = ClampToParent(new Vector2(localPosition.x + 8f, localPosition.y));
+        }
+
+        private Vector2 ClampToParent(Vector2 position)
+        {
+            if (parentRoot == null || menuRoot == null)
+            {
+                return position;
+            }
+
+            Rect parentRect = parentRoot.rect;
+            Vector2 menuSize = menuRoot.sizeDelta;
+            float maxX = Mathf.Max(0f, parentRect.width - menuSize.x);
+            float minY = Mathf.Min(0f, -parentRect.height + menuSize.y);
+
+            return new Vector2(
+                Mathf.Clamp(position.x, 0f, maxX),
+                Mathf.Clamp(position.y, minY, 0f));
         }
 
         private void ClearMenu()

--- a/Assets/_Project/Scripts/_Project.Gameplay/UI/VaultPanelController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/UI/VaultPanelController.cs
@@ -222,13 +222,28 @@ namespace Castlebound.Gameplay.UI
 
         private void ConfigureContextMenu()
         {
+            if (contextMenu == null && panelRoot == null)
+            {
+                return;
+            }
+
             if (contextMenu == null)
             {
-                contextMenu = GetComponent<InventoryContextMenuController>();
-                if (contextMenu == null)
+                contextMenu = panelRoot != null
+                    ? panelRoot.GetComponentInChildren<InventoryContextMenuController>(true)
+                    : null;
+
+                if (contextMenu == null && panelRoot != null)
                 {
-                    contextMenu = gameObject.AddComponent<InventoryContextMenuController>();
+                    var menuObject = new GameObject("VaultInventoryContextMenu", typeof(RectTransform), typeof(InventoryContextMenuController));
+                    menuObject.transform.SetParent(panelRoot, false);
+                    contextMenu = menuObject.GetComponent<InventoryContextMenuController>();
                 }
+            }
+
+            if (contextMenu == null)
+            {
+                return;
             }
 
             HookContextMenu();

--- a/Assets/_Project/_Tests/EditMode/Castle/VaultWorldInteractionTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Castle/VaultWorldInteractionTests.cs
@@ -68,6 +68,77 @@ namespace Castlebound.Tests.Castle
         }
 
         [Test]
+        public void TryToggleVault_OpensWhenClosedAndAccessible()
+        {
+            vault.State.AddItem("potion_health", 1);
+            interaction.SetPlayerInRange(true);
+            phase.SetPhase(WavePhase.PreWave);
+
+            Assert.IsTrue(interaction.TryToggleVault());
+
+            Assert.IsTrue(vaultPanel.IsOpen);
+            AssertTextExists("potion_health x1");
+        }
+
+        [Test]
+        public void TryToggleVault_ClosesWhenVaultPanelIsOpen()
+        {
+            vault.State.AddItem("potion_health", 1);
+            interaction.SetPlayerInRange(true);
+            phase.SetPhase(WavePhase.PreWave);
+
+            Assert.IsTrue(interaction.TryOpenVault());
+            Assert.IsTrue(vaultPanel.IsOpen);
+
+            Assert.IsTrue(interaction.TryToggleVault());
+
+            Assert.IsFalse(vaultPanel.IsOpen);
+        }
+
+        [Test]
+        public void TryToggleVault_DoesNotCloseOpenVault_WhenOutOfRange()
+        {
+            vault.State.AddItem("potion_health", 1);
+            interaction.SetPlayerInRange(true);
+            phase.SetPhase(WavePhase.PreWave);
+
+            Assert.IsTrue(interaction.TryOpenVault());
+
+            interaction.SetPlayerInRange(false);
+
+            Assert.IsFalse(interaction.TryToggleVault());
+            Assert.IsTrue(vaultPanel.IsOpen);
+        }
+
+        [Test]
+        public void TryToggleVault_DoesNotOpenWhenOutOfRangeOrInWave()
+        {
+            vault.State.AddItem("potion_health", 1);
+
+            Assert.IsFalse(interaction.TryToggleVault());
+            Assert.IsFalse(vaultPanel.IsOpen);
+
+            interaction.SetPlayerInRange(true);
+            phase.SetPhase(WavePhase.InWave);
+
+            Assert.IsFalse(interaction.TryToggleVault());
+            Assert.IsFalse(vaultPanel.IsOpen);
+        }
+
+        [Test]
+        public void TryOpenVault_RemainsOpenOnly_WhenVaultPanelIsAlreadyOpen()
+        {
+            vault.State.AddItem("potion_health", 1);
+            interaction.SetPlayerInRange(true);
+            phase.SetPhase(WavePhase.PreWave);
+
+            Assert.IsTrue(interaction.TryOpenVault());
+            Assert.IsTrue(interaction.TryOpenVault());
+
+            Assert.IsTrue(vaultPanel.IsOpen);
+        }
+
+        [Test]
         public void TryOpenVault_KeepsBackpackPanelVisibleBesideVaultPanel()
         {
             backpack.State.AddItem("weapon_sword", 1);
@@ -236,7 +307,7 @@ namespace Castlebound.Tests.Castle
 
             StringAssert.Contains("Touchscreen.current", source);
             StringAssert.Contains("Pointer.current", source);
-            StringAssert.Contains("TryOpenVaultFromHeldScreenPosition(screenPosition, Time.deltaTime)", source);
+            StringAssert.Contains("TryToggleVaultFromHeldScreenPosition(screenPosition, Time.deltaTime)", source);
         }
 
         private void AssertTextExists(string expected)

--- a/Assets/_Project/_Tests/EditMode/UI/InventoryContextMenuControllerTests.cs
+++ b/Assets/_Project/_Tests/EditMode/UI/InventoryContextMenuControllerTests.cs
@@ -126,6 +126,29 @@ namespace Castlebound.Tests.UI
             Assert.That(backpack.State.GetCount("weapon_dagger"), Is.EqualTo(1));
         }
 
+        [Test]
+        public void ShowForItem_ClampsMenuInsideParentRoot()
+        {
+            var parent = root.GetComponent<RectTransform>();
+            parent.sizeDelta = new Vector2(160f, 120f);
+
+            var anchorObject = new GameObject("Anchor", typeof(RectTransform));
+            anchorObject.transform.SetParent(root.transform, false);
+            var anchor = anchorObject.GetComponent<RectTransform>();
+            anchor.anchorMin = new Vector2(0f, 1f);
+            anchor.anchorMax = new Vector2(0f, 1f);
+            anchor.pivot = new Vector2(0f, 1f);
+            anchor.anchoredPosition = new Vector2(150f, -110f);
+            anchor.sizeDelta = new Vector2(34f, 34f);
+
+            menu.ShowForItem("weapon_dagger", true, anchor);
+
+            var menuRoot = FindRectTransform("InventoryContextMenu");
+            Assert.NotNull(menuRoot);
+            Assert.That(menuRoot.anchoredPosition.x, Is.InRange(0f, parent.rect.width - menuRoot.sizeDelta.x));
+            Assert.That(menuRoot.anchoredPosition.y, Is.InRange(-parent.rect.height + menuRoot.sizeDelta.y, 0f));
+        }
+
         private void ClickButton(string label)
         {
             var buttons = root.GetComponentsInChildren<Button>(true);
@@ -154,6 +177,20 @@ namespace Castlebound.Tests.UI
             }
 
             Assert.Fail($"Expected text '{expected}'.");
+        }
+
+        private RectTransform FindRectTransform(string objectName)
+        {
+            var rects = root.GetComponentsInChildren<RectTransform>(true);
+            for (int i = 0; i < rects.Length; i++)
+            {
+                if (rects[i].name == objectName)
+                {
+                    return rects[i];
+                }
+            }
+
+            return null;
         }
 
         private sealed class TestWeaponResolver : MonoBehaviour, IWeaponDefinitionResolver

--- a/Assets/_Project/_Tests/EditMode/UI/VaultPanelControllerTests.cs
+++ b/Assets/_Project/_Tests/EditMode/UI/VaultPanelControllerTests.cs
@@ -118,7 +118,7 @@ namespace Castlebound.Tests.UI
 
             OpenFirstVaultRowContextMenu();
             ClickButton("Move to Backpack");
-            var menu = root.GetComponent<InventoryContextMenuController>();
+            var menu = root.GetComponentInChildren<InventoryContextMenuController>(true);
 
             Assert.IsTrue(menu.IsOpen);
             Assert.That(menu.ActiveSource, Is.EqualTo(InventoryContextSource.Vault));
@@ -144,9 +144,50 @@ namespace Castlebound.Tests.UI
             Assert.That(vault.State.GetCount("weapon_dagger"), Is.EqualTo(1));
         }
 
+        [Test]
+        public void VaultContextMenu_CreatesVaultScopedMenu_WhenSharingRootWithInventoryPanel()
+        {
+            var inventoryPanel = root.AddComponent<InventoryPanelController>();
+            inventoryPanel.SetBackpackSource(backpack);
+            inventoryPanel.SetActiveInventorySource(activeInventory);
+            inventoryPanel.SetCastleInventorySource(vault);
+            inventoryPanel.SetPhaseTracker(phase);
+            inventoryPanel.SetWeaponDefinitionResolver(root.GetComponent<TestWeaponResolver>());
+
+            phase.SetPhase(WavePhase.PreWave);
+            backpack.State.AddItem("weapon_sword", 1);
+            vault.State.AddItem("weapon_sword", 1);
+            inventoryPanel.TogglePanel();
+
+            Assert.IsTrue(panel.OpenFromWorld());
+
+            OpenFirstVaultRowContextMenu();
+            var vaultMenu = FindMenuWithSource(InventoryContextSource.Vault);
+
+            Assert.NotNull(vaultMenu);
+            Assert.That(vaultMenu.transform.parent.name, Is.EqualTo("VaultPanel"));
+
+            OpenFirstInventoryRowContextMenu();
+            var backpackMenu = root.GetComponent<InventoryContextMenuController>();
+
+            Assert.NotNull(backpackMenu);
+            Assert.IsTrue(backpackMenu.IsOpen);
+            Assert.That(backpackMenu.ActiveSource, Is.EqualTo(InventoryContextSource.Backpack));
+            AssertTextExists("Drop");
+            AssertTextExists("Equip");
+        }
+
         private void OpenFirstVaultRowContextMenu()
         {
-            var trigger = root.GetComponentInChildren<InventoryContextMenuTrigger>(true);
+            var trigger = FindTriggerUnder("VaultRows");
+            Assert.NotNull(trigger);
+            var eventData = new PointerEventData(EventSystem.current) { button = PointerEventData.InputButton.Right };
+            trigger.OnPointerClick(eventData);
+        }
+
+        private void OpenFirstInventoryRowContextMenu()
+        {
+            var trigger = FindTriggerUnder("InventoryRows");
             Assert.NotNull(trigger);
             var eventData = new PointerEventData(EventSystem.current) { button = PointerEventData.InputButton.Right };
             trigger.OnPointerClick(eventData);
@@ -197,6 +238,50 @@ namespace Castlebound.Tests.UI
                     Assert.Fail($"Did not expect vault panel text '{expected}'.");
                 }
             }
+        }
+
+        private InventoryContextMenuController FindMenuWithSource(InventoryContextSource source)
+        {
+            var menus = root.GetComponentsInChildren<InventoryContextMenuController>(true);
+            foreach (var menu in menus)
+            {
+                if (menu.IsOpen && menu.ActiveSource == source)
+                {
+                    return menu;
+                }
+            }
+
+            return null;
+        }
+
+        private InventoryContextMenuTrigger FindTriggerUnder(string parentName)
+        {
+            var triggers = root.GetComponentsInChildren<InventoryContextMenuTrigger>(true);
+            foreach (var trigger in triggers)
+            {
+                if (HasParentNamed(trigger.transform, parentName))
+                {
+                    return trigger;
+                }
+            }
+
+            return null;
+        }
+
+        private static bool HasParentNamed(Transform child, string parentName)
+        {
+            var current = child;
+            while (current != null)
+            {
+                if (current.name == parentName)
+                {
+                    return true;
+                }
+
+                current = current.parent;
+            }
+
+            return false;
         }
 
         private sealed class TestWeaponResolver : MonoBehaviour, IWeaponDefinitionResolver

--- a/Assets/_Project/_Tests/PlayMode/Castle/VaultWorldInteractionPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/Castle/VaultWorldInteractionPlayTests.cs
@@ -49,6 +49,17 @@ namespace Castlebound.Tests.PlayMode.Castle
                 AssertTextExists(root, "weapon_sword x1");
                 AssertTextExists(root, "potion_health x1");
 
+                Assert.IsTrue(interaction.TryToggleVault());
+                yield return null;
+
+                Assert.IsTrue(panel.IsOpen);
+                Assert.IsFalse(vaultPanel.IsOpen);
+
+                Assert.IsTrue(interaction.TryToggleVault());
+                yield return null;
+
+                Assert.IsTrue(vaultPanel.IsOpen);
+
                 ClickButton(root, "X");
                 yield return null;
 

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,27 @@
 
 ---
 
+## 2026-07-11 - codex-vault-world-toggle
+
+### Summary
+- Added Vault world interaction toggling so the same input can open or close the dedicated Vault panel.
+- Routed keyboard and touch-hold Vault input through the toggle path while preserving open-only `TryOpenVault` behavior.
+- Kept the existing Vault close button, Backpack side-by-side behavior, and between-wave open gate intact.
+- Fixed Vault context menus to use a Vault-scoped menu instance and clamp menu placement inside the owning panel.
+
+### New or Updated Tests
+**EditMode**
+- `VaultWorldInteractionTests` - validates toggle open, toggle close, blocked open attempts, out-of-range close blocking, open-only compatibility, and touch fallback routing.
+- `InventoryContextMenuControllerTests` - validates context menu placement clamps inside its parent panel.
+- `VaultPanelControllerTests` - validates Vault menus do not steal Backpack menu ownership when both panels share a root.
+
+**PlayMode**
+- `VaultWorldInteractionPlayTests` - validates runtime toggle close/reopen while Backpack remains visible and the close button still closes the Vault.
+
+### Notes
+- Local EditMode runner could not execute because `ci/run-editmode.ps1` currently parse-fails in this shell.
+- Local PlayMode runner could not execute because the configured Unity editor path was not found in this shell.
+
 ## 2026-07-10 - codex-vault-dedicated-panel
 
 ### Summary


### PR DESCRIPTION
## Why
Vault world input should work as a true toggle now that the Vault lives in a dedicated panel, and Backpack/Vault context menus need to remain usable when both panels are visible.

## What changed
- Added Vault world interaction toggling for keyboard and touch-hold input.
- Preserved `TryOpenVault()` as an open-only compatibility path.
- Scoped Vault context menus to the Vault panel so Backpack menus remain independent.
- Clamped context menu placement inside the owning panel.
- Added EditMode and PlayMode coverage for toggle behavior and menu regressions.

## How to test
1. Open the main gameplay scene or Android APK build.
2. Enter the castle between waves, open Backpack, then open Vault from the world interaction.
3. Verify E closes/reopens the Vault, Backpack remains visible, and Backpack/Vault item menus open inside the correct panel.
4. Run tests:
   - EditMode
   - PlayMode

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated (N/A - runtime UI/input only)
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched (N/A - TEST_LOG only)

## Related
- Closes #218