### PR TITLE
feat(ai): improve melee spreading during player approach

### DIFF
--- a/Assets/_Project/Prefabs/Enemy.prefab
+++ b/Assets/_Project/Prefabs/Enemy.prefab
@@ -104,6 +104,7 @@ GameObject:
   - component: {fileID: 2387932495633829988}
   - component: {fileID: 6382125908214597412}
   - component: {fileID: 8041287619235472011}
+  - component: {fileID: 8041287619235472012}
   m_Layer: 7
   m_Name: Enemy
   m_TagString: Enemy
@@ -355,3 +356,22 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c4e52f2f6e7641c4a90b5ce074f50c96, type: 3}
   m_Name:
   m_EditorClassIdentifier:
+--- !u!114 &8041287619235472012
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6394411849047796180}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 94a63b1fd37c43bfab74eae09bb83b18, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  neighborSeparationRadius: 1.5
+  separationStrength: 0.8
+  maxLateralRatio: 0.35
+  minimumForwardRatio: 0.8
+  surroundArrivalDistance: 10
+  maxAngularArrivalRatio: 0.18
+  openGapDeadbandDegrees: 8

--- a/Assets/_Project/Prefabs/Enemy_Lurker.prefab
+++ b/Assets/_Project/Prefabs/Enemy_Lurker.prefab
@@ -124,6 +124,7 @@ GameObject:
   - component: {fileID: 2387932495633829988}
   - component: {fileID: 6382125908214597412}
   - component: {fileID: 8041287619235472011}
+  - component: {fileID: 8041287619235472012}
   m_Layer: 7
   m_Name: Enemy_Lurker
   m_TagString: Enemy
@@ -375,3 +376,22 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c4e52f2f6e7641c4a90b5ce074f50c96, type: 3}
   m_Name:
   m_EditorClassIdentifier:
+--- !u!114 &8041287619235472012
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6394411849047796180}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 94a63b1fd37c43bfab74eae09bb83b18, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  neighborSeparationRadius: 1.5
+  separationStrength: 0.8
+  maxLateralRatio: 0.35
+  minimumForwardRatio: 0.8
+  surroundArrivalDistance: 10
+  maxAngularArrivalRatio: 0.18
+  openGapDeadbandDegrees: 8

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyApproachSpread.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyApproachSpread.cs
@@ -69,7 +69,7 @@ public class EnemyApproachSpread : MonoBehaviour
             if (Mathf.Abs(gapDifference) > deadband)
                 angularPreference = Mathf.Sign(gapDifference) *
                                     Mathf.Clamp01((Mathf.Abs(gapDifference) - deadband) / deadband);
-            else if (gapCW <= 0f && gapCCW <= 0f)
+            else if (hasNeighbors && gapCW <= 0f && gapCCW <= 0f)
                 angularPreference = Vector2.Dot(stableBias.normalized, lateralAxis) * 0.5f;
         }
 

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyApproachSpread.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyApproachSpread.cs
@@ -67,7 +67,7 @@ public class EnemyApproachSpread : MonoBehaviour
             float gapDifference = gapCCW - gapCW;
             float deadband = Mathf.Max(0.0001f, gapDeadbandRadians);
             if (Mathf.Abs(gapDifference) > deadband)
