### PR TITLE
feat(inventory): move backpack items to vault

### DIFF
--- a/Assets/_Project/Scripts/_Project.Gameplay/UI/InventoryContextMenuController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/UI/InventoryContextMenuController.cs
@@ -1,5 +1,7 @@
 using System;
+using Castlebound.Gameplay.AI;
 using Castlebound.Gameplay.Inventory;
+using Castlebound.Gameplay.Spawning;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -20,12 +22,14 @@ namespace Castlebound.Gameplay.UI
         [SerializeField] private BackpackInventoryStateComponent backpackSource;
         [SerializeField] private CastleInventoryStateComponent vaultSource;
         [SerializeField] private InventoryStateComponent activeInventorySource;
+        [SerializeField] private CastleRegionTracker castleRegionTracker;
 
         private RectTransform parentRoot;
         private string activeItemId;
         private bool activeItemIsWeapon;
         private InventoryContextSource activeSource;
         private bool isChoosingEquipSlot;
+        private WavePhaseTracker phaseTracker;
 
         public event Action ActionCompleted;
 
@@ -57,6 +61,12 @@ namespace Castlebound.Gameplay.UI
             backpackSource = backpack;
             vaultSource = vault;
             activeInventorySource = activeInventory;
+        }
+
+        public void SetAccessContext(CastleRegionTracker regionTracker, WavePhaseTracker wavePhaseTracker)
+        {
+            castleRegionTracker = regionTracker;
+            phaseTracker = wavePhaseTracker;
         }
 
         public void ShowForItem(string itemId, bool isWeapon, RectTransform anchor)
@@ -109,11 +119,12 @@ namespace Castlebound.Gameplay.UI
             ClearMenu();
             if (activeSource == InventoryContextSource.Backpack)
             {
+                CreateMenuButton("Vault", TryMoveBackpackItemToVault);
                 CreateMenuButton("Drop", TryDropActiveItem);
             }
             else
             {
-                CreateMenuButton("Move to Backpack", TryMoveVaultItemToBackpack);
+                CreateMenuButton("Backpack", TryMoveVaultItemToBackpack);
             }
 
             if (activeItemIsWeapon)
@@ -135,11 +146,12 @@ namespace Castlebound.Gameplay.UI
             ClearMenu();
             if (activeSource == InventoryContextSource.Backpack)
             {
+                CreateMenuButton("Vault", TryMoveBackpackItemToVault);
                 CreateMenuButton("Drop", TryDropActiveItem);
             }
             else
             {
-                CreateMenuButton("Move to Backpack", TryMoveVaultItemToBackpack);
+                CreateMenuButton("Backpack", TryMoveVaultItemToBackpack);
             }
 
             CreateMenuButton("Main", () => TryEquipActiveItem(0));
@@ -189,6 +201,37 @@ namespace Castlebound.Gameplay.UI
             }
 
             CompleteAction();
+        }
+
+        private void TryMoveBackpackItemToVault()
+        {
+            string itemId = activeItemId;
+            var backpack = backpackSource != null ? backpackSource.State : null;
+            var vault = vaultSource != null ? vaultSource.State : null;
+            if (!CanMoveBackpackItemToVault() || backpack == null || vault == null || string.IsNullOrWhiteSpace(itemId) || backpack.GetCount(itemId) <= 0)
+            {
+                return;
+            }
+
+            if (!backpack.TryRemoveItem(itemId, 1))
+            {
+                return;
+            }
+
+            if (!vault.AddItem(itemId, 1))
+            {
+                backpack.AddItem(itemId, 1);
+                return;
+            }
+
+            CompleteAction();
+        }
+
+        private bool CanMoveBackpackItemToVault()
+        {
+            return castleRegionTracker != null
+                && castleRegionTracker.PlayerInside
+                && (phaseTracker == null || phaseTracker.CurrentPhase == WavePhase.PreWave);
         }
 
         private bool TryEquipVaultItem(int slotIndex)

