### PR TITLE
feat(scene): author expanded barrier spawn formations

### DIFF
--- a/Assets/_Project/Prefabs/Barrier_Gate.prefab
+++ b/Assets/_Project/Prefabs/Barrier_Gate.prefab
@@ -387,6 +387,8 @@ Transform:
   - {fileID: 3654758991378814183}
   - {fileID: 824082721035161966}
   - {fileID: 7704152403565933767}
+  - {fileID: 7704152403565933768}
+  - {fileID: 7704152403565933769}
   - {fileID: 1199000000000000002}
   - {fileID: 3461197392837539735}
   - {fileID: 1199000000000000701}
@@ -1007,7 +1009,7 @@ GameObject:
   - component: {fileID: 7704152403565933767}
   - component: {fileID: 6296148108499927986}
   m_Layer: 8
-  m_Name: SpawnPointMarker
+  m_Name: Spawn_Center
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1022,7 +1024,7 @@ Transform:
   m_GameObject: {fileID: 9092703534570667029}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 6.79, z: 0}
+  m_LocalPosition: {x: 0, y: 21, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1041,6 +1043,96 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   laneId: Center
+--- !u!1 &9092703534570667030
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7704152403565933768}
+  - component: {fileID: 6296148108499927987}
+  m_Layer: 8
+  m_Name: Spawn_Left
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7704152403565933768
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9092703534570667030}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0.13870071, w: 0.9903343}
+  m_LocalPosition: {x: -6, y: 21, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1199000000000000501}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 15.945395}
+--- !u!114 &6296148108499927987
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9092703534570667030}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0d31ea5d0f52b344a869a4b936a05b05, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  laneId: Left
+--- !u!1 &9092703534570667031
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7704152403565933769}
+  - component: {fileID: 6296148108499927988}
+  m_Layer: 8
+  m_Name: Spawn_Right
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7704152403565933769
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9092703534570667031}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: -0.13870071, w: 0.9903343}
+  m_LocalPosition: {x: 6, y: 21, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1199000000000000501}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: -15.945395}
+--- !u!114 &6296148108499927988
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9092703534570667031}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0d31ea5d0f52b344a869a4b936a05b05, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  laneId: Right
 --- !u!1001 &8240005810329671612
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/_Project/_Tests/EditMode/Castle/BarrierPrefabVisualContractTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Castle/BarrierPrefabVisualContractTests.cs
@@ -1,4 +1,5 @@
 using Castlebound.Gameplay.Castle;
+using Castlebound.Gameplay.Spawning;
 using NUnit.Framework;
 using UnityEngine;
 
@@ -170,13 +171,52 @@ namespace Castlebound.Tests.Castle
                 var systemsRoot = GetTransform(binder, "systemsRoot");
                 Assert.NotNull(systemsRoot, "BarrierVisualBinder field 'systemsRoot' must be assigned.");
 
-                AssertIsDescendantOfSystemsRoot(prefab, systemsRoot, "SpawnPointMarker");
+                AssertIsDescendantOfSystemsRoot(prefab, systemsRoot, "Spawn_Center");
+                AssertIsDescendantOfSystemsRoot(prefab, systemsRoot, "Spawn_Left");
+                AssertIsDescendantOfSystemsRoot(prefab, systemsRoot, "Spawn_Right");
                 AssertIsDescendantOfSystemsRoot(prefab, systemsRoot, "HoldAnchor");
                 AssertIsDescendantOfSystemsRoot(prefab, systemsRoot, "DamageHitbox");
                 AssertIsDescendantOfSystemsRoot(prefab, systemsRoot, "PulseOrigin");
                 AssertIsDescendantOfSystemsRoot(prefab, systemsRoot, "BarrierHealthbar");
                 AssertIsDescendantOfSystemsRoot(prefab, systemsRoot, "TowerPlotLeftFlank");
                 AssertIsDescendantOfSystemsRoot(prefab, systemsRoot, "TowerPlotRightFlank");