-                angularPreference = Mathf.Sign(gapDifference) *
+                angularPreference = -Mathf.Sign(gapDifference) *
                                     Mathf.Clamp01((Mathf.Abs(gapDifference) - deadband) / deadband);
             else if (hasNeighbors && gapCW <= 0f && gapCCW <= 0f)
                 angularPreference = Vector2.Dot(stableBias.normalized, lateralAxis) * 0.5f;

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyApproachSpread.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyApproachSpread.cs
@@ -1,0 +1,95 @@
+using UnityEngine;
+
+public class EnemyApproachSpread : MonoBehaviour
+{
+    [SerializeField] private float neighborSeparationRadius = 1.5f;
+    [SerializeField] private float separationStrength = 0.8f;
+    [SerializeField] private float maxLateralRatio = 0.35f;
+    [SerializeField] private float minimumForwardRatio = 0.8f;
+    [SerializeField] private float surroundArrivalDistance = 10f;
+    [SerializeField] private float maxAngularArrivalRatio = 0.18f;
+    [SerializeField] private float openGapDeadbandDegrees = 8f;
+
+    public float NeighborSeparationRadius => Mathf.Max(0f, neighborSeparationRadius);
+
+    public void Compute(Vector2 pursuit, Vector2 directionToTarget, Vector2 localSeparation,
+        bool hasNeighbors, Vector2 stableBias, float distance, float holdRadius,
+        float gapCW, float gapCCW, bool hasGroup, float speed,
+        out Vector2 radial, out Vector2 tangent)
+    {
+        ComputeApproach(pursuit, directionToTarget, localSeparation, hasNeighbors, stableBias,
+            distance, holdRadius, gapCW, gapCCW, hasGroup, speed,
+            separationStrength, maxLateralRatio, minimumForwardRatio,
+            surroundArrivalDistance, maxAngularArrivalRatio,
+            openGapDeadbandDegrees * Mathf.Deg2Rad, out radial, out tangent);
+    }
+
+    public static void ComputeApproach(Vector2 pursuit, Vector2 directionToTarget,
+        Vector2 localSeparation, bool hasNeighbors, Vector2 stableBias, float speed,
+        float separationStrength, float maxLateralRatio, float minimumForwardRatio,
+        out Vector2 radial, out Vector2 tangent)
+    {
+        ComputeApproach(pursuit, directionToTarget, localSeparation, hasNeighbors, stableBias,
+            float.PositiveInfinity, 0f, 0f, 0f, false, speed,
+            separationStrength, maxLateralRatio, minimumForwardRatio,
+            0f, 0f, 0f, out radial, out tangent);
+    }
+
+    public static void ComputeApproach(Vector2 pursuit, Vector2 directionToTarget,
+        Vector2 localSeparation, bool hasNeighbors, Vector2 stableBias,
+        float distance, float holdRadius, float gapCW, float gapCCW, bool hasGroup, float speed,
+        float separationStrength, float maxLateralRatio, float minimumForwardRatio,
+        float surroundArrivalDistance, float maxAngularArrivalRatio, float gapDeadbandRadians,
+        out Vector2 radial, out Vector2 tangent)
+    {
+        radial = pursuit;
+        tangent = Vector2.zero;
+        if (directionToTarget.sqrMagnitude <= 0f) return;
+
+        float safeSpeed = Mathf.Max(0f, speed);
+        Vector2 forward = directionToTarget.normalized;
+        Vector2 lateralAxis = new Vector2(-forward.y, forward.x);
+        float localPreference = 0f;
+        if (hasNeighbors)
+        {
+            Vector2 separation = localSeparation.sqrMagnitude > 0.0001f
+                ? localSeparation.normalized
+                : stableBias.normalized;
+            localPreference = Vector2.Dot(separation, lateralAxis);
+        }
+
+        float angularPreference = 0f;
+        float arrival01 = 0f;
+        float arrivalDistance = Mathf.Max(0.0001f, surroundArrivalDistance);
+        if (hasGroup && distance > holdRadius && distance < holdRadius + arrivalDistance)
+        {
+            arrival01 = 1f - Mathf.Clamp01((distance - holdRadius) / arrivalDistance);
+            float gapDifference = gapCCW - gapCW;
+            float deadband = Mathf.Max(0.0001f, gapDeadbandRadians);
+            if (Mathf.Abs(gapDifference) > deadband)
+                angularPreference = Mathf.Sign(gapDifference) *
+                                    Mathf.Clamp01((Mathf.Abs(gapDifference) - deadband) / deadband);
+            else if (gapCW <= 0f && gapCCW <= 0f)
+                angularPreference = Vector2.Dot(stableBias.normalized, lateralAxis) * 0.5f;
+        }
+
+        float localLateral = Mathf.Clamp01(separationStrength) *
+                             Mathf.Clamp01(maxLateralRatio) * localPreference;
+        float angularLateral = Mathf.Clamp01(maxAngularArrivalRatio) * arrival01 * angularPreference;
+        float lateralRatio = Mathf.Clamp(localLateral + angularLateral,
+            -Mathf.Clamp01(maxLateralRatio), Mathf.Clamp01(maxLateralRatio));
+        if (Mathf.Abs(lateralRatio) <= 0.001f) return;
+
+        float lateralMagnitude = safeSpeed * lateralRatio;
+        float minimumForward = safeSpeed * Mathf.Clamp01(minimumForwardRatio);
+        Vector2 rawRadial = forward * Mathf.Max(minimumForward, Vector2.Dot(pursuit, forward));
+        Vector2 rawTangent = lateralAxis * lateralMagnitude;
+        Vector2 combined = rawRadial + rawTangent;
+        float scale = combined.magnitude > safeSpeed && combined.sqrMagnitude > 0f
+            ? safeSpeed / combined.magnitude
+            : 1f;
+
+        radial = rawRadial * scale;
+        tangent = rawTangent * scale;
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyApproachSpread.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyApproachSpread.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 94a63b1fd37c43bfab74eae09bb83b18
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyController2D.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyController2D.cs
@@ -46,6 +46,8 @@ public class EnemyController2D : MonoBehaviour
     [SerializeField] private bool useBarrierTargeting = true;
     [SerializeField] private EnemyKnockbackReceiver knockbackReceiver;
     [SerializeField] private EnemyRootReceiver rootReceiver;
+    [SerializeField] private EnemyApproachSpread approachSpread;
+    [SerializeField] private EnemySurroundEligibility surroundEligibility;
 
     public Transform Target => target;
     public float Speed
@@ -69,6 +71,10 @@ public class EnemyController2D : MonoBehaviour
     private int _distTrend;
     private float _gapCW;
     private float _gapCCW;
+    private int _surroundParticipantCount;
+    private Vector2 _approachSeparation;
+    private bool _hasApproachNeighbors;
+    private Vector2 _approachSpreadBias;
     private bool _chaseRequested;
     public bool IsChaseRequested => _chaseRequested;
     // Last non-zero direction toward our current target (for pass-through).
@@ -79,6 +85,22 @@ public class EnemyController2D : MonoBehaviour
         _gapCW = gapCW;
         _gapCCW = gapCCW;
     }
+
+    public void SetAngularGaps(float gapCW, float gapCCW, int participantCount)
+    {
+        SetAngularGaps(gapCW, gapCCW);
+        _surroundParticipantCount = Mathf.Max(0, participantCount);
+    }
+
+    public void SetApproachSeparation(Vector2 separation, bool hasNeighbors)
+    {
+        _approachSeparation = separation;
+        _hasApproachNeighbors = hasNeighbors;
+    }
+
+    public float ApproachSeparationRadius => approachSpread != null
+        ? approachSpread.NeighborSeparationRadius
+        : 0f;
 
     public void RequestChase()
     {
@@ -101,6 +123,14 @@ public class EnemyController2D : MonoBehaviour
         if (rootReceiver == null)
         {
             rootReceiver = GetComponent<EnemyRootReceiver>();
+        }
+        if (approachSpread == null)
+        {
+            approachSpread = GetComponent<EnemyApproachSpread>();
+        }
+        if (surroundEligibility == null)
+        {
+            surroundEligibility = GetComponent<EnemySurroundEligibility>();
         }
         if (regionState == null)
         {
@@ -131,6 +161,11 @@ public class EnemyController2D : MonoBehaviour
     private void OnEnable()
     {
         if (!All.Contains(this)) All.Add(this);
+        if (_approachSpreadBias == Vector2.zero)
+        {
+            float angle = All.Count * 137.50776f * Mathf.Deg2Rad;
+            _approachSpreadBias = new Vector2(Mathf.Cos(angle), Mathf.Sin(angle));
+        }
     }
 
     private void OnDisable()
@@ -138,6 +173,9 @@ public class EnemyController2D : MonoBehaviour
         All.Remove(this);
         _gapCW = 0f;
         _gapCCW = 0f;
+        _surroundParticipantCount = 0;
+        _approachSeparation = Vector2.zero;
+        _hasApproachNeighbors = false;
     }
 
     private void Start()
@@ -227,6 +265,32 @@ public class EnemyController2D : MonoBehaviour
             ref _lastNonZeroDir,
             out Vector2 radial,
             out Vector2 tangent);
+
+        if (_state == State.CHASE &&
+            !_chaseRequested &&
+            _currentTargetType == EnemyTargetType.Player &&
+            approachSpread != null &&
+            surroundEligibility != null &&
+            surroundEligibility.IsEligibleFor(player))
+        {
+            Vector2 toPlayer = player != null ? (Vector2)player.position - pos : Vector2.zero;
+            float distanceToPlayer = toPlayer.magnitude;
+            Vector2 directionToPlayer = distanceToPlayer > 0f ? toPlayer / distanceToPlayer : Vector2.zero;
+            approachSpread.Compute(
+                radial,
+                directionToPlayer,
+                _approachSeparation,
+                _hasApproachNeighbors,
+                _approachSpreadBias,
+                distanceToPlayer,
+                holdRadius,
+                _gapCW,
+                _gapCCW,
+                _surroundParticipantCount > 1,
+                speed,
+                out radial,
+                out tangent);
+        }
 
         if (_chaseRequested && steerTarget != null)
         {

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyRingManager.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyRingManager.cs
@@ -52,7 +52,7 @@ public class EnemyRingManager : MonoBehaviour
             var eligibility = e.GetComponent<EnemySurroundEligibility>();
             if (eligibility == null || !eligibility.IsEligibleFor(player))
             {
-                e.SetAngularGaps(0f, 0f);
+                e.SetAngularGaps(0f, 0f, 0);
                 continue;
             }
 
@@ -68,6 +68,8 @@ public class EnemyRingManager : MonoBehaviour
 
         if (count == 0) return;
 
+        FeedApproachSeparation(count);
+
         // Sort by angle (ascending), keeping arrays in sync
         QuickSortByKey(sAngles, sEnemies, sDists, 0, count - 1);
 
@@ -82,7 +84,7 @@ public class EnemyRingManager : MonoBehaviour
         if (count == 1)
         {
             // Single enemy: no meaningful neighbors; send zeros
-            sEnemies[0].SetAngularGaps(0f, 0f);
+            sEnemies[0].SetAngularGaps(0f, 0f, 1);
             return;
         }
 
@@ -115,7 +117,35 @@ public class EnemyRingManager : MonoBehaviour
                 gapCCW = 0f;
             }
 
-            sEnemies[i].SetAngularGaps(gapCW, gapCCW);
+            sEnemies[i].SetAngularGaps(gapCW, gapCCW, count);
+        }
+    }
+
+    private static void FeedApproachSeparation(int count)
+    {
+        for (int i = 0; i < count; i++)
+        {
+            EnemyController2D enemy = sEnemies[i];
+            Vector2 position = enemy.transform.position;
+            float radius = enemy.ApproachSeparationRadius;
+            float radiusSquared = radius * radius;
+            Vector2 separation = Vector2.zero;
+            bool hasNeighbors = false;
+
+            for (int j = 0; j < count; j++)
+            {
+                if (i == j) continue;
+                Vector2 away = position - (Vector2)sEnemies[j].transform.position;
+                float distanceSquared = away.sqrMagnitude;
+                if (distanceSquared > radiusSquared) continue;
+
+                hasNeighbors = true;
+                if (distanceSquared <= 0.0001f) continue;
+                float distance = Mathf.Sqrt(distanceSquared);
+                separation += away / distance * (1f - distance / radius);
+            }
+
+            enemy.SetApproachSeparation(separation, hasNeighbors);
         }
     }
 

