### PR TITLE
fix(combat): prevent inside enemies damaging barriers

### DIFF
--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/EnemyAttack.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/EnemyAttack.cs
@@ -106,15 +106,6 @@ public class EnemyAttack : MonoBehaviour
             if (dmg == null)
                 continue;
 
-            // Skip barrier damage if gate logic disallows it.
-            var barrierHealth = c.GetComponentInParent<BarrierHealth>();
-            if (barrierHealth != null && controller.CurrentTargetType == EnemyTargetType.Barrier)
-            {
-                GetRegionState(out bool enemyInside, out bool playerInside);
-                if (!CanDamageBarrier(enemyInside, playerInside))
-                    continue;
-            }
-
             if (!uniqueTargets.Add(dmg))
                 continue;
 
@@ -137,6 +128,15 @@ public class EnemyAttack : MonoBehaviour
         if (target == null || Damage <= 0 || IsRooted())
         {
             return;
+        }
+
+        if (target is BarrierHealth)
+        {
+            GetRegionState(out bool enemyInside, out bool playerInside);
+            if (!CanDamageBarrier(enemyInside, playerInside))
+            {
+                return;
+            }
         }
 
         target.TakeDamage(Damage);

--- a/Assets/_Project/_Tests/EditMode/Combat/EnemyAttack/EnemyAttackTargetTypeTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Combat/EnemyAttack/EnemyAttackTargetTypeTests.cs
@@ -1,11 +1,18 @@
 using NUnit.Framework;
 using UnityEngine;
 using Castlebound.Gameplay.AI;
+using System.Reflection;
 
 namespace Castlebound.Tests.Combat
 {
     public class EnemyAttackTargetTypeTests
     {
+        private sealed class DummyDamageable : IDamageable
+        {
+            public int DamageTaken { get; private set; }
+            public void TakeDamage(int amount) => DamageTaken += amount;
+        }
+
         [Test]
         public void Attack_UsesBarrierGate_WhenTargetTypeIsBarrier()
         {
@@ -33,33 +40,38 @@ namespace Castlebound.Tests.Combat
         }
 
         [Test]
-        public void Attack_SkipsBarrierGate_WhenTargetTypeIsPlayer()
+        public void PlayerTargetedAttack_BlocksBarrierRecipient_WhenEnemyAndPlayerInside()
         {
             // Arrange
             var enemy = new GameObject("Enemy");
             var controller = enemy.AddComponent<EnemyController2D>();
+            var regionState = enemy.AddComponent<EnemyRegionState>();
             var attack = enemy.AddComponent<EnemyAttack>();
             var player = new GameObject("Player");
             player.tag = "Player";
-            player.AddComponent<BarrierHealth>(); // Would trigger old barrier-based gate check.
-
-            attack.Damage = 1;
+            var barrier = new GameObject("Barrier");
+            var barrierHealth = barrier.AddComponent<BarrierHealth>();
+            barrierHealth.MaxHealth = 5;
+            barrierHealth.CurrentHealth = 5;
+            var playerDamageable = new DummyDamageable();
 
             // Simulate selector decision: player target type.
             controller.Debug_SetupRefs(player.transform, null);
             SetControllerTargetForTest(controller, player.transform, EnemyTargetType.Player);
+            SetRegionState(regionState, enemyInside: true, playerInside: true);
 
             // Act
-            // Gate check shouldn't block when target type is player.
-            bool canDamage = true;
-            if (controller.CurrentTargetType == EnemyTargetType.Barrier)
-            {
-                canDamage = EnemyAttack.CanDamageBarrier(enemyInside: false, playerInside: false);
-            }
+            attack.DealDamage(barrierHealth);
+            attack.DealDamage(playerDamageable);
 
             // Assert
-            Assert.IsTrue(canDamage, "Player target type should not be treated as a barrier even if the target has BarrierHealth.");
+            Assert.That(controller.CurrentTargetType, Is.EqualTo(EnemyTargetType.Player));
+            Assert.That(barrierHealth.CurrentHealth, Is.EqualTo(5),
+                "A player-targeted swing must not damage an overlapping barrier when both actors are inside.");
+            Assert.That(playerDamageable.DamageTaken, Is.EqualTo(1),
+                "Inside/inside barrier gating must not block damage to non-barrier recipients.");
 
+            Object.DestroyImmediate(barrier);
             Object.DestroyImmediate(player);
             Object.DestroyImmediate(enemy);
         }
@@ -71,6 +83,13 @@ namespace Castlebound.Tests.Combat
             typeof(EnemyController2D)
                 .GetField("_currentTargetType", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
                 ?.SetValue(controller, targetType);
+        }
+
+        private static void SetRegionState(EnemyRegionState state, bool enemyInside, bool playerInside)
+        {
+            var type = typeof(EnemyRegionState);
+            type.GetField("enemyInside", BindingFlags.NonPublic | BindingFlags.Instance)?.SetValue(state, enemyInside);
+            type.GetField("playerInside", BindingFlags.NonPublic | BindingFlags.Instance)?.SetValue(state, playerInside);
         }
     }
 }

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,23 @@
 
 ---
 
+## 2026-07-16 - fix-42-inside-barrier-damage-gate
+
+### Summary
+- Blocked protected barrier recipients at the final enemy damage boundary.
+- Prevented player-targeted swings from damaging overlapping gates when both actors are inside.
+- Preserved damage to non-barrier recipients and legitimate outside barrier attacks.
+
+### New or Updated Tests
+**EditMode**
+- `EnemyAttackTargetTypeTests` — verifies a player-targeted attack blocks an inside barrier recipient without blocking non-barrier damage.
+
+**PlayMode**
+- N/A — N/A
+
+### Notes
+- EditMode and PlayMode test suites passed; manual validation confirmed enemies inside the castle do not damage barriers.
+
 ## 2026-07-16 - chore-44-remove-barrier-release-margin
 
 ### Summary


### PR DESCRIPTION
## Why
Player-targeted enemy attacks could damage nearby barriers as collateral when both the player and enemy were inside the castle. The existing gate only ran when the enemy's selected target type was Barrier, so player-targeted swings bypassed it.

## What changed
- Moved barrier gating to the final enemy damage boundary
- Applied the gate based on the damage recipient rather than selected target type
- Preserved player damage and legitimate outside barrier attacks
- Added regression coverage for player-targeted attacks overlapping barriers

## How to test
1. Place the player and an enemy inside the castle near a barrier
2. Press Play and verify enemy attacks damage the player but not the barrier
3. Run tests:
   - EditMode
   - PlayMode

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated (N/A - no scene changes required)
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched (N/A - TEST_LOG updated; no user documentation required)

## Related
- Closes #42