### PR TITLE
refactor(ai): separate enemy targeting and locomotion

### DIFF
--- a/Assets/_Project/Prefabs/Enemy.prefab
+++ b/Assets/_Project/Prefabs/Enemy.prefab
@@ -105,6 +105,8 @@ GameObject:
   - component: {fileID: 6382125908214597412}
   - component: {fileID: 8041287619235472011}
   - component: {fileID: 8041287619235472012}
+  - component: {fileID: 8041287619235472013}
+  - component: {fileID: 8041287619235472014}
   m_Layer: 7
   m_Name: Enemy
   m_TagString: Enemy
@@ -202,13 +204,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9b42b7e1aae77f64e8810845a4e4cbbc, type: 3}
   m_Name:
   m_EditorClassIdentifier:
-  target: {fileID: 0}
-  player: {fileID: 0}
   barrier: {fileID: 0}
-  homeBarrier: {fileID: 0}
-  steerTarget: {fileID: 0}
-  passThroughRadius: 2
   regionState: {fileID: 0}
+  targeting: {fileID: 8041287619235472013}
+  locomotion: {fileID: 8041287619235472014}
   speed: 8
   holdRadius: 2.6
   releaseMargin: 1.2
@@ -217,8 +216,38 @@ MonoBehaviour:
   outrunFrames: 8
   epsilonDist: 0.01
   reseatBias: 1
+  approachSpread: {fileID: 0}
+  surroundEligibility: {fileID: 0}
+--- !u!114 &8041287619235472013
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6394411849047796180}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6aabf131cfbb4e549cefa04df62479c7, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  player: {fileID: 0}
+  homeBarrier: {fileID: 0}
+  passThroughRadius: 2
   useBarrierTargeting: 1
+--- !u!114 &8041287619235472014
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6394411849047796180}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 566ef92fc4a64ac89775be82528fdb02, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
   knockbackReceiver: {fileID: 0}
+  rootReceiver: {fileID: 0}
 --- !u!114 &5939097710446132315
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/_Project/Prefabs/Enemy_Lurker.prefab
+++ b/Assets/_Project/Prefabs/Enemy_Lurker.prefab
@@ -125,6 +125,8 @@ GameObject:
   - component: {fileID: 6382125908214597412}
   - component: {fileID: 8041287619235472011}
   - component: {fileID: 8041287619235472012}
+  - component: {fileID: 8041287619235472013}
+  - component: {fileID: 8041287619235472014}
   m_Layer: 7
   m_Name: Enemy_Lurker
   m_TagString: Enemy
@@ -222,13 +224,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9b42b7e1aae77f64e8810845a4e4cbbc, type: 3}
   m_Name:
   m_EditorClassIdentifier:
-  target: {fileID: 0}
-  player: {fileID: 0}
   barrier: {fileID: 0}
-  homeBarrier: {fileID: 0}
-  steerTarget: {fileID: 0}
-  passThroughRadius: 2
   regionState: {fileID: 0}
+  targeting: {fileID: 8041287619235472013}
+  locomotion: {fileID: 8041287619235472014}
   speed: 3
   holdRadius: 2.6
   releaseMargin: 1.2
@@ -237,8 +236,38 @@ MonoBehaviour:
   outrunFrames: 8
   epsilonDist: 0.01
   reseatBias: 1
+  approachSpread: {fileID: 0}
+  surroundEligibility: {fileID: 0}
+--- !u!114 &8041287619235472013
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6394411849047796180}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6aabf131cfbb4e549cefa04df62479c7, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  player: {fileID: 0}
+  homeBarrier: {fileID: 0}
+  passThroughRadius: 2
   useBarrierTargeting: 1
+--- !u!114 &8041287619235472014
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6394411849047796180}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 566ef92fc4a64ac89775be82528fdb02, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
   knockbackReceiver: {fileID: 0}
+  rootReceiver: {fileID: 0}
 --- !u!114 &5939097710446132315
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyController2D.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyController2D.cs
@@ -2,6 +2,8 @@ using System.Collections.Generic;
 using UnityEngine;
 using Castlebound.Gameplay.AI;
 
+[RequireComponent(typeof(EnemyTargeting))]
+[RequireComponent(typeof(EnemyLocomotion))]
 public class EnemyController2D : MonoBehaviour
 {
     public enum State
@@ -27,13 +29,10 @@ public class EnemyController2D : MonoBehaviour
         return distanceToBarrier <= holdRadius;
     }
 
-    [SerializeField] private Transform target;           // current orbit/spacing target (player)
-    [SerializeField] private Transform player;           // authoritative player reference
     [SerializeField] private Transform barrier;
-    [SerializeField] private Transform homeBarrier;      // per-enemy assigned barrier (nearest at spawn)
-    [SerializeField] private Transform steerTarget;      // movement target (home barrier outside, player inside)
-    [SerializeField] private float passThroughRadius = 0.6f; // distance to consider "at" the barrier opening
     [SerializeField] private EnemyRegionState regionState;
+    [SerializeField] private EnemyTargeting targeting;
+    [SerializeField] private EnemyLocomotion locomotion;
 
     [SerializeField] private float speed = 3.5f;
     [SerializeField] private float holdRadius = 2.6f;    // R_in
@@ -43,42 +42,56 @@ public class EnemyController2D : MonoBehaviour
     [SerializeField] private int outrunFrames = 8;
     [SerializeField] private float epsilonDist = 0.01f;
     [SerializeField] private float reseatBias = 0.3f;
-    [SerializeField] private bool useBarrierTargeting = true;
-    [SerializeField] private EnemyKnockbackReceiver knockbackReceiver;
-    [SerializeField] private EnemyRootReceiver rootReceiver;
     [SerializeField] private EnemyApproachSpread approachSpread;
     [SerializeField] private EnemySurroundEligibility surroundEligibility;
 
-    public Transform Target => target;
+    private EnemyTargeting Targeting
+    {
+        get
+        {
+            if (targeting == null)
+                targeting = GetComponent<EnemyTargeting>();
+
+            return targeting;
+        }
+    }
+
+    private EnemyLocomotion Locomotion
+    {
+        get
+        {
+            if (locomotion == null)
+                locomotion = GetComponent<EnemyLocomotion>();
+
+            return locomotion;
+        }
+    }
+
+    public Transform Target => Targeting != null ? Targeting.AttackTarget : null;
     public float Speed
     {
         get => speed;
         set => speed = Mathf.Max(0f, value);
     }
 