--- a/Assets/_Project/_Tests/EditMode/AI/EnemyApproachSpreadTests.cs
+++ b/Assets/_Project/_Tests/EditMode/AI/EnemyApproachSpreadTests.cs
@@ -70,10 +70,10 @@ namespace Castlebound.Tests.AI
         }
 
         [Test]
-        public void GroupInsideArrivalDistance_SteersTowardLargerAngularGap()
+        public void EnemyEastOfPlayer_SteersNorthTowardLargerCounterClockwiseGap()
         {
             EnemyApproachSpread.ComputeApproach(
-                Vector2.right * 8f, Vector2.right, Vector2.zero, false, Vector2.zero,
+                Vector2.left * 8f, Vector2.left, Vector2.zero, false, Vector2.zero,
                 distance: 8f, holdRadius: 2.6f,
                 gapCW: 0.1f, gapCCW: 0.5f, hasGroup: true, speed: 8f,
                 separationStrength: 0.8f, maxLateralRatio: 0.35f,
@@ -82,7 +82,7 @@ namespace Castlebound.Tests.AI
                 out Vector2 radial, out Vector2 tangent);
 
             Assert.That(tangent.y, Is.GreaterThan(0f));
-            Assert.That(radial.x, Is.GreaterThanOrEqualTo(6.4f));
+            Assert.That(radial.x, Is.LessThanOrEqualTo(-6.4f));
         }
 
         [Test]

