### PR TITLE
feat(spawning): add directional grouped spawn markers

### DIFF
--- a/Assets/_Project/Prefabs/Barrier_Gate.prefab
+++ b/Assets/_Project/Prefabs/Barrier_Gate.prefab
@@ -1040,7 +1040,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0d31ea5d0f52b344a869a4b936a05b05, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  gateId: Barrier_Gate
+  laneId: Center
 --- !u!1001 &8240005810329671612
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyFacing.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyFacing.cs
@@ -15,6 +15,12 @@ public class EnemyFacing : MonoBehaviour
         ApplyVisualDirection();
     }
 
+    public void InitializeAimDirection(Vector2 direction)
+    {
+        AimDirection = NormalizeOrZero(direction);
+        ApplyVisualDirection();
+    }
+
     public void FaceTarget(Vector2 origin, Transform target, float deltaTime)
     {
         if (target == null)

--- a/Assets/_Project/Scripts/_Project.Gameplay/Castle/BarrierAssemblyBuilder.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Castle/BarrierAssemblyBuilder.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Castlebound.Gameplay.Spawning;
 using UnityEngine;
 
 namespace Castlebound.Gameplay.Castle
@@ -41,6 +42,12 @@ namespace Castlebound.Gameplay.Castle
 
                 instance.SetParent(parent, true);
                 instance.position = new Vector3(slot.Position.x, slot.Position.y, instance.position.z);
+
+                var gateIdProvider = instance.GetComponent<GateIdProvider>();
+                if (gateIdProvider != null)
+                {
+                    gateIdProvider.Initialize(slot.Id);
+                }
 
                 var visualBinder = instance.GetComponent<BarrierVisualBinder>();
                 if (visualBinder != null)

--- a/Assets/_Project/Scripts/_Project.Gameplay/Spawning/EnemySpawner.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Spawning/EnemySpawner.cs
@@ -7,13 +7,14 @@ namespace Castlebound.Gameplay.Spawning
     {
         private readonly EnemySpawnSchedule _schedule;
         private readonly List<SpawnPoint> _spawnPoints;
-        private int _gateIndex;
+        private SpawnSequence _orderedSequence;
+        private List<SpawnPoint> _currentSpawnOrder;
+        private int _currentSpawnOrderIndex;
 
         public EnemySpawner(EnemySpawnSchedule schedule, IEnumerable<SpawnPoint> spawnPoints)
         {
             _schedule = schedule;
             _spawnPoints = spawnPoints?.ToList() ?? new List<SpawnPoint>();
-            _gateIndex = 0;
         }
 
         public List<SpawnRequest> Tick(float deltaTime)
@@ -30,10 +31,10 @@ namespace Castlebound.Gameplay.Spawning
 
             while (current.IsReadyToSpawn())
             {
-                var spawnPoint = _spawnPoints[_gateIndex];
-                _gateIndex = (_gateIndex + 1) % _spawnPoints.Count;
+                EnsureSpawnOrder(current);
+                var spawnPoint = _currentSpawnOrder[_currentSpawnOrderIndex++];
 
-                readySpawns.Add(new SpawnRequest(current.EnemyTypeId, spawnPoint.GateId, spawnPoint.Position));
+                readySpawns.Add(new SpawnRequest(current.EnemyTypeId, spawnPoint));
 
                 current.ConsumeSpawn();
 
@@ -51,6 +52,21 @@ namespace Castlebound.Gameplay.Spawning
             }
 
             return readySpawns;
+        }
+
+        private void EnsureSpawnOrder(SpawnSequence sequence)
+        {
+            if (ReferenceEquals(_orderedSequence, sequence))
+            {
+                return;
+            }
+
+            _orderedSequence = sequence;
+            _currentSpawnOrder = SpawnMarkerOrderBuilder.BuildGateOrder(
+                _spawnPoints,
+                sequence.SpawnCount,
+                SpawnMarkerStrategy.RoundRobin);
+            _currentSpawnOrderIndex = 0;
         }
     }
 }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Spawning/EnemySpawnerRunner.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Spawning/EnemySpawnerRunner.cs
