### PR TITLE
fix(ai): restrict surround calculations to eligible melee enemies

### DIFF
--- a/Assets/_Project/Prefabs/Enemy.prefab
+++ b/Assets/_Project/Prefabs/Enemy.prefab
@@ -103,6 +103,7 @@ GameObject:
   - component: {fileID: 4347245256977356794}
   - component: {fileID: 2387932495633829988}
   - component: {fileID: 6382125908214597412}
+  - component: {fileID: 8041287619235472011}
   m_Layer: 7
   m_Name: Enemy
   m_TagString: Enemy
@@ -342,3 +343,15 @@ MonoBehaviour:
   m_EditorClassIdentifier: ""
   enemyTypeId: grunt
   balanceStation: {fileID: 11400000, guid: d70caaeb4e66400f8127d62f459cae21, type: 2}
+--- !u!114 &8041287619235472011
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6394411849047796180}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c4e52f2f6e7641c4a90b5ce074f50c96, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:

--- a/Assets/_Project/Prefabs/Enemy_Lurker.prefab
+++ b/Assets/_Project/Prefabs/Enemy_Lurker.prefab
@@ -123,6 +123,7 @@ GameObject:
   - component: {fileID: 4347245256977356794}
   - component: {fileID: 2387932495633829988}
   - component: {fileID: 6382125908214597412}
+  - component: {fileID: 8041287619235472011}
   m_Layer: 7
   m_Name: Enemy_Lurker
   m_TagString: Enemy
@@ -362,3 +363,15 @@ MonoBehaviour:
   m_EditorClassIdentifier: ""
   enemyTypeId: lurker
   balanceStation: {fileID: 11400000, guid: d70caaeb4e66400f8127d62f459cae21, type: 2}
+--- !u!114 &8041287619235472011
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6394411849047796180}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c4e52f2f6e7641c4a90b5ce074f50c96, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyController2D.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyController2D.cs
@@ -136,6 +136,8 @@ public class EnemyController2D : MonoBehaviour
     private void OnDisable()
     {
         All.Remove(this);
+        _gapCW = 0f;
+        _gapCCW = 0f;
     }
 
     private void Start()

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyRingManager.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyRingManager.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Castlebound.Gameplay.AI;
 using UnityEngine;
 
 public class EnemyRingManager : MonoBehaviour