--- a/Assets/_Project/Scripts/_Project.Gameplay/UI/InventoryPanelController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/UI/InventoryPanelController.cs
@@ -105,6 +105,7 @@ namespace Castlebound.Gameplay.UI
             UnhookPhaseTracker();
             phaseTracker = tracker;
             HookPhaseTracker();
+            UpdateContextMenuAccessContext();
             Refresh();
         }
 
@@ -124,6 +125,7 @@ namespace Castlebound.Gameplay.UI
             UnhookCastleRegionTracker();
             castleRegionTracker = tracker;
             HookCastleRegionTracker();
+            UpdateContextMenuAccessContext();
             HandleShopAccessChanged();
         }
 
@@ -457,6 +459,15 @@ namespace Castlebound.Gameplay.UI
             contextMenu.SetEquipController(equipController);
             contextMenu.SetDropController(dropController);
             contextMenu.SetInventorySources(backpackSource, castleInventorySource, activeInventorySource);
+            UpdateContextMenuAccessContext();
+        }
+
+        private void UpdateContextMenuAccessContext()
+        {
+            if (contextMenu != null)
+            {
+                contextMenu.SetAccessContext(castleRegionTracker, phaseTracker);
+            }
         }
 
         private void HookContextMenu()

--- a/Assets/_Project/_Tests/EditMode/UI/InventoryContextMenuControllerTests.cs
+++ b/Assets/_Project/_Tests/EditMode/UI/InventoryContextMenuControllerTests.cs
@@ -1,5 +1,7 @@
+using Castlebound.Gameplay.AI;
 using Castlebound.Gameplay.Combat;
 using Castlebound.Gameplay.Inventory;
+using Castlebound.Gameplay.Spawning;
 using Castlebound.Gameplay.UI;
 using NUnit.Framework;
 using TMPro;
@@ -17,6 +19,8 @@ namespace Castlebound.Tests.UI
         private InventoryContextMenuController menu;
         private BackpackWeaponEquipController equipController;
         private BackpackItemDropController dropController;
+        private CastleRegionTracker castleRegion;
+        private WavePhaseTracker phase;
         private WeaponDefinition weapon;
 
         [SetUp]
@@ -29,11 +33,14 @@ namespace Castlebound.Tests.UI
             var resolver = root.AddComponent<TestWeaponResolver>();
             equipController = root.AddComponent<BackpackWeaponEquipController>();
             dropController = root.AddComponent<BackpackItemDropController>();
+            castleRegion = root.AddComponent<CastleRegionTracker>();
+            phase = new WavePhaseTracker();
             menu = root.AddComponent<InventoryContextMenuController>();
 
             weapon = ScriptableObject.CreateInstance<WeaponDefinition>();
             weapon.ItemId = "weapon_dagger";
             resolver.Weapon = weapon;
+            castleRegion.Debug_SetPlayerInsideForTests(true);
 
             equipController.SetActiveInventorySource(activeInventory);
             equipController.SetBackpackSource(backpack);
@@ -44,6 +51,7 @@ namespace Castlebound.Tests.UI
             menu.SetEquipController(equipController);
             menu.SetDropController(dropController);
             menu.SetInventorySources(backpack, vault, activeInventory);
+            menu.SetAccessContext(castleRegion, phase);
         }
 
         [TearDown]
@@ -106,7 +114,7 @@ namespace Castlebound.Tests.UI
             vault.State.AddItem("weapon_dagger", 2);
             menu.ShowForItem("weapon_dagger", true, InventoryContextSource.Vault, null);
 
-            ClickButton("Move to Backpack");
+            ClickButton("Backpack");
 
             Assert.IsTrue(menu.IsOpen);
             Assert.That(vault.State.GetCount("weapon_dagger"), Is.EqualTo(1));
@@ -119,11 +127,65 @@ namespace Castlebound.Tests.UI
             vault.State.AddItem("weapon_dagger", 1);
             menu.ShowForItem("weapon_dagger", true, InventoryContextSource.Vault, null);
 