+            }
+            finally
+            {
+                PrefabTestUtil.Unload(prefab);
+            }
+        }
+
+        [Test]
+        public void BarrierPrefab_SpawnFormation_HasThreeUniqueLanesAtTwentyOneUnitsOutward()
+        {
+            var prefab = PrefabTestUtil.Load(BarrierPrefabPath);
+            try
+            {
+                var binder = prefab.GetComponent<BarrierVisualBinder>();
+                var systemsRoot = GetTransform(binder, "systemsRoot");
+                var markers = systemsRoot.GetComponentsInChildren<SpawnPointMarker>(true);
+
+                Assert.That(markers.Length, Is.EqualTo(3), "Barrier prefab must author exactly three spawn lanes.");
+                CollectionAssert.AreEquivalent(
+                    new[] { "Center", "Left", "Right" },
+                    System.Array.ConvertAll(markers, marker => marker.ToSpawnPoint().LaneId));
+
+                var positions = new System.Collections.Generic.HashSet<Vector2>();
+                foreach (var marker in markers)
+                {
+                    var localPosition = (Vector2)marker.transform.localPosition;
+                    Assert.That(localPosition.y, Is.EqualTo(21f).Within(0.001f), $"{marker.name} must be authored 21 units outward.");
+                    Assert.IsTrue(positions.Add(localPosition), $"{marker.name} must have a unique authored position.");
+
+                    var inwardToOpening = -localPosition.normalized;
+                    var authoredForward = (Vector2)systemsRoot.InverseTransformDirection(marker.ToSpawnPoint().ForwardDirection);
+                    Assert.That(Vector2.Dot(authoredForward.normalized, inwardToOpening), Is.GreaterThan(0.999f), $"{marker.name} must point inward toward the barrier opening.");
+                }
+
+                Assert.That(FindChildRecursive(prefab.transform, "Spawn_Center").localPosition.x, Is.EqualTo(0f).Within(0.001f));
+                Assert.That(FindChildRecursive(prefab.transform, "Spawn_Left").localPosition.x, Is.EqualTo(-6f).Within(0.001f));
+                Assert.That(FindChildRecursive(prefab.transform, "Spawn_Right").localPosition.x, Is.EqualTo(6f).Within(0.001f));
             }
             finally
             {

--- a/Assets/_Project/_Tests/PlayMode/Castle/CastleTilemapRuntimeContractsPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/Castle/CastleTilemapRuntimeContractsPlayTests.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using Castlebound.Gameplay.AI;
 using Castlebound.Gameplay.Castle;
+using Castlebound.Gameplay.Spawning;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -129,6 +130,17 @@ namespace Castlebound.Tests.PlayMode.Castle
                 var systemsZ = Mathf.DeltaAngle(0f, systemsRoot.localEulerAngles.z);
                 Assert.That(systemsZ, Is.EqualTo(ExpectedRotation(side)).Within(0.5f),
                     $"SystemsRoot rotation mismatch for barrier '{child.name}' side {side}.");
+
+                var spawnMarkers = systemsRoot.GetComponentsInChildren<SpawnPointMarker>(true);
+                Assert.That(spawnMarkers.Length, Is.EqualTo(3), $"Generated barrier '{child.name}' must expose three spawn lanes.");
+                foreach (var marker in spawnMarkers)
+                {
+                    var inwardToBarrier = (Vector2)(child.position - marker.transform.position);
+                    Assert.That(
+                        Vector2.Dot(marker.ToSpawnPoint().ForwardDirection, inwardToBarrier.normalized),
+                        Is.GreaterThan(0.999f),
+                        $"Spawn lane '{marker.name}' on {side} barrier '{child.name}' must point inward after rotation.");
+                }
 
                 var health = child.GetComponent<BarrierHealth>();
                 var binder = child.GetComponent<BarrierVisualBinder>();

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,23 @@
 
 ---
 
+## 2026-07-28 - feat-256-expanded-barrier-spawn-formations
+
+### Summary
+- Replaced the single barrier spawn marker with prefab-authored center, left, and right lanes.
+- Positioned every lane 21 units outward with six-unit flank offsets and converging inward directions.
+- Preserved runtime spawning, targeting, wave timing, balance, and engagement behavior.
+
+### New or Updated Tests
+**EditMode**
+- BarrierPrefabVisualContractTests — covers exact lane count, identities, unique positions, 21-unit distance, flank offsets, SystemsRoot ownership, and inward direction.
+
+**PlayMode**
+- CastleTilemapRuntimeContractsPlayTests — verifies every cardinal barrier produces three correctly rotated inward-facing lanes.
+
+### Notes
+- EditMode and PlayMode tests pass; manual validation confirmed the three-lane formation behaves correctly.
+
 ## 2026-07-28 - feat-255-directional-grouped-spawn-markers
 
 ### Summary


### PR DESCRIPTION
## Why
The barrier prefab previously exposed one nearby spawn marker, producing uniform entry paths with little visible travel toward the castle. The formation now provides three designer-authored lanes at the approved 21-unit distance.

## What changed
- Replaced the single marker with center, left, and right markers under `SystemsRoot`
- Positioned the formation 21 units outward with six-unit lateral flank offsets
- Authored converging lane rotations so every marker faces the barrier opening
- Added prefab and cardinal runtime contracts without changing spawning, targeting, wave timing, balance, or engagement code

## How to test
1. Open MainPrototype and allow runtime barriers to generate
2. Press Play → verify enemies use center, left, and right approaches from all four barrier orientations
3. Run tests:
   - EditMode
   - PlayMode

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated (N/A - MainPrototype consumes the updated runtime-generated barrier prefab without a scene edit)
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched (TEST_LOG.md updated)

## Related
- Closes #256