-    private EnemyTargetType _currentTargetType = EnemyTargetType.None;
-    public EnemyTargetType CurrentTargetType => _currentTargetType;
+    public EnemyTargetType CurrentTargetType => Targeting != null
+        ? Targeting.CurrentTargetType
+        : EnemyTargetType.None;
 
     // NEW: used by EnemyAttack to decide when we're close enough to attack.
     public bool IsInHoldRange()
     {
-        return _state == State.HOLD;
+        return Locomotion.IsInHoldRange;
     }
 
     private Rigidbody2D _rb;
-    private State _state = State.CHASE;
-    private float _prevDist;
-    private int _distTrend;
     private float _gapCW;
     private float _gapCCW;
     private int _surroundParticipantCount;
     private Vector2 _approachSeparation;
     private bool _hasApproachNeighbors;
     private Vector2 _approachSpreadBias;
-    private bool _chaseRequested;
-    public bool IsChaseRequested => _chaseRequested;
-    // Last non-zero direction toward our current target (for pass-through).
-    private Vector2 _lastNonZeroDir = Vector2.right;
+    public bool IsChaseRequested => Locomotion.IsChaseRequested;
 
     public void SetAngularGaps(float gapCW, float gapCCW)
     {
@@ -104,26 +117,19 @@ public class EnemyController2D : MonoBehaviour
 
     public void RequestChase()
     {
-        _chaseRequested = true;
-        _state = State.CHASE;
+        Locomotion.RequestChase();
     }
 
     public void ClearChaseRequest()
     {
-        _chaseRequested = false;
+        Locomotion.ClearChaseRequest();
     }
 
     private void Awake()
     {
         _rb = GetComponent<Rigidbody2D>();
-        if (knockbackReceiver == null)
-        {
-            knockbackReceiver = GetComponent<EnemyKnockbackReceiver>();
-        }
-        if (rootReceiver == null)
-        {
-            rootReceiver = GetComponent<EnemyRootReceiver>();
-        }
+        targeting = GetComponent<EnemyTargeting>();
+        locomotion = GetComponent<EnemyLocomotion>();
         if (approachSpread == null)
         {
             approachSpread = GetComponent<EnemyApproachSpread>();
@@ -137,23 +143,7 @@ public class EnemyController2D : MonoBehaviour
             regionState = GetComponent<EnemyRegionState>();
         }
 
-        // Ensure player reference is valid.
-        EnsurePlayerReference();
-
-        // Initialize target from player.
-        if (player != null)
-        {
-            target = player;
-            steerTarget = player;
-            Vector2 pos = _rb != null ? _rb.position : (Vector2)transform.position;
-            _prevDist = Vector2.Distance(pos, target.position);
-        }
-        else
-        {
-            target = null;
-            steerTarget = null;
-            _prevDist = 0f;
-        }
+        Targeting.Initialize();
 
         // Home barrier assignment deferred to Start to ensure barriers are registered.
     }
@@ -180,13 +170,7 @@ public class EnemyController2D : MonoBehaviour
 
     private void Start()
     {
-        if (useBarrierTargeting && homeBarrier == null)
-        {
-            homeBarrier = CastleTargetSelector.AssignHomeBarrier(
-                transform.position,
-                GetAllBarrierTransforms());
-            barrier = homeBarrier;
-        }
+        Targeting.AssignHomeBarrierIfNeeded(transform.position);
     }
 
     private void FixedUpdate()
@@ -201,51 +185,27 @@ public class EnemyController2D : MonoBehaviour
         {
             regionState = GetComponent<EnemyRegionState>();
         }
-        if (knockbackReceiver == null)
-        {
-            knockbackReceiver = GetComponent<EnemyKnockbackReceiver>();
-        }
-        if (rootReceiver == null)
-        {
-            rootReceiver = GetComponent<EnemyRootReceiver>();
-        }
 
         bool enemyInsideCastle = regionState != null && regionState.EnemyInside;
         bool playerInsideCastle = regionState != null && regionState.PlayerInside;
 
-        if (player != null)
-        {
-            var decision = EvaluateTargetDecision(playerInsideCastle, enemyInsideCastle);
-            steerTarget = decision.SteerTarget != null ? decision.SteerTarget : player;
-            target = decision.AttackTarget != null ? decision.AttackTarget : player;
-            _currentTargetType = decision.TargetType;
-
-            if (useBarrierTargeting && _currentTargetType == EnemyTargetType.Barrier)
-            {
-                barrier = steerTarget;
-            }
-        }
+        Targeting.Refresh(_rb.position, playerInsideCastle, enemyInsideCastle);
+        Transform steerTarget = Targeting.SteerTarget;
+        Transform target = Targeting.AttackTarget;
+        Transform player = Targeting.Player;
+        if (CurrentTargetType == EnemyTargetType.Barrier)
+            barrier = steerTarget;
 
         Vector2 pos = _rb.position;
         float dt = Time.fixedDeltaTime;
 
-        if (rootReceiver != null && rootReceiver.IsRooted)
-        {
-            return;
-        }
-
-        Vector2 knockbackDelta = knockbackReceiver != null ? knockbackReceiver.ConsumeDisplacement(dt) : Vector2.zero;
-
         if (target == null)
         {
-            if (knockbackDelta != Vector2.zero)
-            {
-                _rb.MovePosition(pos + knockbackDelta);
-            }
+            Locomotion.ExecuteMovement(_rb, Vector2.zero, Vector2.zero, dt);
             return;
         }
         if (steerTarget == null) steerTarget = target;
-        EnemyMovement.ComputeMovement(
+        Locomotion.ComputeBaseMovement(
             pos,
             steerTarget,
             barrier,
@@ -259,16 +219,12 @@ public class EnemyController2D : MonoBehaviour
             epsilonDist,
             _gapCW,
             _gapCCW,
-            ref _state,
-            ref _prevDist,
-            ref _distTrend,
-            ref _lastNonZeroDir,
             out Vector2 radial,
             out Vector2 tangent);
 
-        if (_state == State.CHASE &&
-            !_chaseRequested &&
-            _currentTargetType == EnemyTargetType.Player &&
+        if (Locomotion.CurrentState == State.CHASE &&
+            !Locomotion.IsChaseRequested &&
+            CurrentTargetType == EnemyTargetType.Player &&
             approachSpread != null &&
             surroundEligibility != null &&
             surroundEligibility.IsEligibleFor(player))
@@ -292,27 +248,27 @@ public class EnemyController2D : MonoBehaviour
                 out tangent);
         }
 
-        if (_chaseRequested && steerTarget != null)
+        if (Locomotion.IsChaseRequested && steerTarget != null)
         {
             Vector2 toTarget = (Vector2)steerTarget.position - pos;
             radial = toTarget.sqrMagnitude > 0f ? toTarget.normalized * speed : Vector2.zero;
             tangent = Vector2.zero;
-            _state = State.CHASE;
+            Locomotion.SetMovementState(State.CHASE);
         }
 
-        _rb.MovePosition(pos + (radial + tangent) * dt + knockbackDelta);
+        Locomotion.ExecuteMovement(_rb, radial, tangent, dt);
     }
 
     private Transform SelectTarget(bool playerInside, bool enemyInside)
     {
-        var decision = EvaluateTargetDecision(playerInside, enemyInside);
-        return decision.AttackTarget;
+        Targeting.Refresh(transform.position, playerInside, enemyInside);
+        return Targeting.AttackTarget;
     }
 
     private Transform SelectSteerTarget(bool playerInside, bool enemyInside)
     {
-        var decision = EvaluateTargetDecision(playerInside, enemyInside);
-        return decision.SteerTarget;
+        Targeting.Refresh(transform.position, playerInside, enemyInside);
+        return Targeting.SteerTarget;
     }
 
     public Transform Debug_SelectTarget(bool playerInside, bool enemyInside)
