### PR TITLE
fix(combat): lock melee attacks to selected target

### DIFF
--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyController2D.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyController2D.cs
@@ -69,6 +69,8 @@ public class EnemyController2D : MonoBehaviour
     private int _distTrend;
     private float _gapCW;
     private float _gapCCW;
+    private bool _chaseRequested;
+    public bool IsChaseRequested => _chaseRequested;
     // Last non-zero direction toward our current target (for pass-through).
     private Vector2 _lastNonZeroDir = Vector2.right;
 
@@ -76,6 +78,17 @@ public class EnemyController2D : MonoBehaviour
     {
         _gapCW = gapCW;
         _gapCCW = gapCCW;
+    }
+
+    public void RequestChase()
+    {
+        _chaseRequested = true;
+        _state = State.CHASE;
+    }
+
+    public void ClearChaseRequest()
+    {
+        _chaseRequested = false;
     }
 
     private void Awake()
@@ -212,6 +225,14 @@ public class EnemyController2D : MonoBehaviour
             ref _lastNonZeroDir,
             out Vector2 radial,
             out Vector2 tangent);
+
+        if (_chaseRequested && steerTarget != null)
+        {
+            Vector2 toTarget = (Vector2)steerTarget.position - pos;
+            radial = toTarget.sqrMagnitude > 0f ? toTarget.normalized * speed : Vector2.zero;
+            tangent = Vector2.zero;
+            _state = State.CHASE;
+        }
 
         _rb.MovePosition(pos + (radial + tangent) * dt + knockbackDelta);
     }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/EnemyAttack.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/EnemyAttack.cs
@@ -33,8 +33,6 @@ public class EnemyAttack : MonoBehaviour
     static bool missingRegionStateWarningLogged;
     bool onCooldown;
 
-    static readonly Collider2D[] hits = new Collider2D[4];
-
     void Awake()
     {
         controller = GetComponent<EnemyController2D>();
@@ -54,6 +52,13 @@ public class EnemyAttack : MonoBehaviour
         if (onCooldown || controller == null) return;
         if (IsRooted()) return;
 
+        Transform selectedTarget = controller.Target;
+        if (controller.IsChaseRequested)
+        {
+            if (selectedTarget == null || !IsTargetInReach(selectedTarget)) return;
+            controller.ClearChaseRequest();
+        }
+
         // Only attack while we're holding position near the player
         if (!controller.IsInHoldRange()) return;
 
@@ -65,17 +70,12 @@ public class EnemyAttack : MonoBehaviour
                 return;
         }
 
-        // Confirm target really is in range (extra safety)
-        int count = Physics2D.OverlapCircleNonAlloc(transform.position, attackRange, hits, targetMask);
-        if (count == 0 && controller != null && controller.Target != null && targetMask.value == 0) {
-            // Fallback when mask is unset: distance check to the intended target
-            float dist = Vector2.Distance(transform.position, controller.Target.position);
-            if (dist <= attackRange) count = 1;
-        }
-        if (count > 0) StartCoroutine(AttackRoutine());
+        if (selectedTarget == null || !IsTargetInReach(selectedTarget)) return;
+
+        StartCoroutine(AttackRoutine(selectedTarget));
     }
 
