### PR TITLE
perf(ai): reuse live barrier registry for targeting

### DIFF
--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/CastleTargetSelector.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/CastleTargetSelector.cs
@@ -4,13 +4,11 @@ using UnityEngine;
 namespace Castlebound.Gameplay.AI
 {
     /// <summary>
-    /// Simple stub for castle targeting logic.
-    /// Only returns player for now so the first test can go green.
-    /// Will be expanded as more tests are implemented.
+    /// Resolves deterministic castle targets from the active barrier registry and region state.
     /// </summary>
     public static class CastleTargetSelector
     {
-        public static Transform AssignHomeBarrier(Vector2 spawnPosition, IReadOnlyList<Transform> barriers)
+        public static Transform AssignHomeBarrier(Vector2 spawnPosition, IReadOnlyList<BarrierHealth> barriers)
         {
             if (barriers == null || barriers.Count == 0)
                 return null;
@@ -21,9 +19,11 @@ namespace Castlebound.Gameplay.AI
 
             for (int i = 0; i < barriers.Count; i++)
             {
-                var barrier = barriers[i];
-                if (barrier == null)
+                var barrierHealth = barriers[i];
+                if (barrierHealth == null)
                     continue;
+
+                var barrier = barrierHealth.transform;
 
                 Vector2 targetPos = barrier.position;
                 var hold = barrier.GetComponent<EnemyBarrierHoldBehavior>();

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyTargeting.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyTargeting.cs
@@ -28,7 +28,7 @@ public class EnemyTargeting : MonoBehaviour
         if (!useBarrierTargeting || homeBarrier != null)
             return;
 
-        homeBarrier = CastleTargetSelector.AssignHomeBarrier(enemyPosition, GetAllBarrierTransforms());
+        homeBarrier = CastleTargetSelector.AssignHomeBarrier(enemyPosition, BarrierHealth.All);
     }
 
     public void Refresh(Vector2 enemyPosition, bool playerInside, bool enemyInside)
@@ -134,16 +134,4 @@ public class EnemyTargeting : MonoBehaviour
         return health != null && health.IsBroken;
     }
 
-    private static Transform[] GetAllBarrierTransforms()
-    {
-        var barriers = BarrierHealth.All;
-        if (barriers == null || barriers.Count == 0)
-            return System.Array.Empty<Transform>();
-
-        var result = new Transform[barriers.Count];
-        for (int i = 0; i < barriers.Count; i++)
-            result[i] = barriers[i] != null ? barriers[i].transform : null;
-
-        return result;
-    }
 }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Barrier/BarrierHealth.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Barrier/BarrierHealth.cs
@@ -194,21 +194,4 @@ public class BarrierHealth : MonoBehaviour, IDamageable
         }
     }
 
-    public static Transform[] GetActiveGateTransforms()
-    {
-        if (_all.Count == 0)
-            return System.Array.Empty<Transform>();
-
-        var active = new List<Transform>(_all.Count);
-        for (int i = 0; i < _all.Count; i++)
-        {
-            var barrier = _all[i];
-            if (barrier == null || barrier.IsBroken)
-                continue;
-
-            active.Add(barrier.transform);
-        }
-
-        return active.ToArray();
-    }
 }

--- a/Assets/_Project/_Tests/EditMode/AI/CastleTargetSelectorHomeBarrierTests.cs
+++ b/Assets/_Project/_Tests/EditMode/AI/CastleTargetSelectorHomeBarrierTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Reflection;
 using NUnit.Framework;
 using UnityEngine;
 using Castlebound.Gameplay.AI;