--- a/Assets/_Project/_Tests/EditMode/AI/EnemyApproachSpreadTests.cs
+++ b/Assets/_Project/_Tests/EditMode/AI/EnemyApproachSpreadTests.cs
@@ -101,5 +101,22 @@ namespace Castlebound.Tests.AI
             Assert.That(radial, Is.EqualTo(pursuit));
             Assert.That(tangent, Is.EqualTo(Vector2.zero));
         }
+
+        [Test]
+        public void SeparatedGroupWithClearedGaps_DoesNotUseFallbackBias()
+        {
+            var pursuit = Vector2.right * 8f;
+            EnemyApproachSpread.ComputeApproach(
+                pursuit, Vector2.right, Vector2.zero, hasNeighbors: false, stableBias: Vector2.up,
+                distance: 8f, holdRadius: 2.6f,
+                gapCW: 0f, gapCCW: 0f, hasGroup: true, speed: 8f,
+                separationStrength: 0.8f, maxLateralRatio: 0.35f,
+                minimumForwardRatio: 0.8f, surroundArrivalDistance: 10f,
+                maxAngularArrivalRatio: 0.18f, gapDeadbandRadians: 8f * Mathf.Deg2Rad,
+                out Vector2 radial, out Vector2 tangent);
+
+            Assert.That(radial, Is.EqualTo(pursuit));
+            Assert.That(tangent, Is.EqualTo(Vector2.zero));
+        }
     }
 }