@@ -169,6 +169,12 @@ namespace Castlebound.Gameplay.Spawning
                 var instance = Instantiate(prefab, request.Position, Quaternion.identity);
                 _aliveCount++;
 
+                var facing = instance.GetComponent<EnemyFacing>();
+                if (facing != null && request.ForwardDirection.sqrMagnitude > Mathf.Epsilon)
+                {
+                    facing.InitializeAimDirection(request.ForwardDirection);
+                }
+
                 var balanceApplier = instance.GetComponent<EnemyBalanceApplier>();
                 if (balanceApplier != null)
                 {

--- a/Assets/_Project/Scripts/_Project.Gameplay/Spawning/EnemyWaveSpawner.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Spawning/EnemyWaveSpawner.cs
@@ -114,7 +114,7 @@ namespace Castlebound.Gameplay.Spawning
                 var startsAt = requests.Count;
                 foreach (var gate in gateOrder)
                 {
-                    requests.Add(new SpawnRequest(seq.enemyTypeId, gate.GateId, gate.Position));
+                    requests.Add(new SpawnRequest(seq.enemyTypeId, gate));
                 }
 
                 _sequenceTimers.Add(new SequenceTimer

--- a/Assets/_Project/Scripts/_Project.Gameplay/Spawning/GateIdProvider.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Spawning/GateIdProvider.cs
@@ -8,6 +8,11 @@ namespace Castlebound.Gameplay.Spawning
 
         public string GateId => gateId;
 
+        public void Initialize(string id)
+        {
+            gateId = id;
+        }
+
         private void OnValidate()
         {
             if (string.IsNullOrWhiteSpace(gateId))

--- a/Assets/_Project/Scripts/_Project.Gameplay/Spawning/SpawnMarkerOrderBuilder.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Spawning/SpawnMarkerOrderBuilder.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -15,72 +14,145 @@ namespace Castlebound.Gameplay.Spawning
                 return result;
             }
 
+            BuildGroups(spawnPoints, out var gateIds, out var lanesByGate);
+            var gateIndices = new List<int>(spawnCount);
+            var rng = seed.HasValue ? new System.Random(seed.Value) : null;
+
             switch (strategy)
             {
                 case SpawnMarkerStrategy.RoundRobin:
-                    BuildRoundRobin(spawnPoints, spawnCount, result);
+                    BuildRoundRobin(gateIds.Count, spawnCount, gateIndices);
                     break;
                 case SpawnMarkerStrategy.ShufflePrecompute:
-                    BuildShuffleWithCoverage(spawnPoints, spawnCount, result, seed);
+                    BuildShuffleWithCoverage(gateIds.Count, spawnCount, gateIndices, rng);
                     break;
                 default:
-                    BuildRoundRobin(spawnPoints, spawnCount, result);
+                    BuildRoundRobin(gateIds.Count, spawnCount, gateIndices);
                     break;
             }
+
+            SelectLanes(gateIndices, lanesByGate, strategy, rng, result);
 
             return result;
         }
 
-        private static void BuildRoundRobin(IReadOnlyList<SpawnPoint> spawnPoints, int spawnCount, List<SpawnPoint> output)
+        private static void BuildGroups(
+            IReadOnlyList<SpawnPoint> spawnPoints,
+            out List<string> gateIds,
+            out List<List<SpawnPoint>> lanesByGate)
+        {
+            gateIds = new List<string>();
+            lanesByGate = new List<List<SpawnPoint>>();
+            var gateIndexById = new Dictionary<string, int>();
+
+            for (var markerIndex = 0; markerIndex < spawnPoints.Count; markerIndex++)
+            {
+                var point = spawnPoints[markerIndex];
+                var groupingId = string.IsNullOrWhiteSpace(point.GateId)
+                    ? $"__ungrouped_{markerIndex}"
+                    : point.GateId;
+
+                if (!gateIndexById.TryGetValue(groupingId, out var gateIndex))
+                {
+                    gateIndex = gateIds.Count;
+                    gateIndexById.Add(groupingId, gateIndex);
+                    gateIds.Add(groupingId);
+                    lanesByGate.Add(new List<SpawnPoint>());
+                }
+
+                lanesByGate[gateIndex].Add(point);
+            }
+        }
+
+        private static void BuildRoundRobin(int gateCount, int spawnCount, List<int> output)
         {
             var gateIndex = 0;
             for (int i = 0; i < spawnCount; i++)
             {
-                output.Add(spawnPoints[gateIndex]);
-                gateIndex = (gateIndex + 1) % spawnPoints.Count;
+                output.Add(gateIndex);
+                gateIndex = (gateIndex + 1) % gateCount;
             }
         }
 
-        private static void BuildShuffleWithCoverage(IReadOnlyList<SpawnPoint> spawnPoints, int spawnCount, List<SpawnPoint> output, int? seed)
+        private static void BuildShuffleWithCoverage(int gateCount, int spawnCount, List<int> output, System.Random rng)
         {
-            var rng = seed.HasValue ? new System.Random(seed.Value) : null;
-            var markerCount = spawnPoints.Count;
-
-            var indices = new List<int>(spawnCount);
-
-            if (spawnCount < markerCount)
+            if (spawnCount < gateCount)
             {
-                Debug.LogWarning($"SpawnMarkerOrderBuilder: spawnCount ({spawnCount}) is less than marker count ({markerCount}); cannot cover all gates.");
-                AppendShuffledDistinct(indices, markerCount, spawnCount, rng);
+                Debug.LogWarning($"SpawnMarkerOrderBuilder: spawnCount ({spawnCount}) is less than gate count ({gateCount}); cannot cover all gates.");
+                AppendShuffledDistinct(output, gateCount, spawnCount, rng);
             }
             else
             {
                 // Ensure each gate appears once.
-                for (int i = 0; i < markerCount; i++)
+                for (int i = 0; i < gateCount; i++)
                 {
-                    indices.Add(i);
+                    output.Add(i);
                 }
 
                 // Fill remaining slots with random gates.
-                while (indices.Count < spawnCount)
+                while (output.Count < spawnCount)
                 {
-                    indices.Add(GetRandomIndex(markerCount, rng));
+                    output.Add(GetRandomIndex(gateCount, rng));
                 }
 
                 // Shuffle the full order.
-                Shuffle(indices, rng);
-            }
-
-            foreach (var idx in indices)
-            {
-                output.Add(spawnPoints[idx]);
+                Shuffle(output, rng);
             }
         }
 
-        private static void AppendShuffledDistinct(List<int> output, int markerCount, int takeCount, System.Random rng)
+        private static void SelectLanes(
+            IReadOnlyList<int> gateIndices,
+            IReadOnlyList<List<SpawnPoint>> lanesByGate,
+            SpawnMarkerStrategy strategy,
+            System.Random rng,
+            List<SpawnPoint> output)
         {
-            var pool = new List<int>(markerCount);
-            for (int i = 0; i < markerCount; i++)
+            var nextLaneByGate = new int[lanesByGate.Count];
+            var shuffledLaneIndices = new List<List<int>>(lanesByGate.Count);
+            for (var gateIndex = 0; gateIndex < lanesByGate.Count; gateIndex++)
+            {
+                var indices = new List<int>(lanesByGate[gateIndex].Count);
+                for (var laneIndex = 0; laneIndex < lanesByGate[gateIndex].Count; laneIndex++)
+                {
+                    indices.Add(laneIndex);
+                }
+
+                if (strategy == SpawnMarkerStrategy.ShufflePrecompute)
+                {
+                    Shuffle(indices, rng);
+                }
+
+                shuffledLaneIndices.Add(indices);
+            }
+
+            foreach (var gateIndex in gateIndices)
+            {
+                var lanes = lanesByGate[gateIndex];
+                int laneIndex;
+                if (strategy == SpawnMarkerStrategy.ShufflePrecompute)
+                {
+                    if (nextLaneByGate[gateIndex] >= lanes.Count)
+                    {
+                        Shuffle(shuffledLaneIndices[gateIndex], rng);
+                        nextLaneByGate[gateIndex] = 0;
+                    }
+
+                    laneIndex = shuffledLaneIndices[gateIndex][nextLaneByGate[gateIndex]++];
+                }
+                else
+                {
+                    laneIndex = nextLaneByGate[gateIndex] % lanes.Count;
+                    nextLaneByGate[gateIndex]++;
+                }
+
+                output.Add(lanes[laneIndex]);
+            }
+        }
+
+        private static void AppendShuffledDistinct(List<int> output, int gateCount, int takeCount, System.Random rng)
+        {
+            var pool = new List<int>(gateCount);
+            for (int i = 0; i < gateCount; i++)
             {
                 pool.Add(i);
             }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Spawning/SpawnPoint.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Spawning/SpawnPoint.cs
@@ -5,12 +5,23 @@ namespace Castlebound.Gameplay.Spawning
     public readonly struct SpawnPoint
     {
         public string GateId { get; }
+        public string LaneId { get; }
         public Vector2 Position { get; }
+        public Vector2 ForwardDirection { get; }
 
         public SpawnPoint(string gateId, Vector2 position)
+            : this(gateId, "Default", position, Vector2.down)
+        {
+        }
+
+        public SpawnPoint(string gateId, string laneId, Vector2 position, Vector2 forwardDirection)
         {
             GateId = gateId;
+            LaneId = laneId;
             Position = position;
+            ForwardDirection = forwardDirection.sqrMagnitude > Mathf.Epsilon
+                ? forwardDirection.normalized
+                : Vector2.zero;
         }
     }
 }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Spawning/SpawnPointMarker.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Spawning/SpawnPointMarker.cs
@@ -4,33 +4,19 @@ namespace Castlebound.Gameplay.Spawning
 {
     public class SpawnPointMarker : MonoBehaviour
     {
-        [SerializeField] private string gateId;
+        [SerializeField] private string laneId = "Center";
 
-        private void OnValidate()
+        public void Initialize(string lane)
         {
-            if (string.IsNullOrWhiteSpace(gateId))
-            {
-                var provider = GetComponentInParent<GateIdProvider>();
-                if (provider != null)
-                {
-                    gateId = provider.GateId;
-                }
-            }
+            laneId = lane;
         }
 
         public SpawnPoint ToSpawnPoint()
         {
-            var id = gateId;
-            if (string.IsNullOrWhiteSpace(id))
-            {
-                var provider = GetComponentInParent<GateIdProvider>();
-                if (provider != null)
-                {
-                    id = provider.GateId;
-                }
-            }
+            var provider = GetComponentInParent<GateIdProvider>();
+            var id = provider != null ? provider.GateId : string.Empty;
 
-            return new SpawnPoint(id, (Vector2)transform.position);
+            return new SpawnPoint(id, laneId, (Vector2)transform.position, -transform.up);
         }
     }
 }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Spawning/SpawnRequest.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Spawning/SpawnRequest.cs
@@ -6,13 +6,27 @@ namespace Castlebound.Gameplay.Spawning
     {
         public string EnemyTypeId { get; }
         public string GateId { get; }
+        public string LaneId { get; }
         public Vector2 Position { get; }
+        public Vector2 ForwardDirection { get; }
 
         public SpawnRequest(string enemyTypeId, string gateId, Vector2 position)
+            : this(enemyTypeId, gateId, "Default", position, Vector2.down)
+        {
+        }
+
+        public SpawnRequest(string enemyTypeId, SpawnPoint spawnPoint)
+            : this(enemyTypeId, spawnPoint.GateId, spawnPoint.LaneId, spawnPoint.Position, spawnPoint.ForwardDirection)
+        {
+        }
+
+        public SpawnRequest(string enemyTypeId, string gateId, string laneId, Vector2 position, Vector2 forwardDirection)
         {
             EnemyTypeId = enemyTypeId;
             GateId = gateId;
+            LaneId = laneId;
             Position = position;
+            ForwardDirection = forwardDirection;
         }
     }
 }