@@ -328,108 +284,43 @@ public class EnemyController2D : MonoBehaviour
     // Debug/test helper to ensure player reference via tag/lookup.
     public void Debug_EnsurePlayerReference()
     {
-        EnsurePlayerReference();
+        Targeting.Initialize();
     }
 
     // Test helper: force references for deterministic behavior in EditMode tests.
     public void Debug_SetupRefs(Transform playerRef, Transform homeRef = null)
     {
-        player = playerRef;
-        target = playerRef;
-        steerTarget = playerRef;
-        homeBarrier = homeRef;
+        Targeting.Debug_Setup(playerRef, homeRef);
         barrier = homeRef;
+        Targeting.AssignHomeBarrierIfNeeded(transform.position);
+        barrier = Targeting.HomeBarrier;
+    }
 
-        if (homeBarrier == null && useBarrierTargeting)
-        {
-            homeBarrier = CastleTargetSelector.AssignHomeBarrier(
-                transform.position,
-                GetAllBarrierTransforms());
-            barrier = homeBarrier;
-        }
+    public void Debug_SetTargetDecision(Transform steer, Transform attack, EnemyTargetType targetType)
+    {
+        Targeting.Debug_SetDecision(steer, attack, targetType);
+    }
+
+    public void Debug_SetBarrierTargeting(bool value)
+    {
+        Targeting.Debug_SetUseBarrierTargeting(value);
     }
 
 #if UNITY_EDITOR
     // Editor-only validation helper to surface missing refs without relying on Unity lifecycle.
     public void Debug_ValidateRefs()
     {
-        if (player == null)
+        if (Targeting == null || Targeting.Player == null)
         {
             Debug.LogWarning("[EnemyController2D] Player reference not found in scene. Enemy will have no target.", this);
         }
 
-        if (useBarrierTargeting && homeBarrier == null)
+        if (Targeting != null && Targeting.UsesBarrierTargeting && Targeting.HomeBarrier == null)
         {
             Debug.LogWarning("[EnemyController2D] No home barrier found while barrier targeting is enabled.", this);
         }
     }
 #endif