--- a/Assets/_Project/_Tests/EditMode/AI/EnemyApproachSpreadTests.cs
+++ b/Assets/_Project/_Tests/EditMode/AI/EnemyApproachSpreadTests.cs
@@ -1,0 +1,105 @@
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Castlebound.Tests.AI
+{
+    public class EnemyApproachSpreadTests
+    {
+        [Test]
+        public void CrowdedApproach_BlendsLocalSeparationAndPreservesForwardFloor()
+        {
+            EnemyApproachSpread.ComputeApproach(
+                pursuit: Vector2.right * 8f,
+                directionToTarget: Vector2.right,
+                localSeparation: Vector2.up,
+                hasNeighbors: true,
+                stableBias: Vector2.zero,
+                speed: 8f,
+                separationStrength: 0.8f,
+                maxLateralRatio: 0.35f,
+                minimumForwardRatio: 0.8f,
+                out Vector2 radial,
+                out Vector2 tangent);
+
+            Assert.That(tangent.y, Is.GreaterThan(0f));
+            Assert.That(radial.x, Is.GreaterThanOrEqualTo(6.4f));
+            Assert.That((radial + tangent).magnitude, Is.LessThanOrEqualTo(8.001f));
+        }
+
+        [Test]
+        public void CoincidentNeighbors_UseStableBiasToBreakSymmetry()
+        {
+            EnemyApproachSpread.ComputeApproach(
+                Vector2.right * 8f, Vector2.right, Vector2.zero, true,
+                stableBias: new Vector2(0.2f, -0.8f), speed: 8f,
+                separationStrength: 0.8f, maxLateralRatio: 0.35f,
+                minimumForwardRatio: 0.8f,
+                out _, out Vector2 tangent);
+
+            Assert.That(tangent.y, Is.LessThan(0f));
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void UncrowdedApproach_RemainsDirect(bool hasNeighbors)
+        {
+            var pursuit = Vector2.right * 8f;
+
+            EnemyApproachSpread.ComputeApproach(
+                pursuit, Vector2.right, Vector2.zero, hasNeighbors,
+                stableBias: Vector2.zero, speed: 8f,
+                separationStrength: 0.8f, maxLateralRatio: 0.35f,
+                minimumForwardRatio: 0.8f,
+                out Vector2 radial, out Vector2 tangent);
+
+            Assert.That(radial, Is.EqualTo(pursuit));
+            Assert.That(tangent, Is.EqualTo(Vector2.zero));
+        }
+
+        [Test]
+        public void StrongSeparation_NeverReversesPursuit()
+        {
+            EnemyApproachSpread.ComputeApproach(
+                Vector2.right * 8f, Vector2.right, new Vector2(-10f, 10f), true,
+                stableBias: Vector2.zero, speed: 8f,
+                separationStrength: 1f, maxLateralRatio: 0.5f,
+                minimumForwardRatio: 0.75f,
+                out Vector2 radial, out _);
+
+            Assert.That(radial.x, Is.GreaterThanOrEqualTo(6f));
+        }
+
+        [Test]
+        public void GroupInsideArrivalDistance_SteersTowardLargerAngularGap()
+        {
+            EnemyApproachSpread.ComputeApproach(
+                Vector2.right * 8f, Vector2.right, Vector2.zero, false, Vector2.zero,
+                distance: 8f, holdRadius: 2.6f,
+                gapCW: 0.1f, gapCCW: 0.5f, hasGroup: true, speed: 8f,
+                separationStrength: 0.8f, maxLateralRatio: 0.35f,
+                minimumForwardRatio: 0.8f, surroundArrivalDistance: 10f,
+                maxAngularArrivalRatio: 0.18f, gapDeadbandRadians: 8f * Mathf.Deg2Rad,
+                out Vector2 radial, out Vector2 tangent);
+
+            Assert.That(tangent.y, Is.GreaterThan(0f));
+            Assert.That(radial.x, Is.GreaterThanOrEqualTo(6.4f));
+        }
+
+        [Test]
+        public void GroupOutsideArrivalDistance_DoesNotShapeDistantRing()
+        {
+            var pursuit = Vector2.right * 8f;
+            EnemyApproachSpread.ComputeApproach(
+                pursuit, Vector2.right, Vector2.zero, false, Vector2.up,
+                distance: 13f, holdRadius: 2.6f,
+                gapCW: 0f, gapCCW: 0.5f, hasGroup: true, speed: 8f,
+                separationStrength: 0.8f, maxLateralRatio: 0.35f,
+                minimumForwardRatio: 0.8f, surroundArrivalDistance: 10f,
+                maxAngularArrivalRatio: 0.18f, gapDeadbandRadians: 8f * Mathf.Deg2Rad,
+                out Vector2 radial, out Vector2 tangent);
+
+            Assert.That(radial, Is.EqualTo(pursuit));
+            Assert.That(tangent, Is.EqualTo(Vector2.zero));
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/AI/EnemyApproachSpreadTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/AI/EnemyApproachSpreadTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cb7757dbd8a2e3c4da38c5ec7203a4ed
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/_Tests/EditMode/AI/EnemySurroundPrefabContractTests.cs
+++ b/Assets/_Project/_Tests/EditMode/AI/EnemySurroundPrefabContractTests.cs
@@ -16,6 +16,8 @@ namespace Castlebound.Tests.AI
             Assert.NotNull(prefab, $"Expected melee prefab at {prefabPath}.");
             Assert.NotNull(prefab.GetComponent<EnemySurroundEligibility>(),
                 $"Melee prefab {prefabPath} must opt into player-surround calculations.");
+            Assert.NotNull(prefab.GetComponent<EnemyApproachSpread>(),
+                $"Melee prefab {prefabPath} must define approach spreading.");
         }
     }
 }

--- a/Assets/_Project/_Tests/PlayMode/AI/EnemyApproachSpreadPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/AI/EnemyApproachSpreadPlayTests.cs
@@ -1,0 +1,172 @@
+using System.Collections;
+using System.Reflection;
+using Castlebound.Gameplay.AI;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Castlebound.Tests.PlayMode.AI
+{
+    public class EnemyApproachSpreadPlayTests
+    {
+        [UnityTest]
+        public IEnumerator ClusteredMeleeGroup_FormsMultiplePathsEarlyInApproach()
+        {
+            var player = CreatePlayer();
+            var managerObject = new GameObject("EnemyRingManager");
+            var enemies = new[]
+            {
+                CreateEnemy(player.transform, new Vector2(12f, 0f)),
+                CreateEnemy(player.transform, new Vector2(12f, 0f)),
+                CreateEnemy(player.transform, new Vector2(12f, 0f)),
+                CreateEnemy(player.transform, new Vector2(12f, 0f)),
+                CreateEnemy(player.transform, new Vector2(12f, 0f))
+            };
+            try
+            {
+                managerObject.AddComponent<EnemyRingManager>();
+                for (int i = 0; i < 15; i++) yield return new WaitForFixedUpdate();
+                float[] lateralPositions = GetSortedY(enemies);
+                Assert.That(lateralPositions[4] - lateralPositions[0], Is.GreaterThan(0.35f));
+                Assert.That(CountDistinct(lateralPositions, 0.04f), Is.GreaterThanOrEqualTo(3));
+                Assert.That(Vector2.Distance(enemies[2].transform.position, player.transform.position),
+                    Is.GreaterThan(8f), "Spreading should be visible early in the approach.");
+            }
+            finally
+            {
+                DestroyEnemies(enemies);
+                Object.Destroy(managerObject);
+                Object.Destroy(player);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator AlreadySpacedGroup_ContinuesMostlyForward()
+        {
+            var player = CreatePlayer();
+            var managerObject = new GameObject("EnemyRingManager");
+            var enemies = new[]
+            {
+                CreateEnemy(player.transform, new Vector2(10f, -2f)),
+                CreateEnemy(player.transform, new Vector2(10f, 0f)),
+                CreateEnemy(player.transform, new Vector2(10f, 2f))
+            };
+            try
+            {
+                managerObject.AddComponent<EnemyRingManager>();
+                for (int i = 0; i < 10; i++) yield return new WaitForFixedUpdate();
+                float[] endY = GetSortedY(enemies);
+                Assert.That(Mathf.Abs(endY[0]), Is.LessThan(2f),
+                    "An uncrowded enemy should keep pursuing the player instead of peeling outward.");
+                Assert.That(Mathf.Abs(endY[2]), Is.LessThan(2f));
+                Assert.That(Mathf.Abs(endY[0] + endY[2]), Is.LessThan(0.02f),
+                    "An already-spaced symmetric group should remain symmetric.");
+            }
+            finally
+            {
+                DestroyEnemies(enemies);
+                Object.Destroy(managerObject);
+                Object.Destroy(player);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator LoneMeleeEnemy_ApproachesWithoutSidewaysMotion()
+        {
+            var player = CreatePlayer();
+            var managerObject = new GameObject("EnemyRingManager");
+            var enemy = CreateEnemy(player.transform, new Vector2(8f, 0f));
+            try
+            {
+                managerObject.AddComponent<EnemyRingManager>();
+                for (int i = 0; i < 10; i++) yield return new WaitForFixedUpdate();
+                Assert.That(enemy.transform.position.x, Is.LessThan(8f));
+                Assert.That(Mathf.Abs(enemy.transform.position.y), Is.LessThan(0.01f));
+            }
+            finally
+            {
+                DestroyEnemies(new[] { enemy });
+                Object.Destroy(managerObject);
+                Object.Destroy(player);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator ForcedAttackReacquisition_ChasesDirectlyWithoutSpreading()
+        {
+            var player = CreatePlayer();
+            var enemy = CreateEnemy(player.transform, new Vector2(8f, 0f));
+            var controller = enemy.GetComponent<EnemyController2D>();
+            try
+            {
+                controller.SetApproachSeparation(Vector2.up, true);
+                controller.RequestChase();
+                yield return new WaitForFixedUpdate();
+                Assert.That(enemy.transform.position.x, Is.LessThan(8f));
+                Assert.That(Mathf.Abs(enemy.transform.position.y), Is.LessThan(0.001f));
+            }
+            finally
+            {
+                DestroyEnemies(new[] { enemy });
+                Object.Destroy(player);
+            }
+        }
+
+        private static GameObject CreatePlayer()
+        {
+            var player = new GameObject("Player");
+            player.tag = "Player";
+            return player;
+        }
+
+        private static GameObject CreateEnemy(Transform player, Vector2 position)
+        {
+            var enemy = new GameObject("Enemy");
+            enemy.transform.position = position;
+            var body = enemy.AddComponent<Rigidbody2D>();
+            body.gravityScale = 0f;
+            enemy.AddComponent<Health>().ConfigureMaxHealth(10, refill: true);
+            enemy.AddComponent<EnemyRootReceiver>();
+            enemy.AddComponent<EnemySurroundEligibility>();
+            enemy.AddComponent<EnemyApproachSpread>();
+            var controller = enemy.AddComponent<EnemyController2D>();
+            controller.Speed = 8f;
+            SetField(controller, "useBarrierTargeting", false);
+            controller.Debug_SetupRefs(player);
+            SetField(controller, "_currentTargetType", EnemyTargetType.Player);
+            return enemy;
+        }
+
+        private static float[] GetSortedY(GameObject[] enemies)
+        {
+            var values = new float[enemies.Length];
+            for (int i = 0; i < enemies.Length; i++) values[i] = enemies[i].transform.position.y;
+            System.Array.Sort(values);
+            return values;
+        }
+
+        private static int CountDistinct(float[] sortedValues, float tolerance)
+        {
+            int count = sortedValues.Length > 0 ? 1 : 0;
+            for (int i = 1; i < sortedValues.Length; i++)
+                if (sortedValues[i] - sortedValues[i - 1] > tolerance) count++;
+            return count;
+        }
+
+        private static void SetField(object instance, string fieldName, object value)
+        {
+            instance.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)
+                ?.SetValue(instance, value);
+        }
+
+        private static void DestroyEnemies(GameObject[] enemies)
+        {
+            for (int i = 0; i < enemies.Length; i++)
+            {
+                if (enemies[i] == null) continue;
+                enemies[i].SetActive(false);
+                Object.Destroy(enemies[i]);
+            }
+        }
+    }
+}

--- a/Assets/_Project/_Tests/PlayMode/AI/EnemyApproachSpreadPlayTests.cs.meta
+++ b/Assets/_Project/_Tests/PlayMode/AI/EnemyApproachSpreadPlayTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 28b7fafb131cac64da61fe8cb73d1306
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -13,13 +13,13 @@
 
 ### New or Updated Tests
 **EditMode**
-- `EnemyApproachSpreadTests` and `EnemySurroundPrefabContractTests` — cover local separation, overlap fallback, arrival-band gap steering, distant direct pursuit, forward progress, speed caps, and melee prefab contracts.
+- `EnemyApproachSpreadTests` and `EnemySurroundPrefabContractTests` — cover local separation, overlap fallback, cleared non-local gaps, arrival-band gap steering, distant direct pursuit, forward progress, speed caps, and melee prefab contracts.
 
 **PlayMode**
 - `EnemyApproachSpreadPlayTests` — covers early multi-path separation, direct spaced and lone pursuit, and direct #245 forced reacquisition.
 
 ### Notes
-- EditMode 731/731 and PlayMode 59/59 passed in an isolated Unity project because the primary project was open in another editor instance.
+- EditMode 732/732 and PlayMode 59/59 passed; manual validation confirmed separated enemies no longer receive fallback sideways steering.
 
 ## 2026-07-17 - fix-247-surround-eligibility
 

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,23 @@
 
 ---
 
+## 2026-07-18 - feat-246-approach-spreading
+
+### Summary
+- Added local separation plus bounded open-angle arrival steering for eligible melee enemies during player pursuit.
+- Preserved direct lone-enemy, barrier, HOLD, and forced attack-reacquisition movement.
+- Added stable overlap symmetry breaking, gradual surround-arrival tuning, and forward-motion limits to both melee prefabs.
+
+### New or Updated Tests
+**EditMode**
+- `EnemyApproachSpreadTests` and `EnemySurroundPrefabContractTests` — cover local separation, overlap fallback, arrival-band gap steering, distant direct pursuit, forward progress, speed caps, and melee prefab contracts.
+
+**PlayMode**
+- `EnemyApproachSpreadPlayTests` — covers early multi-path separation, direct spaced and lone pursuit, and direct #245 forced reacquisition.
+
+### Notes
+- EditMode 731/731 and PlayMode 59/59 passed in an isolated Unity project because the primary project was open in another editor instance.
+
 ## 2026-07-17 - fix-247-surround-eligibility
 
 ### Summary

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -13,13 +13,13 @@
 
 ### New or Updated Tests
 **EditMode**
-- `EnemyApproachSpreadTests` and `EnemySurroundPrefabContractTests` — cover local separation, overlap fallback, cleared non-local gaps, arrival-band gap steering, distant direct pursuit, forward progress, speed caps, and melee prefab contracts.
+- `EnemyApproachSpreadTests` and `EnemySurroundPrefabContractTests` — cover local separation, overlap fallback, cleared non-local gaps, world-direction open-gap steering, distant direct pursuit, forward progress, speed caps, and melee prefab contracts.
 
 **PlayMode**
 - `EnemyApproachSpreadPlayTests` — covers early multi-path separation, direct spaced and lone pursuit, and direct #245 forced reacquisition.
 
 ### Notes
-- EditMode 732/732 and PlayMode 59/59 passed; manual validation confirmed separated enemies no longer receive fallback sideways steering.
+- EditMode 732/732 and PlayMode 59/59 passed; manual validation confirmed open-gap steering still behaves as intended.
 
 ## 2026-07-17 - fix-247-surround-eligibility
 


### PR DESCRIPTION
## Why
Melee enemies approached the player as a dense, orderly clump and only began separating near HOLD range. This change introduces earlier, bounded separation while preserving direct pursuit and combat behavior.

## What changed
- Added local separation between eligible melee enemies during player pursuit
- Added conservative open-angle steering within the arrival range
- Corrected angular-gap direction so enemies steer toward open space instead of the occupied side
- Added stable symmetry breaking for enemies occupying the same position
- Restricted zero-gap fallback steering to physically nearby enemies so separated groups continue pursuing directly
- Added regression guards for cleared non-local gaps and world-direction open-gap steering
- Preserved direct lone-enemy, barrier, HOLD, and forced attack-reacquisition movement
- Added speed-relative limits that preserve forward pressure
- Added the approach-spreading component and tuning to both melee prefabs
- Reverted the unsuccessful explicit crescent-formation experiment

## How to test
1. Open the existing gameplay scene and spawn several melee enemies together
2. Press Play and verify enemies begin separating during CHASE while continuing to pressure the player
3. Verify enemies with an asymmetric opening steer toward the open side
4. Place eligible enemies far apart or on opposite sides of the player and verify they do not peel sideways
5. Verify lone enemies pursue directly and attack reacquisition does not introduce sideways movement
6. Run tests:
   - EditMode: 732/732
   - PlayMode: 59/59
7. Manual gameplay validation: passed

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated (N/A - validated in the existing gameplay scene; no scene changes required)
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched (TEST_LOG.md updated)

## Related
- Closes #246