--- a/Assets/_Project/_Tests/EditMode/AI/EnemyFacingTests.cs
+++ b/Assets/_Project/_Tests/EditMode/AI/EnemyFacingTests.cs
@@ -63,5 +63,24 @@ namespace Castlebound.Tests.AI
             Assert.That(EnemyFacing.GetVisualRotationDegrees(Vector2.down), Is.EqualTo(0f).Within(0.001f));
             Assert.That(EnemyFacing.GetVisualRotationDegrees(Vector2.right), Is.EqualTo(90f).Within(0.001f));
         }
+
+        [Test]
+        public void InitializeAimDirection_AppliesNormalizedSpawnDirectionImmediately()
+        {
+            var enemy = new GameObject("Enemy");
+            try
+            {
+                var facing = enemy.AddComponent<EnemyFacing>();
+
+                facing.InitializeAimDirection(new Vector2(2f, 0f));
+
+                Assert.That(facing.AimDirection, Is.EqualTo(Vector2.right));
+            }
+            finally
+            {
+                Object.DestroyImmediate(enemy);
+            }
+        }
+
     }
 }

--- a/Assets/_Project/_Tests/EditMode/Castle/BarrierAssemblyBuilderTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Castle/BarrierAssemblyBuilderTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Reflection;
 using Castlebound.Gameplay.Castle;