@@ -47,6 +48,13 @@ public class EnemyRingManager : MonoBehaviour
         {
             EnemyController2D e = EnemyController2D.All[i];
             if (e == null) continue;
+
+            var eligibility = e.GetComponent<EnemySurroundEligibility>();
+            if (eligibility == null || !eligibility.IsEligibleFor(player))
+            {
+                e.SetAngularGaps(0f, 0f);
+                continue;
+            }
 
             Vector3 p = e.transform.position;
             float dx = p.x - playerPos.x;

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemySurroundEligibility.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemySurroundEligibility.cs
@@ -1,0 +1,55 @@
+using UnityEngine;
+
+namespace Castlebound.Gameplay.AI
+{
+    public class EnemySurroundEligibility : MonoBehaviour
+    {
+        private EnemyController2D controller;
+        private EnemyRootReceiver rootReceiver;
+        private Health health;
+
+        private void Awake()
+        {
+            CacheComponents();
+        }
+
+        public bool IsEligibleFor(Transform player)
+        {
+            CacheComponents();
+
+            return Evaluate(
+                isActiveAndEnabled,
+                controller != null && controller.enabled,
+                health != null && health.Current > 0,
+                rootReceiver != null && rootReceiver.IsRooted,
+                controller != null ? controller.CurrentTargetType : EnemyTargetType.None,
+                controller != null && controller.Target == player);
+        }
+
+        public static bool Evaluate(
+            bool isActiveAndEnabled,
+            bool isControllerEnabled,
+            bool isAlive,
+            bool isRooted,
+            EnemyTargetType targetType,
+            bool targetsPlayer)
+        {
+            return isActiveAndEnabled &&
+                   isControllerEnabled &&
+                   isAlive &&
+                   !isRooted &&
+                   targetType == EnemyTargetType.Player &&
+                   targetsPlayer;
+        }
+
+        private void CacheComponents()
+        {
+            if (controller == null)
+                controller = GetComponent<EnemyController2D>();
+            if (rootReceiver == null)
+                rootReceiver = GetComponent<EnemyRootReceiver>();
+            if (health == null)
+                health = GetComponent<Health>();
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemySurroundEligibility.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemySurroundEligibility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c4e52f2f6e7641c4a90b5ce074f50c96
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/_Tests/EditMode/AI/EnemyRingEligibilityTests.cs
+++ b/Assets/_Project/_Tests/EditMode/AI/EnemyRingEligibilityTests.cs
@@ -1,0 +1,178 @@
+using System.Reflection;
+using Castlebound.Gameplay.AI;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Castlebound.Tests.AI
+{
+    public class EnemyRingEligibilityTests
+    {
+        [Test]
+        public void Refresh_ExcludesIneligibleEnemyAndClearsItsStaleGaps()
+        {
+            var player = new GameObject("Player");
+            var managerObject = new GameObject("EnemyRingManager");
+            var created = new GameObject[3];
+
+            try
+            {
+                player.tag = "Player";
+                var manager = managerObject.AddComponent<EnemyRingManager>();
+                SetManagerPlayer(manager, player.transform);
+                created[0] = CreateEnemy("EligibleA", player.transform, new Vector2(2f, 0f));
+                created[1] = CreateEnemy("EligibleB", player.transform, PolarPosition(2.1f, 30f));
+                created[2] = CreateEnemy("Rooted", player.transform, PolarPosition(100f, 15f));
+
+                created[2].GetComponent<EnemyRootReceiver>().RootForSeconds(10f);
+                created[2].GetComponent<EnemyController2D>().SetAngularGaps(1f, 1f);
+
+                InvokeRefresh(manager);
+
+                GetGaps(created[0].GetComponent<EnemyController2D>(), out float eligibleCw, out float eligibleCcw);
+                GetGaps(created[2].GetComponent<EnemyController2D>(), out float rootedCw, out float rootedCcw);
+
+                Assert.That(Mathf.Max(eligibleCw, eligibleCcw), Is.GreaterThan(0f),
+                    "Eligible melee neighbors should retain their existing angular-gap behavior.");
+                Assert.That(rootedCw, Is.Zero);
+                Assert.That(rootedCcw, Is.Zero,
+                    "An enemy leaving eligibility must not retain stale ring influence.");
+            }
+            finally
+            {
+                for (int i = 0; i < created.Length; i++)
+                    DestroyEnemy(created[i]);
+                Object.DestroyImmediate(managerObject);
+                Object.DestroyImmediate(player);
+            }
+        }
+
+        [Test]
+        public void Refresh_ExcludesEnemyWithoutMeleeEligibilityMarker()
+        {
+            var player = new GameObject("Player");
+            var managerObject = new GameObject("EnemyRingManager");
+            GameObject unmarked = null;
+
+            try
+            {
+                player.tag = "Player";
+                var manager = managerObject.AddComponent<EnemyRingManager>();
+                SetManagerPlayer(manager, player.transform);
+                unmarked = CreateEnemy("FutureRanged", player.transform, new Vector2(2f, 0f), addMarker: false);
+                var controller = unmarked.GetComponent<EnemyController2D>();
+                controller.SetAngularGaps(1f, 1f);
+
+                InvokeRefresh(manager);
+                GetGaps(controller, out float gapCw, out float gapCcw);
+
+                Assert.That(gapCw, Is.Zero);
+                Assert.That(gapCcw, Is.Zero);
+            }
+            finally
+            {
+                DestroyEnemy(unmarked);
+                Object.DestroyImmediate(managerObject);
+                Object.DestroyImmediate(player);
+            }
+        }
+
+        [Test]
+        public void DisabledController_ClearsCachedAngularGaps()
+        {
+            var enemy = new GameObject("Enemy");
+            var controller = enemy.AddComponent<EnemyController2D>();
+
+            try
+            {
+                controller.SetAngularGaps(1f, 2f);
+                controller.enabled = false;
+                InvokeControllerDisable(controller);
+                GetGaps(controller, out float gapCw, out float gapCcw);
+
+                Assert.That(gapCw, Is.Zero);
+                Assert.That(gapCcw, Is.Zero);
+            }
+            finally
+            {
+                Object.DestroyImmediate(enemy);
+            }
+        }
+
+        private static GameObject CreateEnemy(
+            string name,
+            Transform player,
+            Vector2 position,
+            bool addMarker = true)
+        {
+            var enemy = new GameObject(name);
+            enemy.transform.position = position;
+            enemy.AddComponent<Health>().ConfigureMaxHealth(10, refill: true);
+            enemy.AddComponent<EnemyRootReceiver>();
+            var controller = enemy.AddComponent<EnemyController2D>();
+            controller.Debug_SetupRefs(player);
+            SetTargetType(controller, EnemyTargetType.Player);
+            InvokeControllerEnable(controller);
+            if (addMarker) enemy.AddComponent<EnemySurroundEligibility>();
+            return enemy;
+        }
+
+        private static Vector2 PolarPosition(float radius, float degrees)
+        {
+            float radians = degrees * Mathf.Deg2Rad;
+            return new Vector2(Mathf.Cos(radians), Mathf.Sin(radians)) * radius;
+        }
+
+        private static void InvokeRefresh(EnemyRingManager manager)
+        {
+            typeof(EnemyRingManager)
+                .GetMethod("FixedUpdate", BindingFlags.Instance | BindingFlags.NonPublic)
+                ?.Invoke(manager, null);
+        }
+
+        private static void InvokeControllerEnable(EnemyController2D controller)
+        {
+            typeof(EnemyController2D)
+                .GetMethod("OnEnable", BindingFlags.Instance | BindingFlags.NonPublic)
+                ?.Invoke(controller, null);
+        }
+
+        private static void InvokeControllerDisable(EnemyController2D controller)
+        {
+            typeof(EnemyController2D)
+                .GetMethod("OnDisable", BindingFlags.Instance | BindingFlags.NonPublic)
+                ?.Invoke(controller, null);
+        }
+
+        private static void SetManagerPlayer(EnemyRingManager manager, Transform player)
+        {
+            typeof(EnemyRingManager)
+                .GetField("player", BindingFlags.Instance | BindingFlags.NonPublic)
+                ?.SetValue(manager, player);
+        }
+
+        private static void SetTargetType(EnemyController2D controller, EnemyTargetType targetType)
+        {
+            typeof(EnemyController2D)
+                .GetField("_currentTargetType", BindingFlags.Instance | BindingFlags.NonPublic)
+                ?.SetValue(controller, targetType);
+        }
+
+        private static void GetGaps(EnemyController2D controller, out float gapCw, out float gapCcw)
+        {
+            const BindingFlags flags = BindingFlags.Instance | BindingFlags.NonPublic;
+            gapCw = (float)typeof(EnemyController2D).GetField("_gapCW", flags).GetValue(controller);
+            gapCcw = (float)typeof(EnemyController2D).GetField("_gapCCW", flags).GetValue(controller);
+        }
+
+        private static void DestroyEnemy(GameObject enemy)
+        {
+            if (enemy == null)
+                return;
+
+            var controller = enemy.GetComponent<EnemyController2D>();
+            if (controller != null)
+                InvokeControllerDisable(controller);
+            Object.DestroyImmediate(enemy);
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/AI/EnemyRingEligibilityTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/AI/EnemyRingEligibilityTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 142fe89975f0748449f1f940529198e2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/_Tests/EditMode/AI/EnemySurroundEligibilityTests.cs
+++ b/Assets/_Project/_Tests/EditMode/AI/EnemySurroundEligibilityTests.cs
@@ -1,0 +1,43 @@
+using Castlebound.Gameplay.AI;
+using NUnit.Framework;
+
+namespace Castlebound.Tests.AI
+{
+    public class EnemySurroundEligibilityTests
+    {
+        [Test]
+        public void ActiveLivingPlayerTargetingMeleeEnemy_IsEligible()
+        {
+            Assert.IsTrue(EnemySurroundEligibility.Evaluate(
+                isActiveAndEnabled: true,
+                isControllerEnabled: true,
+                isAlive: true,
+                isRooted: false,
+                targetType: EnemyTargetType.Player,
+                targetsPlayer: true));
+        }
+
+        [TestCase(false, true, true, false, EnemyTargetType.Player, true)]
+        [TestCase(true, false, true, false, EnemyTargetType.Player, true)]
+        [TestCase(true, true, false, false, EnemyTargetType.Player, true)]
+        [TestCase(true, true, true, true, EnemyTargetType.Player, true)]
+        [TestCase(true, true, true, false, EnemyTargetType.Barrier, false)]
+        [TestCase(true, true, true, false, EnemyTargetType.Player, false)]
+        public void IneligibleState_IsExcluded(
+            bool isActiveAndEnabled,
+            bool isControllerEnabled,
+            bool isAlive,
+            bool isRooted,
+            EnemyTargetType targetType,
+            bool targetsPlayer)
+        {
+            Assert.IsFalse(EnemySurroundEligibility.Evaluate(
+                isActiveAndEnabled,
+                isControllerEnabled,
+                isAlive,
+                isRooted,
+                targetType,
+                targetsPlayer));
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/AI/EnemySurroundEligibilityTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/AI/EnemySurroundEligibilityTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a6157bb4670538d4585fda9a39f7fecc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/_Tests/EditMode/AI/EnemySurroundPrefabContractTests.cs
+++ b/Assets/_Project/_Tests/EditMode/AI/EnemySurroundPrefabContractTests.cs
@@ -1,0 +1,21 @@
+using Castlebound.Gameplay.AI;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+
+namespace Castlebound.Tests.AI
+{
+    public class EnemySurroundPrefabContractTests
+    {
+        [TestCase("Assets/_Project/Prefabs/Enemy.prefab")]
+        [TestCase("Assets/_Project/Prefabs/Enemy_Lurker.prefab")]
+        public void CurrentMeleePrefab_DefinesSurroundEligibility(string prefabPath)
+        {
+            var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(prefabPath);
+
+            Assert.NotNull(prefab, $"Expected melee prefab at {prefabPath}.");
+            Assert.NotNull(prefab.GetComponent<EnemySurroundEligibility>(),
+                $"Melee prefab {prefabPath} must opt into player-surround calculations.");
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/AI/EnemySurroundPrefabContractTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/AI/EnemySurroundPrefabContractTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8347a603aaef8734e945acd6b2da5fcd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/_Tests/PlayMode/AI/EnemyRingEligibilityPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/AI/EnemyRingEligibilityPlayTests.cs
@@ -1,0 +1,106 @@
+using System.Collections;
+using System.Reflection;
+using Castlebound.Gameplay.AI;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Castlebound.Tests.PlayMode.AI
+{
+    public class EnemyRingEligibilityPlayTests
+    {
+        [UnityTest]
+        public IEnumerator MixedTargetRing_OnlyPlayerTargetingMeleeEnemiesReceiveGaps()
+        {
+            var player = new GameObject("Player");
+            var managerObject = new GameObject("EnemyRingManager");
+            GameObject eligibleA = null;
+            GameObject eligibleB = null;
+            GameObject barrierTarget = null;
+
+            try
+            {
+                player.tag = "Player";
+                var manager = managerObject.AddComponent<EnemyRingManager>();
+                eligibleA = CreateEnemy("EligibleA", player.transform, new Vector2(2f, 0f), EnemyTargetType.Player);
+                eligibleB = CreateEnemy("EligibleB", player.transform, PolarPosition(2f, 30f), EnemyTargetType.Player);
+                barrierTarget = CreateEnemy("BarrierTarget", player.transform, PolarPosition(2f, 15f), EnemyTargetType.Barrier);
+                barrierTarget.GetComponent<EnemyController2D>().SetAngularGaps(1f, 1f);
+
+                yield return null;
+                SetTargetType(eligibleA.GetComponent<EnemyController2D>(), EnemyTargetType.Player);
+                SetTargetType(eligibleB.GetComponent<EnemyController2D>(), EnemyTargetType.Player);
+                SetTargetType(barrierTarget.GetComponent<EnemyController2D>(), EnemyTargetType.Barrier);
+                InvokeRefresh(manager);
+
+                GetGaps(eligibleA.GetComponent<EnemyController2D>(), out float eligibleCw, out float eligibleCcw);
+                GetGaps(barrierTarget.GetComponent<EnemyController2D>(), out float barrierCw, out float barrierCcw);
+
+                Assert.That(Mathf.Max(eligibleCw, eligibleCcw), Is.GreaterThan(0f));
+                Assert.That(barrierCw, Is.Zero);
+                Assert.That(barrierCcw, Is.Zero);
+            }
+            finally
+            {
+                DestroyEnemy(eligibleA);
+                DestroyEnemy(eligibleB);
+                DestroyEnemy(barrierTarget);
+                Object.Destroy(managerObject);
+                Object.Destroy(player);
+            }
+        }
+
+        private static GameObject CreateEnemy(
+            string name,
+            Transform player,
+            Vector2 position,
+            EnemyTargetType targetType)
+        {
+            var enemy = new GameObject(name);
+            enemy.transform.position = position;
+            enemy.AddComponent<Health>().ConfigureMaxHealth(10, refill: true);
+            enemy.AddComponent<EnemyRootReceiver>();
+            var controller = enemy.AddComponent<EnemyController2D>();
+            controller.Debug_SetupRefs(player);
+            SetTargetType(controller, targetType);
+            enemy.AddComponent<EnemySurroundEligibility>();
+            return enemy;
+        }
+
+        private static Vector2 PolarPosition(float radius, float degrees)
+        {
+            float radians = degrees * Mathf.Deg2Rad;
+            return new Vector2(Mathf.Cos(radians), Mathf.Sin(radians)) * radius;
+        }
+
+        private static void InvokeRefresh(EnemyRingManager manager)
+        {
+            typeof(EnemyRingManager)
+                .GetMethod("FixedUpdate", BindingFlags.Instance | BindingFlags.NonPublic)
+                ?.Invoke(manager, null);
+        }
+
+        private static void SetTargetType(EnemyController2D controller, EnemyTargetType targetType)
+        {
+            typeof(EnemyController2D)
+                .GetField("_currentTargetType", BindingFlags.Instance | BindingFlags.NonPublic)
+                ?.SetValue(controller, targetType);
+        }
+
+        private static void GetGaps(EnemyController2D controller, out float gapCw, out float gapCcw)
+        {
+            const BindingFlags flags = BindingFlags.Instance | BindingFlags.NonPublic;
+            gapCw = (float)typeof(EnemyController2D).GetField("_gapCW", flags).GetValue(controller);
+            gapCcw = (float)typeof(EnemyController2D).GetField("_gapCCW", flags).GetValue(controller);
+        }
+
+        private static void DestroyEnemy(GameObject enemy)
+        {
+            if (enemy == null)
+                return;
+
+            enemy.SetActive(false);
+            Object.Destroy(enemy);
+        }
+    }
+}

--- a/Assets/_Project/_Tests/PlayMode/AI/EnemyRingEligibilityPlayTests.cs.meta
+++ b/Assets/_Project/_Tests/PlayMode/AI/EnemyRingEligibilityPlayTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1917173497890cd4b8db46eb2b287b61
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,23 @@
 
 ---
 
+## 2026-07-17 - fix-247-surround-eligibility
+
+### Summary
+- Restricted player-ring calculations to active, living, unrooted melee enemies targeting the player.
+- Cleared stale angular gaps when enemies become ineligible or their controller is disabled.
+- Added explicit melee-surround eligibility to both current enemy prefabs.
+
+### New or Updated Tests
+**EditMode**
+- `EnemySurroundEligibilityTests`, `EnemyRingEligibilityTests`, and `EnemySurroundPrefabContractTests` — cover the eligibility matrix, filtered ring inputs, stale-gap cleanup, ranged-safe exclusion, and melee prefab contracts.
+
+**PlayMode**
+- `EnemyRingEligibilityPlayTests` — verifies mixed-target rings assign gaps only to eligible player-targeting melee enemies.
+
+### Notes
+- EditMode 724/724 and PlayMode 55/55 passed; manual validation confirmed existing eligible-enemy behavior remains unchanged.
+
 ## 2026-07-17 - fix-245-lock-melee-target
 
 ### Summary


### PR DESCRIPTION
## Why
The player-centered enemy ring considered every registered controller, so barrier-targeting, rooted, disabled, dead, and future ranged enemies could distort melee spacing decisions.

## What changed
- Added an explicit melee-surround eligibility component
- Restricted angular-gap and median-ring inputs to active, living, unrooted melee enemies targeting the player
- Cleared cached angular gaps when enemies become ineligible or their controller is disabled
- Added the eligibility marker to both current melee enemy prefabs
- Added eligibility-matrix, ring-filtering, prefab-contract, and mixed-target regression coverage

## How to test
1. Open the relevant combat scene
2. Press Play → mix player-targeting and barrier-targeting enemies and verify existing melee behavior remains unchanged
3. Verify rooted and non-player-targeting enemies do not affect player-surround spacing
4. Run tests:
   - EditMode: 724/724 passing
   - PlayMode: 55/55 passing
5. Manual validation: passing

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated (N/A - no scene changes required)
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched

## Related
- Closes #247