-
-    private void EnsurePlayerReference()
-    {
-        if (player != null) return;
-
-        GameObject playerGO = GameObject.FindGameObjectWithTag("Player");
-        if (playerGO != null)
-        {
-            player = playerGO.transform;
-            target = player;
-            steerTarget = player;
-            return;
-        }
-
-        var pc = FindObjectOfType<PlayerController>();
-        if (pc != null)
-        {
-            player = pc.transform;
-            target = player;
-            steerTarget = player;
-        }
-    }
-
-    private void EnsureHomeBarrier(Transform[] gates)
-    {
-        if (homeBarrier != null) return;
-        if (!useBarrierTargeting) return;
-
-        homeBarrier = CastleTargetSelector.AssignHomeBarrier(
-            transform.position,
-            gates);
-        barrier = homeBarrier;
-    }
-
-    private EnemyTargetSelector.Decision EvaluateTargetDecision(bool playerInside, bool enemyInside)
-    {
-        if (useBarrierTargeting)
-        {
-            EnsureHomeBarrier(GetAllBarrierTransforms());
-        }
-
-        return EnemyTargetSelector.Select(new EnemyTargetSelector.Input
-        {
-            EnemyPosition = transform.position,
-            EnemyInside = enemyInside,
-            PlayerInside = playerInside,
-            Player = player,
-            HomeBarrier = homeBarrier,
-            PassThroughRadius = passThroughRadius
-        });
-    }
-
-    private static Transform[] GetAllBarrierTransforms()
-    {
-        var all = BarrierHealth.All;
-        if (all == null || all.Count == 0)
-            return System.Array.Empty<Transform>();
-
-        var result = new Transform[all.Count];
-        for (int i = 0; i < all.Count; i++)
-        {
-            result[i] = all[i] != null ? all[i].transform : null;
-        }
-
-        return result;
-    }
 
     private void OnDrawGizmosSelected()
     {
@@ -447,9 +338,9 @@ public class EnemyController2D : MonoBehaviour
         tangent = Vector2.zero;
         if (_rb == null) return;
 
-        EnemyMovement.ComputeMovement(
+        Locomotion.ComputeBaseMovement(
             _rb.position,
-            steerTarget,
+            Targeting != null ? Targeting.SteerTarget : null,
             barrier,
             holdRadius,
             releaseMargin,
@@ -461,10 +352,6 @@ public class EnemyController2D : MonoBehaviour
             epsilonDist,
             _gapCW,
             _gapCCW,
-            ref _state,
-            ref _prevDist,
-            ref _distTrend,
-            ref _lastNonZeroDir,
             out radial,
             out tangent);
     }

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyLocomotion.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyLocomotion.cs
@@ -1,0 +1,92 @@
+using UnityEngine;
+using Castlebound.Gameplay.AI;
+
+public class EnemyLocomotion : MonoBehaviour
+{
+    [SerializeField] private EnemyKnockbackReceiver knockbackReceiver;
+    [SerializeField] private EnemyRootReceiver rootReceiver;
+
+    private float previousDistance;
+    private int distanceTrend;
+    private Vector2 lastNonZeroDirection = Vector2.right;
+
+    public EnemyController2D.State CurrentState { get; private set; } = EnemyController2D.State.CHASE;
+    public bool IsChaseRequested { get; private set; }
+    public bool IsInHoldRange => CurrentState == EnemyController2D.State.HOLD;
+
+    public void RequestChase()
+    {
+        IsChaseRequested = true;
+        CurrentState = EnemyController2D.State.CHASE;
+    }
+
+    public void ClearChaseRequest()
+    {
+        IsChaseRequested = false;
+    }
+
+    public void SetMovementState(EnemyController2D.State state)
+    {
+        CurrentState = state;
+    }
+
+    public void ComputeBaseMovement(
+        Vector2 position,
+        Transform steerTarget,
+        Transform barrier,
+        float holdRadius,
+        float releaseMargin,
+        float reseatBias,
+        float speed,
+        float orbitBase,
+        float maxTangent,
+        int outrunFrames,
+        float epsilonDistance,
+        float gapClockwise,
+        float gapCounterClockwise,
+        out Vector2 radial,
+        out Vector2 tangent)
+    {
+        EnemyController2D.State movementState = CurrentState;
+        EnemyMovement.ComputeMovement(
+            position,
+            steerTarget,
+            barrier,
+            holdRadius,
+            releaseMargin,
+            reseatBias,
+            speed,
+            orbitBase,
+            maxTangent,
+            outrunFrames,
+            epsilonDistance,
+            gapClockwise,
+            gapCounterClockwise,
+            ref movementState,
+            ref previousDistance,
+            ref distanceTrend,
+            ref lastNonZeroDirection,
+            out radial,
+            out tangent);
+        CurrentState = movementState;
+    }
+
+    public void ExecuteMovement(Rigidbody2D body, Vector2 radial, Vector2 tangent, float deltaTime)
+    {
+        if (body == null)
+            return;
+
+        if (rootReceiver == null)
+            rootReceiver = GetComponent<EnemyRootReceiver>();
+        if (rootReceiver != null && rootReceiver.IsRooted)
+            return;
+
+        if (knockbackReceiver == null)
+            knockbackReceiver = GetComponent<EnemyKnockbackReceiver>();
+
+        Vector2 knockback = knockbackReceiver != null
+            ? knockbackReceiver.ConsumeDisplacement(deltaTime)
+            : Vector2.zero;
+        body.MovePosition(body.position + (radial + tangent) * deltaTime + knockback);
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyLocomotion.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyLocomotion.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 566ef92fc4a64ac89775be82528fdb02

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyTargeting.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyTargeting.cs
@@ -1,0 +1,137 @@
+using UnityEngine;
+using Castlebound.Gameplay.AI;
+
+public class EnemyTargeting : MonoBehaviour
+{
+    [SerializeField] private Transform player;
+    [SerializeField] private Transform homeBarrier;
+    [SerializeField] private float passThroughRadius = 0.6f;
+    [SerializeField] private bool useBarrierTargeting = true;
+
+    private bool committedThroughBrokenBarrier;
+
+    public Transform Player => player;
+    public Transform HomeBarrier => homeBarrier;
+    public bool UsesBarrierTargeting => useBarrierTargeting;
+    public Transform SteerTarget { get; private set; }
+    public Transform AttackTarget { get; private set; }
+    public EnemyTargetType CurrentTargetType { get; private set; } = EnemyTargetType.None;
+
+    public void Initialize()
+    {
+        EnsurePlayerReference();
+        ApplyFallbackDecision();
+    }
+
+    public void AssignHomeBarrierIfNeeded(Vector2 enemyPosition)
+    {
+        if (!useBarrierTargeting || homeBarrier != null)
+            return;
+
+        homeBarrier = CastleTargetSelector.AssignHomeBarrier(enemyPosition, GetAllBarrierTransforms());
+    }
+
+    public void Refresh(Vector2 enemyPosition, bool playerInside, bool enemyInside)
+    {
+        EnsurePlayerReference();
+        AssignHomeBarrierIfNeeded(enemyPosition);
+
+        if (!playerInside)
+        {
+            committedThroughBrokenBarrier = false;
+        }
+        else if (IsAtBrokenHomeBarrier(enemyPosition))
+        {
+            committedThroughBrokenBarrier = true;
+        }
+
+        if (committedThroughBrokenBarrier)
+        {
+            ApplyFallbackDecision();
+            return;
+        }
+
+        EnemyTargetSelector.Decision decision = EnemyTargetSelector.Select(new EnemyTargetSelector.Input
+        {
+            EnemyPosition = enemyPosition,
+            EnemyInside = enemyInside,
+            PlayerInside = playerInside,
+            Player = player,
+            HomeBarrier = useBarrierTargeting ? homeBarrier : null,
+            PassThroughRadius = passThroughRadius
+        });
+
+        SteerTarget = decision.SteerTarget;
+        AttackTarget = decision.AttackTarget;
+        CurrentTargetType = decision.TargetType;
+    }
+
+    public void Debug_Setup(Transform playerReference, Transform homeBarrierReference = null)
+    {
+        player = playerReference;
+        homeBarrier = homeBarrierReference;
+        ApplyFallbackDecision();
+    }
+
+    public void Debug_SetDecision(Transform steer, Transform attack, EnemyTargetType targetType)
+    {
+        SteerTarget = steer;
+        AttackTarget = attack;
+        CurrentTargetType = targetType;
+    }
+
+    public void Debug_SetUseBarrierTargeting(bool value)
+    {
+        useBarrierTargeting = value;
+    }
+
+    private void ApplyFallbackDecision()
+    {
+        SteerTarget = player;
+        AttackTarget = player;
+        CurrentTargetType = player != null ? EnemyTargetType.Player : EnemyTargetType.None;
+    }
+
+    private void EnsurePlayerReference()
+    {
+        if (player != null)
+            return;
+
+        GameObject playerObject = GameObject.FindGameObjectWithTag("Player");
+        if (playerObject != null)
+        {
+            player = playerObject.transform;
+            return;
+        }
+
+        PlayerController playerController = FindObjectOfType<PlayerController>();
+        if (playerController != null)
+            player = playerController.transform;
+    }
+
+    private bool IsAtBrokenHomeBarrier(Vector2 enemyPosition)
+    {
+        if (!useBarrierTargeting || homeBarrier == null || passThroughRadius <= 0f)
+            return false;
+
+        BarrierHealth health = homeBarrier.GetComponent<BarrierHealth>();
+        if (health == null || !health.IsBroken)
+            return false;
+
+        return ((Vector2)homeBarrier.position - enemyPosition).sqrMagnitude <=
+               passThroughRadius * passThroughRadius;
+    }
+
+    private static Transform[] GetAllBarrierTransforms()
+    {
+        var barriers = BarrierHealth.All;
+        if (barriers == null || barriers.Count == 0)
+            return System.Array.Empty<Transform>();
+
+        var result = new Transform[barriers.Count];
+        for (int i = 0; i < barriers.Count; i++)
+            result[i] = barriers[i] != null ? barriers[i].transform : null;
+
+        return result;
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyTargeting.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyTargeting.cs
@@ -40,6 +40,10 @@ public class EnemyTargeting : MonoBehaviour
         {
             committedThroughBrokenBarrier = false;
         }
+        else if (committedThroughBrokenBarrier && !enemyInside && !IsHomeBarrierBroken())
+        {
+            committedThroughBrokenBarrier = false;
+        }
         else if (IsAtBrokenHomeBarrier(enemyPosition))
         {
             committedThroughBrokenBarrier = true;
@@ -114,12 +118,20 @@ public class EnemyTargeting : MonoBehaviour
         if (!useBarrierTargeting || homeBarrier == null || passThroughRadius <= 0f)
             return false;
 
-        BarrierHealth health = homeBarrier.GetComponent<BarrierHealth>();
-        if (health == null || !health.IsBroken)
+        if (!IsHomeBarrierBroken())
             return false;
 
         return ((Vector2)homeBarrier.position - enemyPosition).sqrMagnitude <=
                passThroughRadius * passThroughRadius;
+    }
+
+    private bool IsHomeBarrierBroken()
+    {
+        if (!useBarrierTargeting || homeBarrier == null)
+            return false;
+
+        BarrierHealth health = homeBarrier.GetComponent<BarrierHealth>();
+        return health != null && health.IsBroken;
     }
 
     private static Transform[] GetAllBarrierTransforms()

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyTargeting.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyTargeting.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6aabf131cfbb4e549cefa04df62479c7

--- a/Assets/_Project/_Tests/EditMode/AI/EnemyController/EnemyControllerKnockbackTests.cs
+++ b/Assets/_Project/_Tests/EditMode/AI/EnemyController/EnemyControllerKnockbackTests.cs
@@ -22,9 +22,7 @@ namespace Castlebound.Tests.AI
                 var knockback = enemy.AddComponent<Castlebound.Gameplay.AI.EnemyKnockbackReceiver>();
 
                 // Force no valid target path.
-                typeof(EnemyController2D)
-                    .GetField("target", BindingFlags.NonPublic | BindingFlags.Instance)
-                    ?.SetValue(controller, null);
+                controller.Debug_SetupRefs(null);
 
                 knockback.AddKnockback(new Vector2(5f, 0f), 4f);
 

--- a/Assets/_Project/_Tests/EditMode/AI/EnemyController/EnemyControllerValidationTests.cs
+++ b/Assets/_Project/_Tests/EditMode/AI/EnemyController/EnemyControllerValidationTests.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
 using UnityEngine;
-using System.Collections.Generic;
 
 namespace Castlebound.Tests.AI
 {
@@ -31,7 +30,7 @@ namespace Castlebound.Tests.AI
                 controller.Debug_EnsurePlayerReference();
 
                 // Assert: player reference is picked up by tag and target set.
-                var assignedPlayer = GetPrivateField<Transform>(controller, "player");
+                var assignedPlayer = enemyGO.GetComponent<EnemyTargeting>().Player;
                 Assert.IsNotNull(assignedPlayer, "Controller should assign player reference by Player tag if missing.");
                 Assert.AreSame(player.transform, assignedPlayer, "Controller should bind to the tagged Player we created.");
                 Assert.AreSame(player.transform, controller.Target, "Controller target should be set to the found player.");
@@ -50,12 +49,6 @@ namespace Castlebound.Tests.AI
                     }
                 }
             }
-        }
-
-        private static T GetPrivateField<T>(object obj, string fieldName) where T : class
-        {
-            var field = obj.GetType().GetField(fieldName, System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-            return field?.GetValue(obj) as T;
         }
     }
 }

--- a/Assets/_Project/_Tests/EditMode/AI/EnemyLocomotionTests.cs
+++ b/Assets/_Project/_Tests/EditMode/AI/EnemyLocomotionTests.cs
@@ -1,0 +1,94 @@
+using NUnit.Framework;
+using UnityEngine;
+using Castlebound.Gameplay.AI;
+
+public class EnemyLocomotionTests
+{
+    [Test]
+    public void RequestChase_LeavesHoldAndRecordsRequestUntilCleared()
+    {
+        GameObject enemy = new GameObject("Enemy");
+        try
+        {
+            EnemyLocomotion locomotion = enemy.AddComponent<EnemyLocomotion>();
+            locomotion.SetMovementState(EnemyController2D.State.HOLD);
+
+            locomotion.RequestChase();
+
+            Assert.AreEqual(EnemyController2D.State.CHASE, locomotion.CurrentState);
+            Assert.IsTrue(locomotion.IsChaseRequested);
+            Assert.IsFalse(locomotion.IsInHoldRange);
+
+            locomotion.ClearChaseRequest();
+            Assert.IsFalse(locomotion.IsChaseRequested);
+        }
+        finally
+        {
+            Object.DestroyImmediate(enemy);
+        }
+    }
+
+    [Test]
+    public void HoldState_ExposesAttackEligibility()
+    {
+        GameObject enemy = new GameObject("Enemy");
+        try
+        {
+            EnemyLocomotion locomotion = enemy.AddComponent<EnemyLocomotion>();
+            locomotion.SetMovementState(EnemyController2D.State.HOLD);
+
+            Assert.IsTrue(locomotion.IsInHoldRange);
+        }
+        finally
+        {
+            Object.DestroyImmediate(enemy);
+        }
+    }
+
+    [Test]
+    public void ComputeBaseMovement_EntersHoldAtPlayerRadius()
+    {
+        GameObject enemy = new GameObject("Enemy");
+        GameObject player = new GameObject("Player");
+        player.transform.position = new Vector2(0.5f, 0f);
+
+        try
+        {
+            EnemyLocomotion locomotion = enemy.AddComponent<EnemyLocomotion>();
+
+            locomotion.ComputeBaseMovement(
+                Vector2.zero, player.transform, null,
+                1f, 0.5f, 0.3f, 3f, 0.8f, 2.5f, 8, 0.01f,
+                0f, 0f, out _, out _);
+
+            Assert.AreEqual(EnemyController2D.State.HOLD, locomotion.CurrentState);
+            Assert.IsTrue(locomotion.IsInHoldRange);
+        }
+        finally
+        {
+            Object.DestroyImmediate(enemy);
+            Object.DestroyImmediate(player);
+        }
+    }
+
+    [Test]
+    public void ExecuteMovement_DoesNotMoveRootedEnemy()
+    {
+        GameObject enemy = new GameObject("Enemy");
+        try
+        {
+            Rigidbody2D body = enemy.AddComponent<Rigidbody2D>();
+            EnemyRootReceiver root = enemy.AddComponent<EnemyRootReceiver>();
+            EnemyLocomotion locomotion = enemy.AddComponent<EnemyLocomotion>();
+            root.RootForSeconds(1f);
+
+            locomotion.ExecuteMovement(body, Vector2.right * 3f, Vector2.zero, 0.02f);
+
+            Assert.AreEqual(Vector2.zero, body.position);
+        }
+        finally
+        {
+            Object.DestroyImmediate(enemy);
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/AI/EnemyLocomotionTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/AI/EnemyLocomotionTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7142d95874ea42eab5b2970514d6f07c

--- a/Assets/_Project/_Tests/EditMode/AI/EnemyRingEligibilityTests.cs
+++ b/Assets/_Project/_Tests/EditMode/AI/EnemyRingEligibilityTests.cs
@@ -152,9 +152,7 @@ namespace Castlebound.Tests.AI
 
         private static void SetTargetType(EnemyController2D controller, EnemyTargetType targetType)
         {
-            typeof(EnemyController2D)
-                .GetField("_currentTargetType", BindingFlags.Instance | BindingFlags.NonPublic)
-                ?.SetValue(controller, targetType);
+            controller.Debug_SetTargetDecision(controller.Target, controller.Target, targetType);
         }
 
         private static void GetGaps(EnemyController2D controller, out float gapCw, out float gapCcw)

--- a/Assets/_Project/_Tests/EditMode/AI/EnemySurroundPrefabContractTests.cs
+++ b/Assets/_Project/_Tests/EditMode/AI/EnemySurroundPrefabContractTests.cs
@@ -19,5 +19,36 @@ namespace Castlebound.Tests.AI
             Assert.NotNull(prefab.GetComponent<EnemyApproachSpread>(),
                 $"Melee prefab {prefabPath} must define approach spreading.");
         }
+
+        [TestCase("Assets/_Project/Prefabs/Enemy.prefab")]
+        [TestCase("Assets/_Project/Prefabs/Enemy_Lurker.prefab")]
+        public void CurrentMeleePrefab_DefinesExtractedResponsibilities(string prefabPath)
+        {
+            var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(prefabPath);
+
+            Assert.NotNull(prefab, $"Expected melee prefab at {prefabPath}.");
+
+            var controller = prefab.GetComponent<EnemyController2D>();
+            var targeting = prefab.GetComponent<EnemyTargeting>();
+            var locomotion = prefab.GetComponent<EnemyLocomotion>();
+
+            Assert.NotNull(controller, $"Melee prefab {prefabPath} must define its controller.");
+            Assert.NotNull(targeting, $"Melee prefab {prefabPath} must define targeting.");
+            Assert.NotNull(locomotion, $"Melee prefab {prefabPath} must define locomotion.");
+
+            var controllerData = new SerializedObject(controller);
+            Assert.That(
+                controllerData.FindProperty("targeting").objectReferenceValue,
+                Is.EqualTo(targeting));
+            Assert.That(
+                controllerData.FindProperty("locomotion").objectReferenceValue,
+                Is.EqualTo(locomotion));
+
+            var targetingData = new SerializedObject(targeting);
+            Assert.That(
+                targetingData.FindProperty("passThroughRadius").floatValue,
+                Is.EqualTo(2f).Within(0.001f),
+                $"Melee prefab {prefabPath} must retain its authored pass-through radius.");
+        }
     }
 }

--- a/Assets/_Project/_Tests/EditMode/AI/EnemyTargetingTests.cs
+++ b/Assets/_Project/_Tests/EditMode/AI/EnemyTargetingTests.cs
@@ -1,0 +1,119 @@
+using Castlebound.Gameplay.AI;
+using NUnit.Framework;
+using UnityEngine;
+
+public class EnemyTargetingTests
+{
+    [Test]
+    public void Refresh_ProducesSingleBarrierDecisionForMovementAndAttack()
+    {
+        GameObject enemy = new GameObject("Enemy");
+        GameObject player = new GameObject("Player");
+        GameObject barrier = new GameObject("Barrier");
+        barrier.AddComponent<BarrierHealth>();
+
+        try
+        {
+            EnemyTargeting targeting = enemy.AddComponent<EnemyTargeting>();
+            targeting.Debug_Setup(player.transform, barrier.transform);
+
+            targeting.Refresh(enemy.transform.position, playerInside: true, enemyInside: false);
+
+            Assert.AreSame(barrier.transform, targeting.SteerTarget);
+            Assert.AreSame(barrier.transform, targeting.AttackTarget);
+            Assert.AreEqual(EnemyTargetType.Barrier, targeting.CurrentTargetType);
+        }
+        finally
+        {
+            Object.DestroyImmediate(enemy);
+            Object.DestroyImmediate(player);
+            Object.DestroyImmediate(barrier);
+        }
+    }
+
+    [Test]
+    public void Refresh_ProducesSinglePlayerDecisionAfterEnemyEntersCastle()
+    {
+        GameObject enemy = new GameObject("Enemy");
+        GameObject player = new GameObject("Player");
+        GameObject barrier = new GameObject("Barrier");
+        barrier.AddComponent<BarrierHealth>();
+
+        try
+        {
+            EnemyTargeting targeting = enemy.AddComponent<EnemyTargeting>();
+            targeting.Debug_Setup(player.transform, barrier.transform);
+
+            targeting.Refresh(enemy.transform.position, playerInside: true, enemyInside: true);
+
+            Assert.AreSame(player.transform, targeting.SteerTarget);
+            Assert.AreSame(player.transform, targeting.AttackTarget);
+            Assert.AreEqual(EnemyTargetType.Player, targeting.CurrentTargetType);
+        }
+        finally
+        {
+            Object.DestroyImmediate(enemy);
+            Object.DestroyImmediate(player);
+            Object.DestroyImmediate(barrier);
+        }
+    }
+
+    [Test]
+    public void Refresh_BrokenBarrierIngress_DoesNotRetargetBarrierWhenRegionFlickersOutside()
+    {
+        GameObject enemy = new GameObject("Enemy");
+        GameObject player = new GameObject("Player");
+        GameObject barrier = new GameObject("Barrier");
+        BarrierHealth barrierHealth = barrier.AddComponent<BarrierHealth>();
+        barrierHealth.TakeDamage(barrierHealth.MaxHealth);
+
+        try
+        {
+            EnemyTargeting targeting = enemy.AddComponent<EnemyTargeting>();
+            targeting.Debug_Setup(player.transform, barrier.transform);
+
+            targeting.Refresh(new Vector2(0.5f, 0f), playerInside: true, enemyInside: false);
+            targeting.Refresh(new Vector2(0.7f, 0f), playerInside: true, enemyInside: false);
+
+            Assert.AreSame(player.transform, targeting.SteerTarget,
+                "An enemy committed through a broken opening must not steer back to the barrier when the region boundary flickers.");
+            Assert.AreEqual(EnemyTargetType.Player, targeting.CurrentTargetType);
+        }
+        finally
+        {
+            Object.DestroyImmediate(enemy);
+            Object.DestroyImmediate(player);
+            Object.DestroyImmediate(barrier);
+        }
+    }
+
+    [Test]
+    public void Refresh_BrokenBarrierIngressCommitment_ClearsWhenPlayerLeavesCastle()
+    {
+        GameObject enemy = new GameObject("Enemy");
+        GameObject player = new GameObject("Player");
+        GameObject barrier = new GameObject("Barrier");
+        BarrierHealth barrierHealth = barrier.AddComponent<BarrierHealth>();
+        barrierHealth.TakeDamage(barrierHealth.MaxHealth);
+
+        try
+        {
+            EnemyTargeting targeting = enemy.AddComponent<EnemyTargeting>();
+            targeting.Debug_Setup(player.transform, barrier.transform);
+
+            targeting.Refresh(new Vector2(0.5f, 0f), playerInside: true, enemyInside: false);
+            targeting.Refresh(new Vector2(2f, 0f), playerInside: false, enemyInside: false);
+            targeting.Refresh(new Vector2(2f, 0f), playerInside: true, enemyInside: false);
+
+            Assert.AreSame(barrier.transform, targeting.SteerTarget,
+                "A later siege approach must be allowed to target its home barrier again.");
+            Assert.AreEqual(EnemyTargetType.Barrier, targeting.CurrentTargetType);
+        }
+        finally
+        {
+            Object.DestroyImmediate(enemy);
+            Object.DestroyImmediate(player);
+            Object.DestroyImmediate(barrier);
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/AI/EnemyTargetingTests.cs
+++ b/Assets/_Project/_Tests/EditMode/AI/EnemyTargetingTests.cs
@@ -116,4 +116,37 @@ public class EnemyTargetingTests
             Object.DestroyImmediate(barrier);
         }
     }
+
+    [Test]
+    public void Refresh_RepairedBarrierAndEnemyOutside_RetargetsHomeBarrier()
+    {
+        GameObject enemy = new GameObject("Enemy");
+        GameObject player = new GameObject("Player");
+        GameObject barrier = new GameObject("Barrier");
+        BarrierHealth barrierHealth = barrier.AddComponent<BarrierHealth>();
+        barrierHealth.TakeDamage(barrierHealth.MaxHealth);
+
+        try
+        {
+            EnemyTargeting targeting = enemy.AddComponent<EnemyTargeting>();
+            targeting.Debug_Setup(player.transform, barrier.transform);
+
+            targeting.Refresh(new Vector2(0.5f, 0f), playerInside: true, enemyInside: false);
+            Assert.AreEqual(EnemyTargetType.Player, targeting.CurrentTargetType);
+
+            barrierHealth.Repair();
+            targeting.Refresh(new Vector2(2f, 0f), playerInside: true, enemyInside: false);
+
+            Assert.AreSame(barrier.transform, targeting.SteerTarget);
+            Assert.AreSame(barrier.transform, targeting.AttackTarget);
+            Assert.AreEqual(EnemyTargetType.Barrier, targeting.CurrentTargetType);
+        }
+        finally
+        {
+            Object.DestroyImmediate(enemy);
+            Object.DestroyImmediate(player);
+            Object.DestroyImmediate(barrier);
+        }
+    }
+
 }

--- a/Assets/_Project/_Tests/EditMode/AI/EnemyTargetingTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/AI/EnemyTargetingTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f0e7c57b16be40b0a66d96a4e10b2679

--- a/Assets/_Project/_Tests/EditMode/Combat/EnemyAttack/EnemyAttackTargetTypeTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Combat/EnemyAttack/EnemyAttackTargetTypeTests.cs
@@ -80,9 +80,7 @@ namespace Castlebound.Tests.Combat
         {
             // Directly assign for test; real flow uses selector.
             controller.Debug_SetupRefs(target, null);
-            typeof(EnemyController2D)
-                .GetField("_currentTargetType", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
-                ?.SetValue(controller, targetType);
+            controller.Debug_SetTargetDecision(target, target, targetType);
         }
 
         private static void SetRegionState(EnemyRegionState state, bool enemyInside, bool playerInside)

--- a/Assets/_Project/_Tests/PlayMode/AI/EnemyApproachSpreadPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/AI/EnemyApproachSpreadPlayTests.cs
@@ -131,9 +131,9 @@ namespace Castlebound.Tests.PlayMode.AI
             enemy.AddComponent<EnemyApproachSpread>();
             var controller = enemy.AddComponent<EnemyController2D>();
             controller.Speed = 8f;
-            SetField(controller, "useBarrierTargeting", false);
+            controller.Debug_SetBarrierTargeting(false);
             controller.Debug_SetupRefs(player);
-            SetField(controller, "_currentTargetType", EnemyTargetType.Player);
+            controller.Debug_SetTargetDecision(player.transform, player.transform, EnemyTargetType.Player);
             return enemy;
         }
 

--- a/Assets/_Project/_Tests/PlayMode/AI/EnemyRingEligibilityPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/AI/EnemyRingEligibilityPlayTests.cs
@@ -82,9 +82,7 @@ namespace Castlebound.Tests.PlayMode.AI
 
         private static void SetTargetType(EnemyController2D controller, EnemyTargetType targetType)
         {
-            typeof(EnemyController2D)
-                .GetField("_currentTargetType", BindingFlags.Instance | BindingFlags.NonPublic)
-                ?.SetValue(controller, targetType);
+            controller.Debug_SetTargetDecision(controller.Target, controller.Target, targetType);
         }
 
         private static void GetGaps(EnemyController2D controller, out float gapCw, out float gapCcw)

--- a/Assets/_Project/_Tests/PlayMode/AI/EnemyTargetingPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/AI/EnemyTargetingPlayTests.cs
@@ -1,0 +1,45 @@
+using System.Collections;
+using Castlebound.Gameplay.AI;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Castlebound.Tests.PlayMode.AI
+{
+    public class EnemyTargetingPlayTests
+    {
+        [UnityTest]
+        public IEnumerator RepairedBarrierPushback_RestoresBarrierTarget()
+        {
+            var enemy = new GameObject("Enemy");
+            var player = new GameObject("Player");
+            var barrier = new GameObject("Barrier");
+            var barrierHealth = barrier.AddComponent<BarrierHealth>();
+            barrierHealth.TakeDamage(barrierHealth.MaxHealth);
+            var targeting = enemy.AddComponent<EnemyTargeting>();
+            targeting.Debug_Setup(player.transform, barrier.transform);
+
+            try
+            {
+                targeting.Refresh(new Vector2(0.5f, 0f), playerInside: true, enemyInside: false);
+                Assert.AreEqual(EnemyTargetType.Player, targeting.CurrentTargetType);
+
+                barrierHealth.Repair();
+                enemy.transform.position = new Vector2(2f, 0f);
+                yield return null;
+
+                targeting.Refresh(enemy.transform.position, playerInside: true, enemyInside: false);
+
+                Assert.AreSame(barrier.transform, targeting.SteerTarget);
+                Assert.AreSame(barrier.transform, targeting.AttackTarget);
+                Assert.AreEqual(EnemyTargetType.Barrier, targeting.CurrentTargetType);
+            }
+            finally
+            {
+                Object.Destroy(enemy);
+                Object.Destroy(player);
+                Object.Destroy(barrier);
+            }
+        }
+    }
+}

--- a/Assets/_Project/_Tests/PlayMode/AI/EnemyTargetingPlayTests.cs.meta
+++ b/Assets/_Project/_Tests/PlayMode/AI/EnemyTargetingPlayTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d7c80f22184b4ec8aa8e06f885313286

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,23 @@
 
 ---
 
+## 2026-07-25 - refactor-242-prefab-migration
+
+### Summary
+- Added EnemyTargeting and EnemyLocomotion to both serialized melee prefabs.
+- Migrated the authored barrier pass-through radius to EnemyTargeting.
+- Added prefab contract coverage for extracted component references and tuning.
+
+### New or Updated Tests
+**EditMode**
+- EnemySurroundPrefabContractTests — verifies both melee prefabs serialize targeting, locomotion, controller references, and pass-through tuning.
+
+**PlayMode**
+- N/A — existing enemy behavior regression coverage remains unchanged.
+
+### Notes
+- EditMode and PlayMode passed; manual validation confirmed enemy behavior and player controls function correctly after restarting Unity.
+
 ## 2026-07-23 - refactor-242-enemy-responsibilities
 
 ### Summary

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,23 @@
 
 ---
 
+## 2026-07-23 - refactor-242-enemy-responsibilities
+
+### Summary
+- Extracted target selection and target state into EnemyTargeting.
+- Extracted CHASE/HOLD state, root handling, knockback, and body movement into EnemyLocomotion.
+- Reduced EnemyController2D to orchestration while preserving existing melee behavior.
+
+### New or Updated Tests
+**EditMode**
+- EnemyTargetingTests and EnemyLocomotionTests — cover unified target decisions, ingress commitment, CHASE/HOLD state, root handling, and movement ownership.
+
+**PlayMode**
+- EnemyApproachSpreadPlayTests and EnemyRingEligibilityPlayTests — preserve approach spreading and surround eligibility through the extracted components.
+
+### Notes
+- EditMode 740/740 and PlayMode 59/59 passed in an isolated Unity project; repaired-barrier pushback regression is deferred to the next commit.
+
 ## 2026-07-18 - feat-246-approach-spreading
 
 ### Summary

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -10,16 +10,17 @@
 - Extracted target selection and target state into EnemyTargeting.
 - Extracted CHASE/HOLD state, root handling, knockback, and body movement into EnemyLocomotion.
 - Reduced EnemyController2D to orchestration while preserving existing melee behavior.
+- Restored home-barrier targeting when a repaired barrier pushes a committed enemy outside.
 
 ### New or Updated Tests
 **EditMode**
-- EnemyTargetingTests and EnemyLocomotionTests — cover unified target decisions, ingress commitment, CHASE/HOLD state, root handling, and movement ownership.
+- EnemyTargetingTests and EnemyLocomotionTests — cover unified target decisions, ingress commitment reset after repair, CHASE/HOLD state, root handling, and movement ownership.
 
 **PlayMode**
-- EnemyApproachSpreadPlayTests and EnemyRingEligibilityPlayTests — preserve approach spreading and surround eligibility through the extracted components.
+- EnemyTargetingPlayTests, EnemyApproachSpreadPlayTests, and EnemyRingEligibilityPlayTests — cover repaired-barrier retargeting and preserve approach spreading and surround eligibility.
 
 ### Notes
-- EditMode 740/740 and PlayMode 59/59 passed in an isolated Unity project; repaired-barrier pushback regression is deferred to the next commit.
+- EditMode 741/741 and PlayMode 60/60 passed; manual validation confirmed repaired-barrier retargeting and outside-enemy knockback.
 
 ## 2026-07-18 - feat-246-approach-spreading
 


### PR DESCRIPTION
## Why
EnemyController2D coordinated targeting, movement state, root handling, knockback, barrier behavior, and attack setup. Separating these responsibilities makes future facing and attack-alignment work safer while preserving current melee behavior.

The existing melee prefabs also needed explicit migration because RequireComponent does not retrofit dependencies onto already serialized prefab components.

## What changed
- Extracted target selection and target state into EnemyTargeting
- Extracted CHASE/HOLD state and movement execution into EnemyLocomotion
- Moved root and knockback handling into EnemyLocomotion
- Reduced EnemyController2D to coordinating targeting, movement, and approach adjustments
- Preserved unified movement and attack targets
- Preserved broken-opening commitment through region-boundary flicker
- Restored home-barrier targeting after a repaired barrier pushes an enemy outside
- Added EnemyTargeting and EnemyLocomotion to Enemy.prefab and Enemy_Lurker.prefab
- Wired both extracted component references into each serialized EnemyController2D
- Migrated the authored pass-through radius of 2 to each EnemyTargeting component
- Updated existing tests to configure the extracted components
- Added focused EditMode, PlayMode, and prefab-contract regression coverage

## How to test
1. Open the existing gameplay scene
2. Press Play and verify normal and Lurker enemies spawn without exceptions
3. Verify enemies outside the castle chase the player normally
4. Move inside and verify outside enemies target their home barriers
5. Break a barrier and verify enemies entering the castle target the player
6. Repair the barrier and verify pushed-out enemies retarget that same barrier
7. Verify root, knockback, melee attacks, approach spreading, and player controls remain unchanged
8. Run tests:
   - EditMode: passed
   - PlayMode: passed

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated (N/A - no scene changes required)
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched (N/A - TEST_LOG updated; no README changes required)

## Related
- Closes #242