+using Castlebound.Gameplay.Spawning;
 using NUnit.Framework;
 using UnityEngine;
 
@@ -99,6 +100,33 @@ namespace Castlebound.Tests.Castle
                         CastlePlacementRules.IsOnLattice(worldPos),
                         $"Spawned barrier '{child.name}' must land on 3-unit lattice. Position=({worldPos.x:0.###}, {worldPos.y:0.###})");
                 }
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(prefabGo);
+                UnityEngine.Object.DestroyImmediate(parentGo);
+            }
+        }
+
+        [Test]
+        public void BarrierAssemblyBuilder_Rebuild_AssignsUniqueSlotIdToEachBarrier()
+        {
+            var parentGo = new GameObject("GeneratedBarriers");
+            var prefabGo = new GameObject("Barrier_Gate_Template");
+            prefabGo.AddComponent<GateIdProvider>();
+
+            try
+            {
+                var slots = new[]
+                {
+                    new BarrierPlacementSlot { Id = "barrier_n", Position = Vector2.zero, Side = BarrierSide.North },
+                    new BarrierPlacementSlot { Id = "barrier_e", Position = Vector2.right * 3f, Side = BarrierSide.East }
+                };
+
+                BarrierAssemblyBuilder.Rebuild(parentGo.transform, prefabGo, slots);
+
+                Assert.That(parentGo.transform.Find("barrier_n").GetComponent<GateIdProvider>().GateId, Is.EqualTo("barrier_n"));
+                Assert.That(parentGo.transform.Find("barrier_e").GetComponent<GateIdProvider>().GateId, Is.EqualTo("barrier_e"));
             }
             finally
             {

--- a/Assets/_Project/_Tests/EditMode/Spawning/EnemySpawnerTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Spawning/EnemySpawnerTests.cs
@@ -85,6 +85,29 @@ namespace Castlebound.Tests.Spawning
         }
 
         [Test]
+        public void PropagatesSelectedLaneAndDirectionIntoRequest()
+        {
+            var spawnPoints = new[]
+            {
+                new SpawnPoint("NorthGate", "Center", Vector2.zero, Vector2.down),
+                new SpawnPoint("NorthGate", "Left", Vector2.left, Vector2.right)
+            };
+            var schedule = new EnemySpawnSchedule(new[]
+            {
+                new SpawnSequence("grunt", spawnCount: 2, intervalSeconds: 0f, initialDelaySeconds: 0f)
+            });
+            var spawner = new EnemySpawner(schedule, spawnPoints);
+
+            var ready = spawner.Tick(0.1f);
+
+            Assert.That(ready.Count, Is.EqualTo(2));
+            Assert.That(ready[0].LaneId, Is.EqualTo("Center"));
+            Assert.That(ready[0].ForwardDirection, Is.EqualTo(Vector2.down));
+            Assert.That(ready[1].LaneId, Is.EqualTo("Left"));
+            Assert.That(ready[1].ForwardDirection, Is.EqualTo(Vector2.right));
+        }
+
+        [Test]
         public void UpdatesWaveIndexProvider_WhenWaveStarts()
         {
             var runnerGo = new GameObject("EnemySpawnerRunner");

--- a/Assets/_Project/_Tests/EditMode/Spawning/SpawnMarkerOrderBuilderTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Spawning/SpawnMarkerOrderBuilderTests.cs
@@ -10,6 +10,91 @@ namespace Castlebound.Tests.Spawning
     public class SpawnMarkerOrderBuilderTests
     {
         [Test]
+        public void Marker_InheritsGateIdentityAndCarriesAuthoredLaneAndDirection()
+        {
+            var barrier = new GameObject("Barrier");
+            var provider = barrier.AddComponent<GateIdProvider>();
+            provider.Initialize("barrier_n");
+            var markerObject = new GameObject("LeftLane");
+            markerObject.transform.SetParent(barrier.transform);
+            markerObject.transform.rotation = Quaternion.Euler(0f, 0f, -90f);
+            var marker = markerObject.AddComponent<SpawnPointMarker>();
+            marker.Initialize("Left");
+
+            try
+            {
+                var point = marker.ToSpawnPoint();
+
+                Assert.That(point.GateId, Is.EqualTo("barrier_n"));
+                Assert.That(point.LaneId, Is.EqualTo("Left"));
+                Assert.That(Vector2.Distance(point.ForwardDirection, Vector2.left), Is.LessThan(0.001f));
+            }
+            finally
+            {
+                Object.DestroyImmediate(barrier);
+            }
+        }
+
+        [Test]
+        public void RoundRobin_GroupsLanesByGateBeforeSelectingLane()
+        {
+            var markers = new List<SpawnPoint>
+            {
+                new SpawnPoint("North", "Center", Vector2.zero, Vector2.down),
+                new SpawnPoint("North", "Left", Vector2.left, Vector2.down),
+                new SpawnPoint("North", "Right", Vector2.right, Vector2.down),
+                new SpawnPoint("East", "Center", Vector2.one, Vector2.left),
+                new SpawnPoint("East", "Left", Vector2.up, Vector2.left),
+                new SpawnPoint("East", "Right", Vector2.down, Vector2.left)
+            };
+
+            var order = SpawnMarkerOrderBuilder.BuildGateOrder(markers, 6, SpawnMarkerStrategy.RoundRobin);
+
+            CollectionAssert.AreEqual(new[] { "North", "East", "North", "East", "North", "East" }, order.Select(p => p.GateId));
+            CollectionAssert.AreEqual(new[] { "Center", "Center", "Left", "Left", "Right", "Right" }, order.Select(p => p.LaneId));
+        }
+
+        [Test]
+        public void ShufflePrecompute_LaneSelectionIsSeededWithoutWeightingGateCoverage()
+        {
+            var markers = new List<SpawnPoint>
+            {
+                new SpawnPoint("North", "Center", Vector2.zero, Vector2.down),
+                new SpawnPoint("North", "Left", Vector2.left, Vector2.down),
+                new SpawnPoint("North", "Right", Vector2.right, Vector2.down),
+                new SpawnPoint("East", "Only", Vector2.one, Vector2.left)
+            };
+
+            var evenlyAuthoredMarkers = new List<SpawnPoint>(markers)
+            {
+                new SpawnPoint("East", "Left", Vector2.up, Vector2.left),
+                new SpawnPoint("East", "Right", Vector2.down, Vector2.left)
+            };
+
+            var orderA = SpawnMarkerOrderBuilder.BuildGateOrder(markers, 8, SpawnMarkerStrategy.ShufflePrecompute, 1234);
+            var orderB = SpawnMarkerOrderBuilder.BuildGateOrder(markers, 8, SpawnMarkerStrategy.ShufflePrecompute, 1234);
+            var evenlyAuthoredOrder = SpawnMarkerOrderBuilder.BuildGateOrder(evenlyAuthoredMarkers, 8, SpawnMarkerStrategy.ShufflePrecompute, 1234);
+
+            CollectionAssert.AreEqual(orderA.Select(p => $"{p.GateId}:{p.LaneId}"), orderB.Select(p => $"{p.GateId}:{p.LaneId}"));
+            CollectionAssert.AreEqual(orderA.Select(p => p.GateId), evenlyAuthoredOrder.Select(p => p.GateId), "Adding lanes must not change seeded barrier selection.");
+        }
+
+        [Test]
+        public void ShufflePrecompute_CoversEveryLaneBeforeRepeatingWithinGate()
+        {
+            var markers = new List<SpawnPoint>
+            {
+                new SpawnPoint("North", "Center", Vector2.zero, Vector2.down),
+                new SpawnPoint("North", "Left", Vector2.left, Vector2.down),
+                new SpawnPoint("North", "Right", Vector2.right, Vector2.down)
+            };
+
+            var order = SpawnMarkerOrderBuilder.BuildGateOrder(markers, 3, SpawnMarkerStrategy.ShufflePrecompute, 42);
+
+            CollectionAssert.AreEquivalent(new[] { "Center", "Left", "Right" }, order.Select(p => p.LaneId));
+        }
+
+        [Test]
         public void ShufflePrecompute_CoversAllGatesAndIsDeterministicWithSeed()
         {
             var markers = new List<SpawnPoint>
@@ -43,7 +128,7 @@ namespace Castlebound.Tests.Spawning
                 new SpawnPoint("South", new Vector2(1f, -1f)),
             };
 
-            LogAssert.Expect(LogType.Warning, "SpawnMarkerOrderBuilder: spawnCount (2) is less than marker count (3); cannot cover all gates.");
+            LogAssert.Expect(LogType.Warning, "SpawnMarkerOrderBuilder: spawnCount (2) is less than gate count (3); cannot cover all gates.");
 
             var order = SpawnMarkerOrderBuilder.BuildGateOrder(markers, spawnCount: 2, SpawnMarkerStrategy.ShufflePrecompute, seed: 999);
 

--- a/Assets/_Project/_Tests/PlayMode/Spawning/EnemySpawnerRunnerPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/Spawning/EnemySpawnerRunnerPlayTests.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Reflection;
 using Castlebound.Gameplay.Spawning;
 using NUnit.Framework;
 using UnityEngine;
@@ -33,13 +34,11 @@ namespace Castlebound.Tests.PlayMode.Spawning
             // Markers.
             var markerA = new GameObject("MarkerA").AddComponent<SpawnPointMarker>();
             markerA.transform.position = new Vector2(-1f, 0f);
-            typeof(SpawnPointMarker).GetField("gateId", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
-                ?.SetValue(markerA, "GateA");
+            markerA.gameObject.AddComponent<GateIdProvider>().Initialize("GateA");
 
             var markerB = new GameObject("MarkerB").AddComponent<SpawnPointMarker>();
             markerB.transform.position = new Vector2(2f, 0f);
-            typeof(SpawnPointMarker).GetField("gateId", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
-                ?.SetValue(markerB, "GateB");
+            markerB.gameObject.AddComponent<GateIdProvider>().Initialize("GateB");
 
             // Runner setup.
             var runnerGO = new GameObject("SpawnerRunner");
@@ -131,8 +130,7 @@ namespace Castlebound.Tests.PlayMode.Spawning
 
             var marker = new GameObject("MixedMarker").AddComponent<SpawnPointMarker>();
             marker.transform.position = new Vector2(1f, 0f);
-            typeof(SpawnPointMarker).GetField("gateId", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
-                ?.SetValue(marker, "GateA");
+            marker.gameObject.AddComponent<GateIdProvider>().Initialize("GateA");
 
             var runnerGO = new GameObject("MixedSpawnerRunner");
             var runner = runnerGO.AddComponent<EnemySpawnerRunner>();
@@ -163,6 +161,53 @@ namespace Castlebound.Tests.PlayMode.Spawning
             Object.DestroyImmediate(gruntPrefab);
             Object.DestroyImmediate(lurkerPrefab);
             Object.DestroyImmediate(scheduleAsset);
+        }
+
+        [UnityTest]
+        public IEnumerator SpawnReady_InitializesFacingFromEveryCardinalMarkerDirection()
+        {
+            var enemyPrefab = new GameObject("DirectionalEnemyPrefab");
+            enemyPrefab.AddComponent<EnemyFacing>();
+            var runnerObject = new GameObject("DirectionalSpawnerRunner");
+            var runner = runnerObject.AddComponent<EnemySpawnerRunner>();
+            var prefabMap = new Dictionary<string, GameObject> { ["grunt"] = enemyPrefab };
+            typeof(EnemySpawnerRunner).GetField("_prefabMap", BindingFlags.NonPublic | BindingFlags.Instance)
+                ?.SetValue(runner, prefabMap);
+
+            var directions = new[] { Vector2.up, Vector2.right, Vector2.down, Vector2.left };
+            var requests = new List<SpawnRequest>();
+            for (var i = 0; i < directions.Length; i++)
+            {
+                requests.Add(new SpawnRequest("grunt", $"Gate{i}", "Center", new Vector2(i * 2f, 5f), directions[i]));
+            }
+
+            var spawnReady = typeof(EnemySpawnerRunner).GetMethod("SpawnReady", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(spawnReady);
+            spawnReady.Invoke(runner, new object[] { requests });
+            yield return null;
+
+            var clones = new List<GameObject>();
+            foreach (var candidate in Object.FindObjectsOfType<EnemyFacing>())
+            {
+                if (candidate.gameObject.name.Contains("(Clone)"))
+                {
+                    clones.Add(candidate.gameObject);
+                }
+            }
+
+            Assert.That(clones.Count, Is.EqualTo(4));
+            clones.Sort((a, b) => a.transform.position.x.CompareTo(b.transform.position.x));
+            for (var i = 0; i < directions.Length; i++)
+            {
+                Assert.That(clones[i].GetComponent<EnemyFacing>().AimDirection, Is.EqualTo(directions[i]));
+            }
+
+            foreach (var clone in clones)
+            {
+                Object.DestroyImmediate(clone);
+            }
+            Object.DestroyImmediate(runnerObject);
+            Object.DestroyImmediate(enemyPrefab);
         }
 
         private static void AddMapping(System.Type mappingType, IList mappingList, string enemyTypeId, GameObject prefab)

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,23 @@
 
 ---
 
+## 2026-07-28 - feat-255-directional-grouped-spawn-markers
+
+### Summary
+- Added prefab-authored spawn lane and inward-direction data through the runtime spawn contract.
+- Changed marker ordering to select barriers before lanes with round-robin and seeded lane coverage.
+- Assigned unique runtime gate IDs to generated barriers and initialized enemy facing without coupling spawn groups to targeting.
+
+### New or Updated Tests
+**EditMode**
+- BarrierAssemblyBuilderTests, SpawnMarkerOrderBuilderTests, EnemySpawnerTests, and EnemyFacingTests — cover unique gate identity, marker ownership, grouped fairness, seeded lane determinism, request propagation, and facing initialization.
+
+**PlayMode**
+- EnemySpawnerRunnerPlayTests — covers cardinal initial facing and preserves spawn-count, position, and mixed-wave behavior.
+
+### Notes
+- EditMode and PlayMode tests pass; manual validation confirmed existing gameplay behavior remains unchanged.
+
 ## 2026-07-27 - refactor-253-melee-engagement
 
 ### Summary


### PR DESCRIPTION
## Why
Runtime spawning could not preserve prefab-authored lane direction, and multiple lane markers would incorrectly weight a barrier as multiple independent gates. This adds a flexible barrier-first spawn contract without coupling spawning to enemy targeting.

## What changed
- Added prefab-authored lane identity and inward direction to spawn points and requests
- Assigned unique runtime gate IDs to generated barriers while removing duplicated marker identity ownership
- Selected barriers before lanes with round-robin and seeded deterministic lane coverage
- Initialized enemy facing from the selected marker while preserving targeting, schedules, balance, and spawn counts
- Added EditMode and PlayMode regression coverage for identity, grouping, determinism, propagation, and cardinal facing

## How to test
1. Open the relevant prototype scene and allow runtime barriers and enemies to spawn
2. Press Play → verify existing wave behavior is unchanged and enemies initialize toward their selected barrier
3. Run tests:
   - EditMode
   - PlayMode

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated (N/A - runtime contract only; authored three-lane formation is tracked separately)
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched (TEST_LOG.md updated)

## Related
- Closes #255
