### PR TITLE
feat(stats): add run stats tracking service

### DIFF
--- a/Assets/_Project/Scripts/_Project.Gameplay/Barrier/BarrierHealth.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Barrier/BarrierHealth.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine;
+using Castlebound.Gameplay.Stats;
 
 public class BarrierHealth : MonoBehaviour, IDamageable
 {
@@ -89,6 +90,7 @@ public class BarrierHealth : MonoBehaviour, IDamageable
         UpdateBrokenState();
         ResolveActiveOverlaps();
         OnRepaired?.Invoke();
+        RunStatsEvents.RaiseRepairPerformed();
         return true;
     }
 

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/Health.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/Health.cs
@@ -2,6 +2,7 @@
 using System;
 using UnityEngine;
 using Castlebound.Gameplay.Inventory;
+using Castlebound.Gameplay.Stats;
 
 public class Health : MonoBehaviour, IDamageable, IHealable
 {
@@ -29,9 +30,13 @@ public class Health : MonoBehaviour, IDamageable, IHealable
 
     public void TakeDamage(int amount)
     {
-        if (current <= 0) return;
+        if (current <= 0 || amount <= 0) return;
+        int previous = current;
         current = Mathf.Max(0, current - amount);
         OnHealthChanged?.Invoke(current, maxHealth);
+
+        if (CompareTag("Enemy"))
+            RunStatsEvents.RaiseDamageDealt(previous - current);
 
         if (CompareTag("Player") && playerHitFeedbackChannel != null)
         {
@@ -43,14 +48,20 @@ public class Health : MonoBehaviour, IDamageable, IHealable
 
     public void Heal(int amount)
     {
-        if (current <= 0) return;
+        if (current <= 0 || amount <= 0) return;
+        int previous = current;
         current = Mathf.Min(maxHealth, current + amount);
         OnHealthChanged?.Invoke(current, maxHealth);
+
+        if (CompareTag("Player"))
+            RunStatsEvents.RaiseHealthRestored(current - previous);
     }
 
     void Die()
     {
         OnDied?.Invoke();
+        if (CompareTag("Enemy"))
+            RunStatsEvents.RaiseEnemyKilled();
         if (CompareTag("Player"))
             GameManager.I?.OnPlayerDied();
 

--- a/Assets/_Project/Scripts/_Project.Gameplay/Inventory/InventoryState.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Inventory/InventoryState.cs
@@ -1,4 +1,5 @@
 using System;
+using Castlebound.Gameplay.Stats;
 
 namespace Castlebound.Gameplay.Inventory
 {
@@ -24,6 +25,12 @@ namespace Castlebound.Gameplay.Inventory
         public int Xp { get; private set; }
 
         public event Action<InventoryChangeFlags> OnInventoryChanged;
+
+        public InventoryState(int initialGold = 0, int initialXp = 0)
+        {
+            Gold = initialGold > 0 ? initialGold : 0;
+            Xp = initialXp > 0 ? initialXp : 0;
+        }
 
         public string GetWeaponId(int slotIndex)
         {
@@ -150,6 +157,7 @@ namespace Castlebound.Gameplay.Inventory
 
             Gold += amount;
             RaiseChanged(InventoryChangeFlags.Currency);
+            RunStatsEvents.RaiseGoldEarned(amount);
             return true;
         }
 
@@ -162,6 +170,7 @@ namespace Castlebound.Gameplay.Inventory
 
             Gold -= amount;
             RaiseChanged(InventoryChangeFlags.Currency);
+            RunStatsEvents.RaiseGoldSpent(amount);
             return true;
         }
 

--- a/Assets/_Project/Scripts/_Project.Gameplay/Inventory/InventoryStateComponent.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Inventory/InventoryStateComponent.cs
@@ -34,18 +34,9 @@ namespace Castlebound.Gameplay.Inventory
             {
                 if (state == null)
                 {
-                    state = new InventoryState();
                     int initialGold = ActiveEconomyTable != null ? ActiveEconomyTable.StartingGold : startingGold;
                     int initialXp = ActiveEconomyTable != null ? ActiveEconomyTable.StartingXp : startingXp;
-                    if (initialGold > 0)
-                    {
-                        state.AddGold(initialGold);
-                    }
-
-                    if (initialXp > 0)
-                    {
-                        state.AddXp(initialXp);
-                    }
+                    state = new InventoryState(initialGold, initialXp);
                 }
 
                 return state;

--- a/Assets/_Project/Scripts/_Project.Gameplay/Managers/GameManager.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Managers/GameManager.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using Castlebound.Gameplay.UI;
+using Castlebound.Gameplay.Stats;
 #if ENABLE_INPUT_SYSTEM
 using UnityEngine.InputSystem;
 #endif
@@ -12,6 +13,7 @@ public class GameManager : MonoBehaviour
     [SerializeField] GameObject gameOverUI; // optional canvas element
 
     public Random LootRng { get; private set; }
+    public RunStatsTracker RunStatsTracker { get; private set; }
 
     bool gameOver;
     GameOverScreenController gameOverScreenController;
@@ -21,6 +23,9 @@ public class GameManager : MonoBehaviour
         if (I && I != this) { Destroy(gameObject); return; }
         I = this;
         LootRng = new Random();
+        RunStatsTracker = GetComponent<RunStatsTracker>();
+        if (RunStatsTracker == null)
+            RunStatsTracker = gameObject.AddComponent<RunStatsTracker>();
         ResolveGameOverScreenController();
     }
 

--- a/Assets/_Project/Scripts/_Project.Gameplay/Spawning/EnemySpawnerRunner.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Spawning/EnemySpawnerRunner.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Castlebound.Gameplay.Balance;
 using UnityEngine;
+using Castlebound.Gameplay.Stats;
 
 namespace Castlebound.Gameplay.Spawning
 {
@@ -125,6 +126,7 @@ namespace Castlebound.Gameplay.Spawning
 
         private void HandleWaveEnded()
         {
+            RunStatsEvents.RaiseWaveSurvived();
             OnWaveEnded?.Invoke();
             phaseTracker.SetPhase(WavePhase.PreWave);
         }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Stats.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Stats.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 49cfba2a2d6d4106868f8e222ea20dc8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/_Project.Gameplay/Stats/RunStats.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Stats/RunStats.cs
@@ -1,0 +1,23 @@
+namespace Castlebound.Gameplay.Stats
+{
+    public sealed class RunStats
+    {
+        public int WavesSurvived { get; private set; }
+        public int EnemiesKilled { get; private set; }
+        public int DamageDealt { get; private set; }
+        public int RepairsPerformed { get; private set; }
+        public int HealthRestored { get; private set; }
+        public int GoldEarned { get; private set; }
+        public int GoldSpent { get; private set; }
+
+        public void RecordWaveSurvived() => WavesSurvived++;
+        public void RecordEnemyKilled() => EnemiesKilled++;
+        public void RecordRepair() => RepairsPerformed++;
+        public void RecordDamageDealt(int amount) => DamageDealt += Positive(amount);
+        public void RecordHealthRestored(int amount) => HealthRestored += Positive(amount);
+        public void RecordGoldEarned(int amount) => GoldEarned += Positive(amount);
+        public void RecordGoldSpent(int amount) => GoldSpent += Positive(amount);
+
+        private static int Positive(int amount) => amount > 0 ? amount : 0;
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Stats/RunStats.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Stats/RunStats.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 34b335af629f4d79b354a606b5f8503c

--- a/Assets/_Project/Scripts/_Project.Gameplay/Stats/RunStatsEvents.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Stats/RunStatsEvents.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace Castlebound.Gameplay.Stats
+{
+    public static class RunStatsEvents
+    {
+        public static event Action WaveSurvived;
+        public static event Action EnemyKilled;
+        public static event Action RepairPerformed;
+        public static event Action<int> DamageDealt;
+        public static event Action<int> HealthRestored;
+        public static event Action<int> GoldEarned;
+        public static event Action<int> GoldSpent;
+
+        public static void RaiseWaveSurvived() => WaveSurvived?.Invoke();
+        public static void RaiseEnemyKilled() => EnemyKilled?.Invoke();
+        public static void RaiseRepairPerformed() => RepairPerformed?.Invoke();
+        public static void RaiseDamageDealt(int amount) => DamageDealt?.Invoke(amount);
+        public static void RaiseHealthRestored(int amount) => HealthRestored?.Invoke(amount);
+        public static void RaiseGoldEarned(int amount) => GoldEarned?.Invoke(amount);
+        public static void RaiseGoldSpent(int amount) => GoldSpent?.Invoke(amount);
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Stats/RunStatsEvents.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Stats/RunStatsEvents.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0a2cf69ad41a4af8b0805159ee76a534

--- a/Assets/_Project/Scripts/_Project.Gameplay/Stats/RunStatsTracker.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Stats/RunStatsTracker.cs
@@ -1,0 +1,51 @@
+using UnityEngine;
+
+namespace Castlebound.Gameplay.Stats
+{
+    public sealed class RunStatsTracker : MonoBehaviour
+    {
+        private bool isTracking;
+
+        public RunStats Stats { get; } = new RunStats();
+
+        private void OnEnable()
+        {
+            BeginTracking();
+        }
+
+        public void BeginTracking()
+        {
+            if (isTracking)
+                return;
+
+            RunStatsEvents.WaveSurvived += Stats.RecordWaveSurvived;
+            RunStatsEvents.EnemyKilled += Stats.RecordEnemyKilled;
+            RunStatsEvents.DamageDealt += Stats.RecordDamageDealt;
+            RunStatsEvents.RepairPerformed += Stats.RecordRepair;
+            RunStatsEvents.HealthRestored += Stats.RecordHealthRestored;
+            RunStatsEvents.GoldEarned += Stats.RecordGoldEarned;
+            RunStatsEvents.GoldSpent += Stats.RecordGoldSpent;
+            isTracking = true;
+        }
+
+        private void OnDisable()
+        {
+            StopTracking();
+        }
+
+        public void StopTracking()
+        {
+            if (!isTracking)
+                return;
+
+            RunStatsEvents.WaveSurvived -= Stats.RecordWaveSurvived;
+            RunStatsEvents.EnemyKilled -= Stats.RecordEnemyKilled;
+            RunStatsEvents.DamageDealt -= Stats.RecordDamageDealt;
+            RunStatsEvents.RepairPerformed -= Stats.RecordRepair;
+            RunStatsEvents.HealthRestored -= Stats.RecordHealthRestored;
+            RunStatsEvents.GoldEarned -= Stats.RecordGoldEarned;
+            RunStatsEvents.GoldSpent -= Stats.RecordGoldSpent;
+            isTracking = false;
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Stats/RunStatsTracker.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Stats/RunStatsTracker.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6c7bfa03089248eea3e830cdb208b4de

--- a/Assets/_Project/_Tests/EditMode/Stats.meta
+++ b/Assets/_Project/_Tests/EditMode/Stats.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 57c74f3005e145098a288c4713f21c8a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/_Tests/EditMode/Stats/HealthRunStatsRegressionTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Stats/HealthRunStatsRegressionTests.cs
@@ -1,0 +1,39 @@
+using Castlebound.Gameplay.Stats;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Castlebound.Tests.Stats
+{
+    public class HealthRunStatsRegressionTests
+    {
+        private GameObject player;
+        private int restored;
+
+        [TearDown]
+        public void TearDown()
+        {
+            RunStatsEvents.HealthRestored -= RecordHealthRestored;
+            if (player != null)
+                Object.DestroyImmediate(player);
+        }
+
+        [Test]
+        public void Heal_Overheal_RaisesOnlyActualHealthRestored()
+        {
+            RunStatsEvents.HealthRestored += RecordHealthRestored;
+            player = new GameObject("Player") { tag = "Player" };
+            var health = player.AddComponent<Health>();
+            health.ConfigureMaxHealth(10, true);
+            health.TakeDamage(3);
+
+            health.Heal(10);
+
+            Assert.That(restored, Is.EqualTo(3));
+        }
+
+        private void RecordHealthRestored(int amount)
+        {
+            restored += amount;
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Stats/HealthRunStatsRegressionTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Stats/HealthRunStatsRegressionTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d4743ef1df18435c983c5446070620a3

--- a/Assets/_Project/_Tests/EditMode/Stats/RunStatsTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Stats/RunStatsTests.cs
@@ -1,0 +1,115 @@
+using Castlebound.Gameplay.Stats;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Castlebound.Tests.Stats
+{
+    public class RunStatsTests
+    {
+        [Test]
+        public void NewStats_StartAtZero()
+        {
+            var stats = new RunStats();
+
+            Assert.That(stats.WavesSurvived, Is.Zero);
+            Assert.That(stats.EnemiesKilled, Is.Zero);
+            Assert.That(stats.DamageDealt, Is.Zero);
+            Assert.That(stats.RepairsPerformed, Is.Zero);
+            Assert.That(stats.HealthRestored, Is.Zero);
+            Assert.That(stats.GoldEarned, Is.Zero);
+            Assert.That(stats.GoldSpent, Is.Zero);
+        }
+
+        [Test]
+        public void RecordMethods_AccumulateConfirmedOutcomes()
+        {
+            var stats = new RunStats();
+
+            stats.RecordWaveSurvived();
+            stats.RecordWaveSurvived();
+            stats.RecordEnemyKilled();
+            stats.RecordDamageDealt(4);
+            stats.RecordDamageDealt(6);
+            stats.RecordRepair();
+            stats.RecordHealthRestored(3);
+            stats.RecordGoldEarned(8);
+            stats.RecordGoldSpent(5);
+
+            Assert.That(stats.WavesSurvived, Is.EqualTo(2));
+            Assert.That(stats.EnemiesKilled, Is.EqualTo(1));
+            Assert.That(stats.DamageDealt, Is.EqualTo(10));
+            Assert.That(stats.RepairsPerformed, Is.EqualTo(1));
+            Assert.That(stats.HealthRestored, Is.EqualTo(3));
+            Assert.That(stats.GoldEarned, Is.EqualTo(8));
+            Assert.That(stats.GoldSpent, Is.EqualTo(5));
+        }
+
+        [Test]
+        public void RecordAmounts_IgnoreNonPositiveValues()
+        {
+            var stats = new RunStats();
+
+            stats.RecordDamageDealt(-2);
+            stats.RecordHealthRestored(0);
+            stats.RecordGoldEarned(-1);
+            stats.RecordGoldSpent(0);
+
+            Assert.That(stats.DamageDealt, Is.Zero);
+            Assert.That(stats.HealthRestored, Is.Zero);
+            Assert.That(stats.GoldEarned, Is.Zero);
+            Assert.That(stats.GoldSpent, Is.Zero);
+        }
+
+        [Test]
+        public void StartingCurrency_IsNotReportedAsGoldEarned()
+        {
+            int earned = 0;
+            RunStatsEvents.GoldEarned += RecordEarned;
+            try
+            {
+                var inventory = new Castlebound.Gameplay.Inventory.InventoryState(25);
+                Assert.That(inventory.Gold, Is.EqualTo(25));
+                Assert.That(earned, Is.Zero);
+            }
+            finally
+            {
+                RunStatsEvents.GoldEarned -= RecordEarned;
+            }
+
+            void RecordEarned(int amount) => earned += amount;
+        }
+
+        [Test]
+        public void Tracker_CollectsRuntimeOutcomeEvents()
+        {
+            var gameObject = new GameObject("RunStatsTracker");
+            RunStatsTracker tracker = null;
+            try
+            {
+                tracker = gameObject.AddComponent<RunStatsTracker>();
+                tracker.BeginTracking();
+
+                RunStatsEvents.RaiseWaveSurvived();
+                RunStatsEvents.RaiseEnemyKilled();
+                RunStatsEvents.RaiseDamageDealt(7);
+                RunStatsEvents.RaiseRepairPerformed();
+                RunStatsEvents.RaiseHealthRestored(2);
+                RunStatsEvents.RaiseGoldEarned(9);
+                RunStatsEvents.RaiseGoldSpent(4);
+
+                Assert.That(tracker.Stats.WavesSurvived, Is.EqualTo(1));
+                Assert.That(tracker.Stats.EnemiesKilled, Is.EqualTo(1));
+                Assert.That(tracker.Stats.DamageDealt, Is.EqualTo(7));
+                Assert.That(tracker.Stats.RepairsPerformed, Is.EqualTo(1));
+                Assert.That(tracker.Stats.HealthRestored, Is.EqualTo(2));
+                Assert.That(tracker.Stats.GoldEarned, Is.EqualTo(9));
+                Assert.That(tracker.Stats.GoldSpent, Is.EqualTo(4));
+            }
+            finally
+            {
+                tracker?.StopTracking();
+                Object.DestroyImmediate(gameObject);
+            }
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Stats/RunStatsTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Stats/RunStatsTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f8046f65b1fa439c899217890e438a8e

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,24 @@
 
 ---
 
+## 2026-07-15 - codex-stats-run-stats-tracking-service
+
+### Summary
+- Added run counters for waves survived, enemies killed, damage dealt, repairs, health restored, and gold flow.
+- Connected counters to confirmed gameplay outcomes through a lightweight runtime event relay.
+- Excluded overheal and starting currency from earned run totals.
+
+### New or Updated Tests
+**EditMode**
+- `RunStatsTests` — validates zero initialization, accumulation, wave survival, invalid amounts, and starting currency semantics.
+- `HealthRunStatsRegressionTests` — validates health-restored stats count actual recovery without overheal.
+
+**PlayMode**
+- N/A — runtime wiring is installed by the existing `GameManager` without scene changes.
+
+### Notes
+- N/A
+
 ## 2026-07-14 - codex-spawning-lurker-enemy-type
 
 ### Summary


### PR DESCRIPTION
## Why
Track confirmed gameplay outcomes during each run so a future failure summary can present meaningful performance statistics.

## What changed
- Added counters for waves survived, enemies killed, damage dealt, repairs performed, health restored, gold earned, and gold spent
- Connected tracking to confirmed gameplay outcomes through a lightweight event relay
- Counted actual health recovery without overheal and excluded starting gold from earned gold
- Exposed the run statistics through the existing game manager
- Added EditMode coverage for the stats model and runtime tracking contracts

## How to test
1. Open the MainPrototype scene
2. Press Play → complete gameplay actions and verify run counters update through `GameManager.I.RunStatsTracker.Stats`
3. Run tests:
   - EditMode
   - PlayMode (manual runtime validation used because no scene wiring changed)

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated (N/A - no scene changes required)
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched

## Related
- Closes #100