-            ClickButton("Move to Backpack");
+            ClickButton("Backpack");
 
             Assert.IsFalse(menu.IsOpen);
             Assert.That(vault.State.GetCount("weapon_dagger"), Is.EqualTo(0));
             Assert.That(backpack.State.GetCount("weapon_dagger"), Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Vault_MovesOneBackpackItem_AndKeepsMenuOpenWhenMoreRemain()
+        {
+            backpack.State.AddItem("weapon_dagger", 2);
+            menu.ShowForItem("weapon_dagger", true, InventoryContextSource.Backpack, null);
+
+            ClickButton("Vault");
+
+            Assert.IsTrue(menu.IsOpen);
+            Assert.That(backpack.State.GetCount("weapon_dagger"), Is.EqualTo(1));
+            Assert.That(vault.State.GetCount("weapon_dagger"), Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Vault_ClosesMenuWhenLastBackpackItemMoves()
+        {
+            backpack.State.AddItem("weapon_dagger", 1);
+            menu.ShowForItem("weapon_dagger", true, InventoryContextSource.Backpack, null);
+
+            ClickButton("Vault");
+
+            Assert.IsFalse(menu.IsOpen);
+            Assert.That(backpack.State.GetCount("weapon_dagger"), Is.EqualTo(0));
+            Assert.That(vault.State.GetCount("weapon_dagger"), Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Vault_DoesNotMoveBackpackItem_WhenPlayerOutsideCastle()
+        {
+            backpack.State.AddItem("weapon_dagger", 1);
+            castleRegion.Debug_SetPlayerInsideForTests(false);
+            menu.ShowForItem("weapon_dagger", true, InventoryContextSource.Backpack, null);
+
+            ClickButton("Vault");
+
+            Assert.IsTrue(menu.IsOpen);
+            Assert.That(backpack.State.GetCount("weapon_dagger"), Is.EqualTo(1));
+            Assert.That(vault.State.GetCount("weapon_dagger"), Is.EqualTo(0));
+        }
+
+        [Test]
+        public void Vault_DoesNotMoveBackpackItem_DuringWave()
+        {
+            backpack.State.AddItem("weapon_dagger", 1);
+            phase.SetPhase(WavePhase.InWave);
+            menu.ShowForItem("weapon_dagger", true, InventoryContextSource.Backpack, null);
+
+            ClickButton("Vault");
+
+            Assert.IsTrue(menu.IsOpen);
+            Assert.That(backpack.State.GetCount("weapon_dagger"), Is.EqualTo(1));
+            Assert.That(vault.State.GetCount("weapon_dagger"), Is.EqualTo(0));
         }
 
         [Test]

--- a/Assets/_Project/_Tests/EditMode/UI/InventoryPanelControllerTests.cs
+++ b/Assets/_Project/_Tests/EditMode/UI/InventoryPanelControllerTests.cs
@@ -267,6 +267,7 @@ namespace Castlebound.Tests.UI
             Assert.NotNull(rowButton);
             trigger.OnPointerClick(eventData);
 
+            AssertTextExists("Vault");
             AssertTextExists("Drop");
             AssertTextExists("Equip");
         }

--- a/Assets/_Project/_Tests/EditMode/UI/VaultPanelControllerTests.cs
+++ b/Assets/_Project/_Tests/EditMode/UI/VaultPanelControllerTests.cs
@@ -105,7 +105,7 @@ namespace Castlebound.Tests.UI
             Assert.NotNull(rowButton);
             rowButton.onClick.Invoke();
 
-            AssertTextExists("Move to Backpack");
+            AssertTextExists("Backpack");
             AssertTextExists("Equip");
         }
 
@@ -117,7 +117,7 @@ namespace Castlebound.Tests.UI
             Assert.IsTrue(panel.OpenFromWorld());
 
             OpenFirstVaultRowContextMenu();
-            ClickButton("Move to Backpack");
+            ClickButton("Backpack");
             var menu = root.GetComponentInChildren<InventoryContextMenuController>(true);
 
             Assert.IsTrue(menu.IsOpen);

--- a/Assets/_Project/_Tests/PlayMode/UI/InventoryPanelControllerPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/UI/InventoryPanelControllerPlayTests.cs
@@ -98,6 +98,46 @@ namespace Castlebound.Tests.UI
         }
 
         [UnityTest]
+        public IEnumerator InventoryPanel_BackpackContextMenu_VaultMovesOneItem_WhenInsideCastlePreWave()
+        {
+            var root = new GameObject("InventoryPanelVaultMovePlayRoot", typeof(Canvas));
+
+            try
+            {
+                var backpack = root.AddComponent<BackpackInventoryStateComponent>();
+                root.AddComponent<InventoryStateComponent>();
+                var vault = root.AddComponent<CastleInventoryStateComponent>();
+                var castleRegion = root.AddComponent<CastleRegionTracker>();
+                var phase = new WavePhaseTracker();
+                var panel = root.AddComponent<InventoryPanelController>();
+                panel.SetBackpackSource(backpack);
+                panel.SetCastleInventorySource(vault);
+                panel.SetCastleRegionTracker(castleRegion);
+                panel.SetPhaseTracker(phase);
+
+                castleRegion.Debug_SetPlayerInsideForTests(true);
+                backpack.State.AddItem("potion_health", 2);
+                panel.TogglePanel();
+                yield return null;
+
+                var trigger = root.GetComponentInChildren<InventoryContextMenuTrigger>(true);
+                Assert.NotNull(trigger);
+                trigger.OnPointerClick(new PointerEventData(EventSystem.current) { button = PointerEventData.InputButton.Right });
+                yield return null;
+
+                ClickButton(root, "Vault");
+                yield return null;
+
+                Assert.That(backpack.State.GetCount("potion_health"), Is.EqualTo(1));
+                Assert.That(vault.State.GetCount("potion_health"), Is.EqualTo(1));
+            }
+            finally
+            {
+                Object.Destroy(root);
+            }
+        }
+
+        [UnityTest]
         public IEnumerator InventoryPanel_ShopRendersInCastle_AndClosesOnWaveStart()
         {
             var root = new GameObject("InventoryPanelShopPlayRoot", typeof(Canvas));

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,24 @@
 
 ---
 
+## 2026-07-14 - codex-backpack-move-to-vault
+
+### Summary
+- Added Backpack context menu transfer into the Castle Vault with the short `Vault` button label.
+- Renamed the Vault-to-Backpack context action to `Backpack`.
+- Gated Backpack-to-Vault transfer to inside-castle PreWave access while preserving Drop, Equip, and Vault panel actions.
+
+### New or Updated Tests
+**EditMode**
+- `InventoryContextMenuControllerTests` — validates Backpack-to-Vault transfer, short action labels, menu close/retain behavior, and outside-castle / in-wave blocking.
+- `InventoryPanelControllerTests` — validates Backpack row context menus expose the `Vault` action beside existing Drop and Equip actions.
+
+**PlayMode**
+- `InventoryPanelControllerPlayTests` — validates runtime Backpack context menu can move one item into the Vault when inside the castle during PreWave.
+
+### Notes
+- N/A
+
 ## 2026-07-11 - codex-vault-world-toggle
 
 ### Summary


### PR DESCRIPTION
## Why
Backpack items need a direct context menu path into Castle Vault storage so players can intentionally bank items between waves while inside the castle.

## What changed
- Added a `Vault` action to Backpack item context menus.
- Renamed the Vault-to-Backpack action to `Backpack`.
- Gated Backpack-to-Vault transfers to inside-castle PreWave access.
- Added EditMode and PlayMode coverage for transfer behavior, labels, and access blocking.
- Updated the test log for #219.

## How to test
1. Open the relevant scene or demo
2. Press Play -> verify Backpack item context menu shows `Vault` inside the castle between waves
3. Verify `Vault` moves one Backpack item into Castle Inventory
4. Verify the action does not move items outside the castle or during active waves
5. Run tests:
   - EditMode
   - PlayMode

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated (N/A - no scene changes required)
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched (TEST_LOG.md updated)

## Related
- Closes #219