@@ -8,20 +9,34 @@ namespace Castlebound.Tests.AI
     public class CastleTargetSelectorHomeBarrierTests
     {
         [Test]
+        public void HomeBarrierAssignment_ConsumesHealthRegistryWithoutTransformCollectionBuilder()
+        {
+            var selectorMethod = typeof(CastleTargetSelector).GetMethod(
+                "AssignHomeBarrier",
+                new[] { typeof(Vector2), typeof(IReadOnlyList<BarrierHealth>) });
+            var obsoleteBuilder = typeof(EnemyTargeting).GetMethod(
+                "GetAllBarrierTransforms",
+                BindingFlags.NonPublic | BindingFlags.Static);
+
+            Assert.NotNull(selectorMethod, "Home-barrier selection must consume the lifecycle-aware BarrierHealth registry directly.");
+            Assert.IsNull(obsoleteBuilder, "EnemyTargeting must not rebuild a Transform collection during home-barrier assignment.");
+        }
+
+        [Test]
         public void AssignsHomeBarrier_BasedOnSpawnPosition()
         {
-            var barrierNear = new GameObject("BarrierNear").transform;
-            barrierNear.position = new Vector2(-2f, 0f);
+            var barrierNear = new GameObject("BarrierNear").AddComponent<BarrierHealth>();
+            barrierNear.transform.position = new Vector2(-2f, 0f);
 
-            var barrierFar = new GameObject("BarrierFar").transform;
-            barrierFar.position = new Vector2(10f, 0f);
+            var barrierFar = new GameObject("BarrierFar").AddComponent<BarrierHealth>();
+            barrierFar.transform.position = new Vector2(10f, 0f);
 
             var spawnPosition = new Vector2(-3f, 0f);
-            var barriers = new List<Transform> { barrierFar, barrierNear };
+            var barriers = new List<BarrierHealth> { barrierFar, barrierNear };
 
             var homeBarrier = CastleTargetSelector.AssignHomeBarrier(spawnPosition, barriers);
 
-            Assert.AreSame(barrierNear, homeBarrier, "Enemy should assign the nearest barrier to its spawn as the home barrier.");
+            Assert.AreSame(barrierNear.transform, homeBarrier, "Enemy should assign the nearest barrier to its spawn as the home barrier.");
 
             Object.DestroyImmediate(barrierNear.gameObject);
             Object.DestroyImmediate(barrierFar.gameObject);
@@ -30,14 +45,14 @@ namespace Castlebound.Tests.AI
         [Test]
         public void KeepsHomeBarrier_EvenIfAnotherBecomesCloser()
         {
-            var barrierHome = new GameObject("BarrierHome").transform;
-            barrierHome.position = new Vector2(-2f, 0f);
+            var barrierHome = new GameObject("BarrierHome").AddComponent<BarrierHealth>();
+            barrierHome.transform.position = new Vector2(-2f, 0f);
 
-            var barrierOther = new GameObject("BarrierOther").transform;
-            barrierOther.position = new Vector2(8f, 0f);
+            var barrierOther = new GameObject("BarrierOther").AddComponent<BarrierHealth>();
+            barrierOther.transform.position = new Vector2(8f, 0f);
 
             var spawnPosition = new Vector2(-3f, 0f);
-            var barriers = new List<Transform> { barrierOther, barrierHome };
+            var barriers = new List<BarrierHealth> { barrierOther, barrierHome };
 
             var homeBarrier = CastleTargetSelector.AssignHomeBarrier(spawnPosition, barriers);
 
@@ -55,7 +70,7 @@ namespace Castlebound.Tests.AI
                 playerInside,
                 player,
                 homeBarrier,
-                barriers);
+                new List<Transform> { barrierOther.transform, barrierHome.transform });
 
             Assert.AreSame(homeBarrier, result, "Enemy should keep its assigned home barrier even if another barrier becomes closer.");
 
@@ -75,7 +90,7 @@ namespace Castlebound.Tests.AI
             health.TakeDamage(health.MaxHealth);
 
             var spawnPosition = new Vector2(-3f, 0f);
-            var barriers = new List<Transform> { barrierHome };
+            var barriers = new List<BarrierHealth> { health };
 
             var homeBarrier = CastleTargetSelector.AssignHomeBarrier(spawnPosition, barriers);
 
@@ -93,7 +108,7 @@ namespace Castlebound.Tests.AI
                 playerInside,
                 player,
                 homeBarrier,
-                barriers);
+                new List<Transform> { barrierHome });
 
             Assert.AreSame(homeBarrier, result, "While outside, enemy should continue to target its assigned barrier, even if it is already broken.");
 
@@ -111,7 +126,7 @@ namespace Castlebound.Tests.AI
             health.TakeDamage(health.MaxHealth);
 
             var spawnPosition = new Vector2(-3f, 0f);
-            var barriers = new List<Transform> { barrierHome };
+            var barriers = new List<BarrierHealth> { health };
 
             var homeBarrier = CastleTargetSelector.AssignHomeBarrier(spawnPosition, barriers);
 
@@ -129,12 +144,30 @@ namespace Castlebound.Tests.AI
                 playerInside,
                 player,
                 homeBarrier,
-                barriers);
+                new List<Transform> { barrierHome });
 
             Assert.AreSame(player, result, "Once the home barrier is broken and the enemy is inside, target should switch to the player.");
 
             Object.DestroyImmediate(barrierHome.gameObject);
             Object.DestroyImmediate(player.gameObject);