-    IEnumerator AttackRoutine()
+    IEnumerator AttackRoutine(Transform lockedTarget)
     {
         onCooldown = true;
 
@@ -84,37 +84,84 @@ public class EnemyAttack : MonoBehaviour
 
         yield return new WaitForSeconds(windupSeconds);
 
-        // Apply damage once per unique IDamageable in range (avoid double hits on multi-collider targets).
-        int count = Physics2D.OverlapCircleNonAlloc(transform.position, attackRange, hits, targetMask);
-        var uniqueTargets = new System.Collections.Generic.HashSet<IDamageable>();
-
-        for (int i = 0; i < count; i++)
+        bool targetInReach = IsTargetInReach(lockedTarget);
+        if (!IsLockedTargetValid(lockedTarget, controller != null ? controller.Target : null, targetInReach))
         {
-            var c = hits[i];
-            if (!c) continue;
-
-            IDamageable dmg = null;
-            if (c.TryGetComponent<IDamageable>(out var selfDmg))
-            {
-                dmg = selfDmg;
-            }
-            else
-            {
-                dmg = c.GetComponentInParent<IDamageable>();
-            }
-
-            if (dmg == null)
-                continue;
-
-            if (!uniqueTargets.Add(dmg))
-                continue;
-
-            Debug.Log($"[EnemyAttack] Hit IDamageable target: {c.name}, tag: {c.tag}, damage: {Damage}", this);
-            DealDamage(dmg);
+            CancelWindup();
+            yield break;
         }
 
-        yield return new WaitForSeconds(cooldownSeconds);
+        IDamageable damageable = ResolveDamageable(lockedTarget);
+        if (damageable == null)
+        {
+            CancelWindup();
+            yield break;
+        }
+
+        Debug.Log($"[EnemyAttack] Hit locked target: {lockedTarget.name}, damage: {Damage}", this);
+        DealDamage(damageable);
+
+        if (RequiresCompletedCooldown(attackCompleted: true))
+            yield return new WaitForSeconds(cooldownSeconds);
+
         onCooldown = false;
+    }
+
+    public static bool IsLockedTargetValid(Transform lockedTarget, Transform selectedTarget, bool isInReach)
+    {
+        return lockedTarget != null && lockedTarget == selectedTarget && isInReach;
+    }
+
+    public static bool RequiresCompletedCooldown(bool attackCompleted)
+    {
+        return attackCompleted;
+    }
+
+    private bool IsTargetInReach(Transform selectedTarget)
+    {
+        if (selectedTarget == null)
+            return false;
+
+        var targetColliders = selectedTarget.GetComponentsInChildren<Collider2D>();
+        if (targetColliders.Length == 0)
+        {
+            return Vector2.Distance(transform.position, selectedTarget.position) <= attackRange;
+        }
+
+        for (int i = 0; i < targetColliders.Length; i++)
+        {
+            var targetCollider = targetColliders[i];
+            if (targetCollider == null || !targetCollider.enabled)
+                continue;
+
+            Vector2 closestPoint = targetCollider.ClosestPoint(transform.position);
+            if (Vector2.Distance(transform.position, closestPoint) <= attackRange)
+                return true;
+        }
+
+        return false;
+    }
+
+    private static IDamageable ResolveDamageable(Transform lockedTarget)
+    {
+        if (lockedTarget == null)
+            return null;
+
+        var damageable = lockedTarget.GetComponent<IDamageable>();
+        if (damageable != null)
+            return damageable;
+
+        damageable = lockedTarget.GetComponentInParent<IDamageable>();
+        return damageable ?? lockedTarget.GetComponentInChildren<IDamageable>();
+    }
+
+    private void CancelWindup()
+    {
+        if (animator && !string.IsNullOrEmpty(attackTriggerName))
+            animator.ResetTrigger(attackTriggerName);
+
+        onCooldown = false;
+        controller?.RequestChase();
     }
 
     void OnDrawGizmosSelected()

