### PR TITLE
refactor(ai): remove unused barrier release margin

### DIFF
--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyController2D.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyController2D.cs
@@ -16,10 +16,7 @@ public class EnemyController2D : MonoBehaviour
     public static bool ShouldHoldForBarrierTarget(
         float distanceToBarrier,
         bool barrierBroken,
-        float holdRadius,
-        float releaseMargin,
-        int distTrend,
-        int outrunFrames)
+        float holdRadius)
     {
         // For now, this is intentionally minimal:
         // - If the barrier is broken, enemies should *not* HOLD at the barrier.

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyMovement.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyMovement.cs
@@ -76,10 +76,7 @@ public static class EnemyMovement
             bool shouldHold = EnemyController2D.ShouldHoldForBarrierTarget(
                 distToBarrier,
                 barrierBroken,
-                effectiveHoldRadius,
-                releaseMargin,
-                distTrend,
-                outrunFrames);
+                effectiveHoldRadius);
 
             state = shouldHold ? EnemyController2D.State.HOLD : EnemyController2D.State.CHASE;
         }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Barrier/EnemyBarrierHoldBehavior.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Barrier/EnemyBarrierHoldBehavior.cs
@@ -6,10 +6,8 @@ namespace Castlebound.Gameplay.AI
     {
         [SerializeField] private Transform approachAnchor;
         [SerializeField] private float holdRadius = 2.6f;
-        [SerializeField] private float releaseMargin = 0.6f;
 
         public float HoldRadius => holdRadius;
-        public float ReleaseMargin => releaseMargin;
 
         public float DistanceToAnchor(Vector2 enemyPosition)
         {
@@ -22,16 +20,13 @@ namespace Castlebound.Gameplay.AI
             return approachAnchor != null ? (Vector2)approachAnchor.position : (Vector2)transform.position;
         }
 
-        public bool CanHold(Vector2 enemyPosition, bool barrierBroken, int distTrend, int outrunFrames)
+        public bool CanHold(Vector2 enemyPosition, bool barrierBroken)
         {
             float dist = DistanceToAnchor(enemyPosition);
             return EnemyController2D.ShouldHoldForBarrierTarget(
                 dist,
                 barrierBroken,
-                holdRadius,
-                releaseMargin,
-                distTrend,
-                outrunFrames);
+                holdRadius);
         }
 
         #region Debug/Test hooks
@@ -47,7 +42,7 @@ namespace Castlebound.Gameplay.AI
 
         public bool Debug_CanHold(Vector2 enemyPosition)
         {
-            return CanHold(enemyPosition, barrierBroken: false, distTrend: 0, outrunFrames: 0);
+            return CanHold(enemyPosition, barrierBroken: false);
         }
         #endregion
 

--- a/Assets/_Project/_Tests/EditMode/AI/EnemyBarrierHoldBehaviorTests.cs
+++ b/Assets/_Project/_Tests/EditMode/AI/EnemyBarrierHoldBehaviorTests.cs
@@ -11,10 +11,6 @@ namespace Castlebound.Tests.AI
         {
             // Arrange
             float holdRadius = 2.0f;
-            float releaseMargin = 0.5f;
-            int outrunFrames = 8;
-            int distTrend = 0;
-
             float distanceToBarrier = 1.0f; // inside hold radius
             bool barrierBroken = true;
 
@@ -22,10 +18,7 @@ namespace Castlebound.Tests.AI
             bool shouldHold = EnemyController2D.ShouldHoldForBarrierTarget(
                 distanceToBarrier,
                 barrierBroken,
-                holdRadius,
-                releaseMargin,
-                distTrend,
-                outrunFrames);
+                holdRadius);
 
             // Assert
             Assert.IsFalse(shouldHold,
@@ -37,10 +30,6 @@ namespace Castlebound.Tests.AI
         {
             // Arrange
             float holdRadius = 2.0f;
-            float releaseMargin = 0.5f;
-            int outrunFrames = 8;
-            int distTrend = 0;
-
             float distanceToBarrier = 1.0f; // inside hold radius
             bool barrierBroken = false;
 
@@ -48,14 +37,30 @@ namespace Castlebound.Tests.AI
             bool shouldHold = EnemyController2D.ShouldHoldForBarrierTarget(
                 distanceToBarrier,
                 barrierBroken,
-                holdRadius,
-                releaseMargin,
-                distTrend,
-                outrunFrames);
+                holdRadius);
 
             // Assert
             Assert.IsTrue(shouldHold,
                 "Enemy may enter HOLD at an intact barrier when within hold radius.");
+        }
+
+        [Test]
+        public void DoesNotHold_WhenBarrierIntact_AndOutsideHoldRadius()
+        {
+            // Arrange
+            float holdRadius = 2.0f;
+            float distanceToBarrier = 2.1f;
+            bool barrierBroken = false;
+
+            // Act
+            bool shouldHold = EnemyController2D.ShouldHoldForBarrierTarget(
+                distanceToBarrier,
+                barrierBroken,
+                holdRadius);
+
+            // Assert
+            Assert.IsFalse(shouldHold,
+                "Enemy should not hold at an intact barrier when outside the hold radius.");
         }
     }
 }

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,23 @@
 
 ---
 
+## 2026-07-16 - chore-44-remove-barrier-release-margin
+
+### Summary
+- Removed the unused barrier-specific release-margin configuration.
+- Narrowed barrier hold decisions to barrier state, distance, and hold radius.
+- Preserved controller release-margin hysteresis for non-barrier targets.
+
+### New or Updated Tests
+**EditMode**
+- `EnemyBarrierHoldBehaviorTests` — covers broken, inside-radius, and outside-radius barrier hold decisions using the narrowed contract.
+
+**PlayMode**
+- N/A — N/A
+
+### Notes
+- EditMode and PlayMode test suites passed; manual validation confirmed enemy behavior is unchanged.
+
 ## 2026-07-16 - codex-ui-p5-meaningful-failure-closeout
 
 ### Summary


### PR DESCRIPTION
## Why
Barrier hold behavior exposed a serialized release-margin setting and method parameters that were never used. Removing them clarifies the barrier hold contract without changing enemy movement behavior.

## What changed
- Removed the unused barrier-specific release-margin field and property
- Narrowed barrier hold decisions to distance, barrier state, and hold radius
- Preserved controller release-margin hysteresis for non-barrier targets
- Added outside-radius regression coverage and updated the test log

## How to test
1. Open the relevant enemy and barrier test scenes
2. Press Play and verify enemies retain their existing hold, chase, and surround behavior
3. Run tests:
   - EditMode
   - PlayMode

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated (N/A - no scene behavior or layout changed)
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched (N/A - TEST_LOG.md updated; no user documentation change required)

## Related
- Closes #44