### PR TITLE
feat(ui): add complete failure run summary

### DIFF
--- a/Assets/_Project/Scenes/MainPrototype.unity
+++ b/Assets/_Project/Scenes/MainPrototype.unity
@@ -2471,6 +2471,7 @@ GameObject:
   - component: {fileID: 904751788}
   - component: {fileID: 904751787}
   - component: {fileID: 904751789}
+  - component: {fileID: 904751790}
   m_Layer: 5
   m_Name: GameOver
   m_TagString: Untagged
@@ -2616,6 +2617,21 @@ MonoBehaviour:
   restartButtonSprite: {fileID: 21300000, guid: b2831b7f6899ee944a13fa562e3b84df, type: 3}
   restartButtonText: Rise Again
   restartButtonTextColor: {r: 0.84, g: 0.95, b: 1, a: 1}
+--- !u!114 &904751790
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 904751785}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 82dbf3f13d5c44a084b9cc10a3c22da2, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  summaryText: {fileID: 904751787}
+  panelColor: {r: 0.16, g: 0.18, b: 0.2, a: 0.96}
+  textColor: {r: 0.86, g: 0.88, b: 0.9, a: 1}
 --- !u!1 &977390122
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/_Project/Scenes/SampleScene.unity
+++ b/Assets/_Project/Scenes/SampleScene.unity
@@ -1260,6 +1260,7 @@ GameObject:
   - component: {fileID: 904751788}
   - component: {fileID: 904751787}
   - component: {fileID: 904751789}
+  - component: {fileID: 904751790}
   m_Layer: 5
   m_Name: GameOver
   m_TagString: Untagged
@@ -1405,6 +1406,21 @@ MonoBehaviour:
   restartButtonSprite: {fileID: 0}
   restartButtonText: Rise Again
   restartButtonTextColor: {r: 0.84, g: 0.95, b: 1, a: 1}
+--- !u!114 &904751790
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 904751785}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 82dbf3f13d5c44a084b9cc10a3c22da2, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  summaryText: {fileID: 904751787}
+  panelColor: {r: 0.16, g: 0.18, b: 0.2, a: 0.96}
+  textColor: {r: 0.86, g: 0.88, b: 0.9, a: 1}
 --- !u!1 &969171467
 GameObject:
   m_ObjectHideFlags: 0
@@ -3224,4 +3240,3 @@ SceneRoots:
   - {fileID: 833814061}
   - {fileID: 1027969717}
   - {fileID: 751719342}
-

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/Health.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/Health.cs
@@ -37,6 +37,8 @@ public class Health : MonoBehaviour, IDamageable, IHealable
 
         if (CompareTag("Enemy"))
             RunStatsEvents.RaiseDamageDealt(previous - current);
+        else if (CompareTag("Player"))
+            RunStatsEvents.RaiseDamageTaken(previous - current);
 
         if (CompareTag("Player") && playerHitFeedbackChannel != null)
         {
@@ -65,6 +67,9 @@ public class Health : MonoBehaviour, IDamageable, IHealable
         if (CompareTag("Player"))
             GameManager.I?.OnPlayerDied();
 
-        Destroy(gameObject);
+        if (Application.isPlaying)
+            Destroy(gameObject);
+        else
+            DestroyImmediate(gameObject);
     }
 }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Managers/GameManager.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Managers/GameManager.cs