--- a/Assets/_Project/_Tests/EditMode/Combat/EnemyAttack/EnemyAttackTargetLockTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Combat/EnemyAttack/EnemyAttackTargetLockTests.cs
@@ -1,0 +1,71 @@
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Castlebound.Tests.Combat
+{
+    public class EnemyAttackTargetLockTests
+    {
+        [Test]
+        public void LockedTarget_RemainsValid_WhenSameSelectedTargetIsInReach()
+        {
+            var target = new GameObject("Target");
+
+            try
+            {
+                Assert.IsTrue(EnemyAttack.IsLockedTargetValid(
+                    target.transform,
+                    target.transform,
+                    isInReach: true));
+            }
+            finally
+            {
+                Object.DestroyImmediate(target);
+            }
+        }
+
+        [Test]
+        public void LockedTarget_IsInvalid_WhenSelectionChanges()
+        {
+            var lockedTarget = new GameObject("LockedTarget");
+            var replacementTarget = new GameObject("ReplacementTarget");
+
+            try
+            {
+                Assert.IsFalse(EnemyAttack.IsLockedTargetValid(
+                    lockedTarget.transform,
+                    replacementTarget.transform,
+                    isInReach: true));
+            }
+            finally
+            {
+                Object.DestroyImmediate(replacementTarget);
+                Object.DestroyImmediate(lockedTarget);
+            }
+        }
+
+        [Test]
+        public void LockedTarget_IsInvalid_WhenItLeavesReach()
+        {
+            var target = new GameObject("Target");
+
+            try
+            {
+                Assert.IsFalse(EnemyAttack.IsLockedTargetValid(
+                    target.transform,
+                    target.transform,
+                    isInReach: false));
+            }
+            finally
+            {
+                Object.DestroyImmediate(target);
+            }
+        }
+
+        [Test]
+        public void CancelledWindup_DoesNotRequireCompletedAttackCooldown()
+        {
+            Assert.IsFalse(EnemyAttack.RequiresCompletedCooldown(attackCompleted: false));
+            Assert.IsTrue(EnemyAttack.RequiresCompletedCooldown(attackCompleted: true));
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Combat/EnemyAttack/EnemyAttackTargetLockTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Combat/EnemyAttack/EnemyAttackTargetLockTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9c486de91eb5a7b43b218a7b13677ba1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/_Tests/PlayMode/Combat/EnemyAttackTargetLockPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/Combat/EnemyAttackTargetLockPlayTests.cs
@@ -1,0 +1,133 @@
+using System.Collections;
+using System.Reflection;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Castlebound.Tests.PlayMode.Combat
+{
+    public class EnemyAttackTargetLockPlayTests
+    {
+        [UnityTest]
+        public IEnumerator CompletedWindup_DamagesOnlyLockedSelectedTarget()
+        {
+            var player = CreateDamageable("Player", new Vector2(0.5f, 0f), "Player");
+            var unrelated = CreateDamageable("Unrelated", new Vector2(0.5f, 0f), null);
+            var enemy = CreateEnemy(player.transform, windupSeconds: 0.02f, cooldownSeconds: 0.5f);
+
+            try
+            {
+                yield return new WaitForSeconds(0.08f);
+
+                Assert.That(player.GetComponent<Health>().Current, Is.EqualTo(9),
+                    "The locked selected target should receive one completed melee hit.");
+                Assert.That(unrelated.GetComponent<Health>().Current, Is.EqualTo(10),
+                    "An unrelated overlap recipient must not receive melee damage.");
+            }
+            finally
+            {
+                Object.Destroy(enemy);
+                Object.Destroy(unrelated);
+                Object.Destroy(player);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator TargetEscapesDuringWindup_CancelsDamageAndResumesPursuit()
+        {
+            var player = CreateDamageable("Player", new Vector2(0.5f, 0f), "Player");
+            var enemy = CreateEnemy(player.transform, windupSeconds: 0.08f, cooldownSeconds: 1f);
+            var controller = enemy.GetComponent<EnemyController2D>();
+            float startingX = enemy.transform.position.x;
+
+            try
+            {
+                yield return new WaitForSeconds(0.02f);
+                player.transform.position = new Vector2(3f, 0f);
+                Physics2D.SyncTransforms();
+
+                yield return new WaitForSeconds(0.12f);
+                yield return new WaitForFixedUpdate();
+
+                Assert.That(player.GetComponent<Health>().Current, Is.EqualTo(10),
+                    "A target outside collider-aware reach at hit time must receive no damage.");
+                Assert.IsTrue(controller.IsChaseRequested,
+                    "A cancelled windup should request pursuit until attack reach is reacquired.");
+                Assert.That(enemy.transform.position.x, Is.GreaterThan(startingX),
+                    "The cancelled attacker should move toward its escaped target.");
+            }
+            finally
+            {
+                Object.Destroy(enemy);
+                Object.Destroy(player);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator CancelledWindup_ReacquiresRangeAndStartsEntirelyNewWindup()
+        {
+            var player = CreateDamageable("Player", new Vector2(0.5f, 0f), "Player");
+            var enemy = CreateEnemy(player.transform, windupSeconds: 0.08f, cooldownSeconds: 1f);
+
+            try
+            {
+                yield return new WaitForSeconds(0.02f);
+                player.transform.position = new Vector2(3f, 0f);
+                Physics2D.SyncTransforms();
+                yield return new WaitForSeconds(0.1f);
+
+                player.transform.position = new Vector2(0.5f, 0f);
+                Physics2D.SyncTransforms();
+                yield return new WaitForFixedUpdate();
+                yield return null;
+
+                Assert.That(player.GetComponent<Health>().Current, Is.EqualTo(10),
+                    "Reacquiring range must begin a new windup rather than applying immediate damage.");
+
+                yield return new WaitForSeconds(0.1f);
+
+                Assert.That(player.GetComponent<Health>().Current, Is.EqualTo(9),
+                    "A cancelled windup should not impose the completed cooldown before a new swing.");
+            }
+            finally
+            {
+                Object.Destroy(enemy);
+                Object.Destroy(player);
+            }
+        }
+
+        private static GameObject CreateDamageable(string name, Vector2 position, string tag)
+        {
+            var target = new GameObject(name);
+            if (!string.IsNullOrEmpty(tag))
+                target.tag = tag;
+            target.layer = LayerMask.NameToLayer("Player");
+            target.transform.position = position;
+            target.AddComponent<BoxCollider2D>();
+            target.AddComponent<Health>().ConfigureMaxHealth(10, refill: true);
+            return target;
+        }
+
+        private static GameObject CreateEnemy(Transform target, float windupSeconds, float cooldownSeconds)
+        {
+            var enemy = new GameObject("Enemy");
+            var body = enemy.AddComponent<Rigidbody2D>();
+            body.gravityScale = 0f;
+            enemy.AddComponent<BoxCollider2D>();
+            var controller = enemy.AddComponent<EnemyController2D>();
+            controller.Debug_SetupRefs(target);
+
+            var attack = enemy.AddComponent<EnemyAttack>();
+            SetField(attack, "windupSeconds", windupSeconds);
+            attack.CooldownSeconds = cooldownSeconds;
+            return enemy;
+        }
+
+        private static void SetField(object instance, string fieldName, object value)
+        {
+            instance.GetType()
+                .GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)
+                ?.SetValue(instance, value);
+        }
+    }
+}

--- a/Assets/_Project/_Tests/PlayMode/Combat/EnemyAttackTargetLockPlayTests.cs.meta
+++ b/Assets/_Project/_Tests/PlayMode/Combat/EnemyAttackTargetLockPlayTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b09d41b0fa525b4438f0c0a87772598f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,23 @@
 
 ---
 
+## 2026-07-17 - fix-245-lock-melee-target
+
+### Summary
+- Locked each melee windup to the enemy's selected target.
+- Cancelled escaped or deselected targets without damage or completed-attack cooldown.
+- Resumed pursuit until collider-aware attack reach is reacquired.
+
+### New or Updated Tests
+**EditMode**
+- `EnemyAttackTargetLockTests` — covers target identity, hit-time reach validation, and cancellation cooldown decisions.
+
+**PlayMode**
+- `EnemyAttackTargetLockPlayTests` — covers target-only damage, windup escape cancellation, pursuit resume, and fresh windup behavior.
+
+### Notes
+- EditMode 712/712 and PlayMode 54/54 passed in an isolated Unity project because the primary project was open in another editor instance.
+
 ## 2026-07-16 - fix-42-inside-barrier-damage-gate
 
 ### Summary


### PR DESCRIPTION
## Why
Melee swings could damage unrelated overlap recipients and still complete after the selected target escaped during windup.

## What changed
- Locked each melee windup to its selected target
- Revalidated target identity and collider-aware reach at hit time
- Cancelled invalid swings without damage or full cooldown
- Resumed pursuit until the target returned to attack reach
- Added target-lock EditMode and PlayMode regression coverage

## How to test
1. Open the relevant combat scene
2. Press Play → verify an enemy cancels its swing and pursues when its target escapes during windup
3. Run tests:
   - EditMode: 712/712 passing
   - PlayMode: 54/54 passing
4. Manual combat validation: passing

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated (N/A - no scene changes required)
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched

## Related
- Closes #245