### PR TITLE
feat(ui): complete meaningful failure milestone

### DIFF
--- a/Assets/_Project/Scripts/_Project.Gameplay/UI/RunSummaryFormatter.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/UI/RunSummaryFormatter.cs
@@ -18,7 +18,7 @@ namespace Castlebound.Gameplay.UI
                    Line("Health Restored", stats.HealthRestored) +
                    Line("Gold Earned", stats.GoldEarned) +
                    Line("Gold Spent", stats.GoldSpent) +
-                   "\nRise again. The castle still stands.";
+                   "\nEnduring loss reveals the path to mastery.";
         }
 
         private static string Line(string label, int value) =>

--- a/Assets/_Project/_Tests/EditMode/UI/RunSummaryFormatterTests.cs
+++ b/Assets/_Project/_Tests/EditMode/UI/RunSummaryFormatterTests.cs
@@ -29,6 +29,8 @@ namespace Castlebound.Tests.UI
             StringAssert.Contains("Health Restored    <color=#78D68A><b>4</b></color>", summary);
             StringAssert.Contains("Gold Earned    <color=#78D68A><b>5</b></color>", summary);
             StringAssert.Contains("Gold Spent    <color=#78D68A><b>6</b></color>", summary);
+            StringAssert.Contains("Enduring loss reveals the path to mastery.", summary);
+            StringAssert.DoesNotContain("Rise again. The castle still stands.", summary);
         }
     }
 }

--- a/Assets/_Project/_Tests/PlayMode/Smoke/DeathScreenRestartPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/Smoke/DeathScreenRestartPlayTests.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.TestTools;
 using TMPro;
+using UnityEngine.UI;
 
 namespace Castlebound.Tests.PlayMode.UI
 {
@@ -53,6 +54,38 @@ namespace Castlebound.Tests.PlayMode.UI
             StringAssert.Contains("Waves Survived", summary.text);
             StringAssert.Contains("Enemies Defeated", summary.text);
             StringAssert.Contains("Damage Dealt", summary.text);
+        }
+
+        [UnityTest]
+        public IEnumerator RiseAgainButton_ReloadsCurrentScene()
+        {
+            yield return LoadMainPrototype();
+
+            var manager = Object.FindObjectOfType<GameManager>();
+            Assert.NotNull(manager);
+            int previousManagerId = manager.GetInstanceID();
+
+            manager.OnPlayerDied();
+
+            var button = GetGameOverUi(manager).GetComponentInChildren<Button>(true);
+            Assert.NotNull(button, "Expected the Rise Again button on the failure screen.");
+
+            button.onClick.Invoke();
+
+            GameManager reloadedManager = null;
+            for (int frame = 0; frame < 120; frame++)
+            {
+                yield return null;
+                reloadedManager = Object.FindObjectOfType<GameManager>();
+                if (reloadedManager != null && reloadedManager.GetInstanceID() != previousManagerId)
+                {
+                    break;
+                }
+            }
+
+            Assert.That(SceneManager.GetActiveScene().name, Is.EqualTo("MainPrototype"));
+            Assert.NotNull(reloadedManager, "Restart should load a fresh GameManager.");
+            Assert.That(reloadedManager.GetInstanceID(), Is.Not.EqualTo(previousManagerId));
         }
 
         private static IEnumerator LoadMainPrototype()

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,23 @@
 
 ---
 
+## 2026-07-16 - codex-ui-p5-meaningful-failure-closeout
+
+### Summary
+- Replaced duplicate Rise Again summary copy with the approved philosophical failure line.
+- Preserved the Rise Again button as the single restart call to action.
+- Strengthened fast-restart validation by exercising the actual failure-screen button.
+
+### New or Updated Tests
+**EditMode**
+- `RunSummaryFormatterTests` — validates the approved philosophical line and guards against duplicate Rise Again copy.
+
+**PlayMode**
+- `DeathScreenRestartPlayTests` — validates the Rise Again button reloads MainPrototype with a fresh GameManager.
+
+### Notes
+- N/A
+
 ## 2026-07-15 - codex-ui-failure-run-summary
 
 ### Summary


### PR DESCRIPTION
## Why
Complete P5 Meaningful Failure with a non-blaming philosophical line and verified fast restart flow.

## What changed
- Replaced duplicate Rise Again summary copy with Enduring loss reveals the path to mastery.
- Kept Rise Again as the single restart call to action.
- Added PlayMode coverage that presses the actual failure-screen button and verifies MainPrototype reloads with a fresh GameManager.
- Added regression coverage for the approved failure copy.

## How to test
1. Open MainPrototype.
2. Lose a run and verify the summary ends with the approved philosophical line.
3. Confirm Rise Again appears only on the button.
4. Press Rise Again and verify the scene restarts promptly.
5. Run EditMode and PlayMode tests.

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated (N/A - no scene changes required)
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched

## Related
- Closes #97
- Closes #98