@@ -36,7 +36,7 @@ public class GameManager : MonoBehaviour
 
         if (gameOverScreenController != null)
         {
-            gameOverScreenController.Show();
+            gameOverScreenController.Show(RunStatsTracker?.Stats);
         }
         else if (gameOverUI)
         {

--- a/Assets/_Project/Scripts/_Project.Gameplay/Stats/RunStats.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Stats/RunStats.cs
@@ -5,6 +5,7 @@ namespace Castlebound.Gameplay.Stats
         public int WavesSurvived { get; private set; }
         public int EnemiesKilled { get; private set; }
         public int DamageDealt { get; private set; }
+        public int DamageTaken { get; private set; }
         public int RepairsPerformed { get; private set; }
         public int HealthRestored { get; private set; }
         public int GoldEarned { get; private set; }
@@ -14,6 +15,7 @@ namespace Castlebound.Gameplay.Stats
         public void RecordEnemyKilled() => EnemiesKilled++;
         public void RecordRepair() => RepairsPerformed++;
         public void RecordDamageDealt(int amount) => DamageDealt += Positive(amount);
+        public void RecordDamageTaken(int amount) => DamageTaken += Positive(amount);
         public void RecordHealthRestored(int amount) => HealthRestored += Positive(amount);
         public void RecordGoldEarned(int amount) => GoldEarned += Positive(amount);
         public void RecordGoldSpent(int amount) => GoldSpent += Positive(amount);

--- a/Assets/_Project/Scripts/_Project.Gameplay/Stats/RunStatsEvents.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Stats/RunStatsEvents.cs
@@ -8,6 +8,7 @@ namespace Castlebound.Gameplay.Stats
         public static event Action EnemyKilled;
         public static event Action RepairPerformed;
         public static event Action<int> DamageDealt;
+        public static event Action<int> DamageTaken;
         public static event Action<int> HealthRestored;
         public static event Action<int> GoldEarned;
         public static event Action<int> GoldSpent;
@@ -16,6 +17,7 @@ namespace Castlebound.Gameplay.Stats
         public static void RaiseEnemyKilled() => EnemyKilled?.Invoke();
         public static void RaiseRepairPerformed() => RepairPerformed?.Invoke();
         public static void RaiseDamageDealt(int amount) => DamageDealt?.Invoke(amount);
+        public static void RaiseDamageTaken(int amount) => DamageTaken?.Invoke(amount);
         public static void RaiseHealthRestored(int amount) => HealthRestored?.Invoke(amount);
         public static void RaiseGoldEarned(int amount) => GoldEarned?.Invoke(amount);
         public static void RaiseGoldSpent(int amount) => GoldSpent?.Invoke(amount);

--- a/Assets/_Project/Scripts/_Project.Gameplay/Stats/RunStatsTracker.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Stats/RunStatsTracker.cs
@@ -21,6 +21,7 @@ namespace Castlebound.Gameplay.Stats
             RunStatsEvents.WaveSurvived += Stats.RecordWaveSurvived;
             RunStatsEvents.EnemyKilled += Stats.RecordEnemyKilled;
             RunStatsEvents.DamageDealt += Stats.RecordDamageDealt;
+            RunStatsEvents.DamageTaken += Stats.RecordDamageTaken;
             RunStatsEvents.RepairPerformed += Stats.RecordRepair;
             RunStatsEvents.HealthRestored += Stats.RecordHealthRestored;
             RunStatsEvents.GoldEarned += Stats.RecordGoldEarned;
@@ -41,6 +42,7 @@ namespace Castlebound.Gameplay.Stats
             RunStatsEvents.WaveSurvived -= Stats.RecordWaveSurvived;
             RunStatsEvents.EnemyKilled -= Stats.RecordEnemyKilled;
             RunStatsEvents.DamageDealt -= Stats.RecordDamageDealt;
+            RunStatsEvents.DamageTaken -= Stats.RecordDamageTaken;
             RunStatsEvents.RepairPerformed -= Stats.RecordRepair;
             RunStatsEvents.HealthRestored -= Stats.RecordHealthRestored;
             RunStatsEvents.GoldEarned -= Stats.RecordGoldEarned;

--- a/Assets/_Project/Scripts/_Project.Gameplay/UI/GameOverScreenController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/UI/GameOverScreenController.cs
@@ -2,6 +2,7 @@ using TMPro;
 using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.UI;
+using Castlebound.Gameplay.Stats;
 
 namespace Castlebound.Gameplay.UI
 {
@@ -13,6 +14,7 @@ namespace Castlebound.Gameplay.UI
         [SerializeField] private Color restartButtonTextColor = new Color(0.84f, 0.95f, 1f, 1f);
 
         private UnityAction restartHandler;
+        private RunSummaryPresenter summaryPresenter;
 
         private void OnEnable()
         {
@@ -47,6 +49,13 @@ namespace Castlebound.Gameplay.UI
             gameObject.SetActive(true);
         }
 
+        public void Show(RunStats stats)
+        {
+            gameObject.SetActive(true);
+            ResolveSummaryPresenter();
+            summaryPresenter?.Present(stats);
+        }
+
         private void BindRestartHandler()
         {
             if (restartButton == null || restartHandler == null)
@@ -71,14 +80,22 @@ namespace Castlebound.Gameplay.UI
             }
         }
 
+        private void ResolveSummaryPresenter()
+        {
+            if (summaryPresenter == null)
+                summaryPresenter = GetComponent<RunSummaryPresenter>();
+            if (summaryPresenter == null)
+                summaryPresenter = gameObject.AddComponent<RunSummaryPresenter>();
+        }
+
         private static Button CreateDefaultRestartButton(Transform parent)
         {
             var buttonObject = new GameObject("RestartButton", typeof(RectTransform), typeof(Image), typeof(Button));
             buttonObject.transform.SetParent(parent, false);
 
             var rect = buttonObject.GetComponent<RectTransform>();
-            rect.anchorMin = new Vector2(0.5f, 0.2f);
-            rect.anchorMax = new Vector2(0.5f, 0.2f);
+            rect.anchorMin = new Vector2(0.5f, 0.14f);
+            rect.anchorMax = new Vector2(0.5f, 0.14f);
             rect.pivot = new Vector2(0.5f, 0.5f);
             rect.sizeDelta = new Vector2(300f, 92f);
 

--- a/Assets/_Project/Scripts/_Project.Gameplay/UI/RunSummaryFormatter.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/UI/RunSummaryFormatter.cs
@@ -1,0 +1,27 @@
+using Castlebound.Gameplay.Stats;
+
+namespace Castlebound.Gameplay.UI
+{
+    public static class RunSummaryFormatter
+    {
+        private const string ValueColor = "#78D68A";
+
+        public static string Format(RunStats stats)
+        {
+            stats ??= new RunStats();
+            return $"<b>RUN SUMMARY</b>\n\n" +
+                   Line("Waves Survived", stats.WavesSurvived) +
+                   Line("Enemies Defeated", stats.EnemiesKilled) +
+                   Line("Damage Dealt", stats.DamageDealt) +
+                   Line("Damage Taken", stats.DamageTaken) +
+                   Line("Repairs Made", stats.RepairsPerformed) +
+                   Line("Health Restored", stats.HealthRestored) +
+                   Line("Gold Earned", stats.GoldEarned) +
+                   Line("Gold Spent", stats.GoldSpent) +
+                   "\nRise again. The castle still stands.";
+        }
+
+        private static string Line(string label, int value) =>
+            $"{label}    <color={ValueColor}><b>{value}</b></color>\n";
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/UI/RunSummaryFormatter.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/UI/RunSummaryFormatter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7adf1b2e94b744e2b77805b4b1a87a14

--- a/Assets/_Project/Scripts/_Project.Gameplay/UI/RunSummaryPresenter.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/UI/RunSummaryPresenter.cs
@@ -1,0 +1,79 @@
+using Castlebound.Gameplay.Stats;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Castlebound.Gameplay.UI
+{
+    public sealed class RunSummaryPresenter : MonoBehaviour
+    {
+        [SerializeField] private TextMeshProUGUI summaryText;
+        [SerializeField] private Color panelColor = new Color(0.16f, 0.18f, 0.20f, 0.96f);
+        [SerializeField] private Color textColor = new Color(0.86f, 0.88f, 0.90f, 1f);
+
+        private RectTransform panelRect;
+
+        public void Present(RunStats stats)
+        {
+            EnsureText();
+            if (summaryText == null)
+                return;
+
+            summaryText.text = RunSummaryFormatter.Format(stats);
+            summaryText.color = textColor;
+            summaryText.alignment = TextAlignmentOptions.Center;
+            summaryText.enableAutoSizing = true;
+            summaryText.fontSizeMin = 18f;
+            summaryText.fontSizeMax = 36f;
+            summaryText.enableWordWrapping = false;
+
+            var rect = summaryText.rectTransform;
+            rect.anchorMin = new Vector2(0.06f, 0.06f);
+            rect.anchorMax = new Vector2(0.94f, 0.94f);
+            rect.offsetMin = Vector2.zero;
+            rect.offsetMax = Vector2.zero;
+        }
+
+        private void EnsureText()
+        {
+            if (panelRect == null)
+                CreatePanel();
+
+            if (summaryText == null || summaryText.transform == transform)
+                CreateSummaryText();
+        }
+
+        private void CreatePanel()
+        {
+            if (transform is RectTransform rootRect)
+            {
+                rootRect.anchorMin = new Vector2(0.04f, 0.04f);
+                rootRect.anchorMax = new Vector2(0.96f, 0.96f);
+                rootRect.offsetMin = Vector2.zero;
+                rootRect.offsetMax = Vector2.zero;
+            }
+
+            var panelObject = new GameObject("RunSummaryPanel", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image));
+            panelObject.transform.SetParent(transform, false);
+            panelRect = panelObject.GetComponent<RectTransform>();
+            panelRect.anchorMin = new Vector2(0.12f, 0.28f);
+            panelRect.anchorMax = new Vector2(0.88f, 0.88f);
+            panelRect.offsetMin = Vector2.zero;
+            panelRect.offsetMax = Vector2.zero;
+            panelObject.GetComponent<Image>().color = panelColor;
+        }
+
+        private void CreateSummaryText()
+        {
+            var authoredText = summaryText != null ? summaryText : GetComponent<TextMeshProUGUI>();
+            if (authoredText != null)
+                authoredText.enabled = false;
+
+            var textObject = new GameObject("RunSummaryText", typeof(RectTransform), typeof(TextMeshProUGUI));
+            textObject.transform.SetParent(panelRect, false);
+            summaryText = textObject.GetComponent<TextMeshProUGUI>();
+            if (authoredText != null)
+                summaryText.font = authoredText.font;
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/UI/RunSummaryPresenter.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/UI/RunSummaryPresenter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 82dbf3f13d5c44a084b9cc10a3c22da2

--- a/Assets/_Project/_Tests/EditMode/Stats/DamageTakenRunStatsRegressionTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Stats/DamageTakenRunStatsRegressionTests.cs
@@ -1,0 +1,35 @@
+using Castlebound.Gameplay.Stats;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Castlebound.Tests.Stats
+{
+    public class DamageTakenRunStatsRegressionTests
+    {
+        private GameObject player;
+        private int damageTaken;
+
+        [TearDown]
+        public void TearDown()
+        {
+            RunStatsEvents.DamageTaken -= RecordDamageTaken;
+            if (player != null)
+                Object.DestroyImmediate(player);
+        }
+
+        [Test]
+        public void LethalDamage_RaisesOnlyActualHealthLost()
+        {
+            RunStatsEvents.DamageTaken += RecordDamageTaken;
+            player = new GameObject("Player") { tag = "Player" };
+            var health = player.AddComponent<Health>();
+            health.ConfigureMaxHealth(10, true);
+
+            health.TakeDamage(50);
+
+            Assert.That(damageTaken, Is.EqualTo(10));
+        }
+
+        private void RecordDamageTaken(int amount) => damageTaken += amount;
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Stats/DamageTakenRunStatsRegressionTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Stats/DamageTakenRunStatsRegressionTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: af65c1eef78d4165ab0921a9a25fb79a

--- a/Assets/_Project/_Tests/EditMode/Stats/RunStatsTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Stats/RunStatsTests.cs
@@ -14,6 +14,7 @@ namespace Castlebound.Tests.Stats
             Assert.That(stats.WavesSurvived, Is.Zero);
             Assert.That(stats.EnemiesKilled, Is.Zero);
             Assert.That(stats.DamageDealt, Is.Zero);
+            Assert.That(stats.DamageTaken, Is.Zero);
             Assert.That(stats.RepairsPerformed, Is.Zero);
             Assert.That(stats.HealthRestored, Is.Zero);
             Assert.That(stats.GoldEarned, Is.Zero);
@@ -30,6 +31,7 @@ namespace Castlebound.Tests.Stats
             stats.RecordEnemyKilled();
             stats.RecordDamageDealt(4);
             stats.RecordDamageDealt(6);
+            stats.RecordDamageTaken(3);
             stats.RecordRepair();
             stats.RecordHealthRestored(3);
             stats.RecordGoldEarned(8);
@@ -38,6 +40,7 @@ namespace Castlebound.Tests.Stats
             Assert.That(stats.WavesSurvived, Is.EqualTo(2));
             Assert.That(stats.EnemiesKilled, Is.EqualTo(1));
             Assert.That(stats.DamageDealt, Is.EqualTo(10));
+            Assert.That(stats.DamageTaken, Is.EqualTo(3));
             Assert.That(stats.RepairsPerformed, Is.EqualTo(1));
             Assert.That(stats.HealthRestored, Is.EqualTo(3));
             Assert.That(stats.GoldEarned, Is.EqualTo(8));
@@ -50,11 +53,13 @@ namespace Castlebound.Tests.Stats
             var stats = new RunStats();
 
             stats.RecordDamageDealt(-2);
+            stats.RecordDamageTaken(0);
             stats.RecordHealthRestored(0);
             stats.RecordGoldEarned(-1);
             stats.RecordGoldSpent(0);
 
             Assert.That(stats.DamageDealt, Is.Zero);
+            Assert.That(stats.DamageTaken, Is.Zero);
             Assert.That(stats.HealthRestored, Is.Zero);
             Assert.That(stats.GoldEarned, Is.Zero);
             Assert.That(stats.GoldSpent, Is.Zero);
@@ -92,6 +97,7 @@ namespace Castlebound.Tests.Stats
                 RunStatsEvents.RaiseWaveSurvived();
                 RunStatsEvents.RaiseEnemyKilled();
                 RunStatsEvents.RaiseDamageDealt(7);
+                RunStatsEvents.RaiseDamageTaken(5);
                 RunStatsEvents.RaiseRepairPerformed();
                 RunStatsEvents.RaiseHealthRestored(2);
                 RunStatsEvents.RaiseGoldEarned(9);
@@ -100,6 +106,7 @@ namespace Castlebound.Tests.Stats
                 Assert.That(tracker.Stats.WavesSurvived, Is.EqualTo(1));
                 Assert.That(tracker.Stats.EnemiesKilled, Is.EqualTo(1));
                 Assert.That(tracker.Stats.DamageDealt, Is.EqualTo(7));
+                Assert.That(tracker.Stats.DamageTaken, Is.EqualTo(5));
                 Assert.That(tracker.Stats.RepairsPerformed, Is.EqualTo(1));
                 Assert.That(tracker.Stats.HealthRestored, Is.EqualTo(2));
                 Assert.That(tracker.Stats.GoldEarned, Is.EqualTo(9));

--- a/Assets/_Project/_Tests/EditMode/UI/RunSummaryFormatterTests.cs
+++ b/Assets/_Project/_Tests/EditMode/UI/RunSummaryFormatterTests.cs
@@ -22,7 +22,7 @@ namespace Castlebound.Tests.UI
             string summary = RunSummaryFormatter.Format(stats);
 
             StringAssert.Contains("Waves Survived    <color=#78D68A><b>1</b></color>", summary);
-            StringAssert.Contains("Enemies Defeated  <color=#78D68A><b>1</b></color>", summary);
+            StringAssert.Contains("Enemies Defeated    <color=#78D68A><b>1</b></color>", summary);
             StringAssert.Contains("Damage Dealt    <color=#78D68A><b>2</b></color>", summary);
             StringAssert.Contains("Damage Taken    <color=#78D68A><b>3</b></color>", summary);
             StringAssert.Contains("Repairs Made    <color=#78D68A><b>1</b></color>", summary);

--- a/Assets/_Project/_Tests/EditMode/UI/RunSummaryFormatterTests.cs
+++ b/Assets/_Project/_Tests/EditMode/UI/RunSummaryFormatterTests.cs
@@ -1,0 +1,34 @@
+using Castlebound.Gameplay.Stats;
+using Castlebound.Gameplay.UI;
+using NUnit.Framework;
+
+namespace Castlebound.Tests.UI
+{
+    public class RunSummaryFormatterTests
+    {
+        [Test]
+        public void Format_MapsEveryRunStatToSummary()
+        {
+            var stats = new RunStats();
+            stats.RecordWaveSurvived();
+            stats.RecordEnemyKilled();
+            stats.RecordDamageDealt(2);
+            stats.RecordDamageTaken(3);
+            stats.RecordRepair();
+            stats.RecordHealthRestored(4);
+            stats.RecordGoldEarned(5);
+            stats.RecordGoldSpent(6);
+
+            string summary = RunSummaryFormatter.Format(stats);
+
+            StringAssert.Contains("Waves Survived    <color=#78D68A><b>1</b></color>", summary);
+            StringAssert.Contains("Enemies Defeated  <color=#78D68A><b>1</b></color>", summary);
+            StringAssert.Contains("Damage Dealt    <color=#78D68A><b>2</b></color>", summary);
+            StringAssert.Contains("Damage Taken    <color=#78D68A><b>3</b></color>", summary);
+            StringAssert.Contains("Repairs Made    <color=#78D68A><b>1</b></color>", summary);
+            StringAssert.Contains("Health Restored    <color=#78D68A><b>4</b></color>", summary);
+            StringAssert.Contains("Gold Earned    <color=#78D68A><b>5</b></color>", summary);
+            StringAssert.Contains("Gold Spent    <color=#78D68A><b>6</b></color>", summary);
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/UI/RunSummaryFormatterTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/UI/RunSummaryFormatterTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c4e9732619d34f22a8de8b9906d226e5

--- a/Assets/_Project/_Tests/PlayMode/Smoke/DeathScreenRestartPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/Smoke/DeathScreenRestartPlayTests.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.TestTools;
+using TMPro;
 
 namespace Castlebound.Tests.PlayMode.UI
 {
@@ -31,6 +32,27 @@ namespace Castlebound.Tests.PlayMode.UI
 
             Assert.That(buttonComponents.Length, Is.GreaterThan(0),
                 "Death screen should include a tappable Restart button.");
+        }
+
+        [UnityTest]
+        public IEnumerator OnPlayerDied_GameOverUiDisplaysRunSummary()
+        {
+            yield return LoadMainPrototype();
+
+            var manager = Object.FindObjectOfType<GameManager>();
+            manager.RunStatsTracker.Stats.RecordWaveSurvived();
+            manager.RunStatsTracker.Stats.RecordEnemyKilled();
+            manager.RunStatsTracker.Stats.RecordDamageDealt(7);
+
+            manager.OnPlayerDied();
+
+            var summary = GetGameOverUi(manager)
+                .GetComponentsInChildren<TextMeshProUGUI>(true)
+                .FirstOrDefault(text => text.text.Contains("RUN SUMMARY"));
+            Assert.NotNull(summary);
+            StringAssert.Contains("Waves Survived", summary.text);
+            StringAssert.Contains("Enemies Defeated", summary.text);
+            StringAssert.Contains("Damage Dealt", summary.text);
         }
 
         private static IEnumerator LoadMainPrototype()

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,25 @@
 
 ---
 
+## 2026-07-15 - codex-ui-failure-run-summary
+
+### Summary
+- Added a complete run summary to the failure screen for issues #96 and #99.
+- Added actual player damage-taken tracking, including lethal overkill clamping.
+- Preserved the existing Rise Again restart flow while rendering the summary only on failure.
+
+### New or Updated Tests
+**EditMode**
+- `RunStatsTests` — covers damage-taken initialization, accumulation, validation, and runtime relay tracking.
+- `DamageTakenRunStatsRegressionTests` — validates lethal damage records only actual player health lost.
+- `RunSummaryFormatterTests` — validates every run statistic maps to the failure summary.
+
+**PlayMode**
+- `DeathScreenRestartPlayTests` — validates the death screen displays populated run summary values and retains its tappable restart button.
+
+### Notes
+- N/A
+
 ## 2026-07-15 - codex-stats-run-stats-tracking-service
 
 ### Summary


### PR DESCRIPTION
## Why
Make failure clear and meaningful by showing the player what they accomplished during the completed run.

## What changed
- Added a neutral mobile-friendly run summary panel to the failure screen
- Displayed waves survived, enemies defeated, damage dealt, damage taken, repairs, health restored, gold earned, and gold spent
- Added actual player damage-taken tracking with lethal overkill clamping
- Styled statistic values in green and positioned the existing Rise Again button below the panel
- Preserved the existing touch and keyboard restart paths
- Populated the summary once when failure opens, with no per-frame UI processing

## How to test
1. Open `MainPrototype`
2. Play a run and perform combat, repair, healing, and economy actions
3. Lose the run and verify the failure summary values and layout
4. Verify the Rise Again button remains below the panel and restarts the scene
5. Run EditMode and PlayMode tests

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched

## Related
- Closes #96
- Closes #99