+        }
+
+        [Test]
+        public void AssignHomeBarrier_EqualDistanceUsesOrdinalNameTieBreak()
+        {
+            var barrierB = new GameObject("Barrier_B").AddComponent<BarrierHealth>();
+            barrierB.transform.position = Vector2.left;
+            var barrierA = new GameObject("Barrier_A").AddComponent<BarrierHealth>();
+            barrierA.transform.position = Vector2.right;
+
+            var result = CastleTargetSelector.AssignHomeBarrier(
+                Vector2.zero,
+                new List<BarrierHealth> { barrierB, barrierA });
+
+            Assert.AreSame(barrierA.transform, result);
+
+            Object.DestroyImmediate(barrierB.gameObject);
+            Object.DestroyImmediate(barrierA.gameObject);
         }
     }
 }

--- a/Assets/_Project/_Tests/PlayMode/AI/EnemyTargetingPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/AI/EnemyTargetingPlayTests.cs
@@ -9,6 +9,47 @@ namespace Castlebound.Tests.PlayMode.AI
     public class EnemyTargetingPlayTests
     {
         [UnityTest]
+        public IEnumerator DestroyedHomeBarrier_ReassignsFromLiveRegistry()
+        {
+            var enemy = new GameObject("Enemy");
+            var player = new GameObject("Player");
+            var nearBarrier = new GameObject("NearBarrier");
+            nearBarrier.transform.position = Vector2.left;
+            nearBarrier.AddComponent<BarrierHealth>();
+            var disabledBarrier = new GameObject("DisabledBarrier");
+            disabledBarrier.transform.position = Vector2.zero;
+            disabledBarrier.AddComponent<BarrierHealth>();
+            disabledBarrier.SetActive(false);
+            var farBarrier = new GameObject("FarBarrier");
+            farBarrier.transform.position = Vector2.right * 10f;
+            farBarrier.AddComponent<BarrierHealth>();
+            var targeting = enemy.AddComponent<EnemyTargeting>();
+            targeting.Debug_Setup(player.transform);
+
+            try
+            {
+                targeting.AssignHomeBarrierIfNeeded(Vector2.zero);
+                Assert.AreSame(nearBarrier.transform, targeting.HomeBarrier,
+                    "Disabled barriers must leave the live registry before home-barrier selection.");
+
+                Object.Destroy(nearBarrier);
+                yield return null;
+
+                targeting.Refresh(Vector2.zero, playerInside: true, enemyInside: false);
+
+                Assert.AreSame(farBarrier.transform, targeting.HomeBarrier,
+                    "Destroyed barriers must leave the registry so targeting can safely reassign.");
+            }
+            finally
+            {
+                Object.Destroy(enemy);
+                Object.Destroy(player);
+                Object.Destroy(disabledBarrier);
+                Object.Destroy(farBarrier);
+            }
+        }
+
+        [UnityTest]
         public IEnumerator RepairedBarrierPushback_RestoresBarrierTarget()
         {
             var enemy = new GameObject("Enemy");

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,23 @@
 
 ---
 
+## 2026-07-28 - perf-241-barrier-registry-targeting
+
+### Summary
+- Changed home-barrier selection to consume the live BarrierHealth registry without building temporary Transform arrays.
+- Preserved nearest-anchor selection, deterministic tie-breaking, retained homes, and targeting fallback behavior.
+- Removed the unused allocating active-gate transform helper.
+
+### New or Updated Tests
+**EditMode**
+- CastleTargetSelectorHomeBarrierTests — covers direct registry consumption, nearest selection, tie-breaking, retained homes, and broken-barrier behavior.
+
+**PlayMode**
+- EnemyTargetingPlayTests — verifies disabled and destroyed barriers leave the live registry and targeting safely reassigns.
+
+### Notes
+- EditMode and PlayMode tests pass; manual validation confirmed targeting behavior remains unchanged.
+
 ## 2026-07-28 - feat-256-expanded-barrier-spawn-formations
 
 ### Summary


### PR DESCRIPTION
## Why
Home-barrier assignment rebuilt a temporary transform array for each enemy assignment or lifecycle retry. This removes avoidable allocation bursts from a mobile AI path and makes the existing barrier registry the clear source of truth.

## What changed
- Changed home-barrier selection to consume `BarrierHealth.All` directly
- Preserved nearest anchor selection, ordinal tie-breaking, retained homes, and broken-barrier behavior
- Removed temporary transform-array construction and an unused allocating active-gate helper
- Added registry lifecycle regressions for disabled and destroyed barriers
- Corrected the stale castle-targeting class description

## How to test
1. Open MainPrototype and spawn multiple enemies around the castle
2. Press Play → verify enemies retain normal home-barrier selection, fallback targeting, and attacks
3. Run tests:
   - EditMode
   - PlayMode

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated (N/A - allocation cleanup requires no scene changes)
- [x] Prefab links, tags, and layers validated (N/A - no prefab, tag, or layer changes)
- [x] README / Docs touched (TEST_LOG.md updated)

## Related
- Closes #241
