### PR TITLE
fix(feedback): route targeted cues directly

### DIFF
--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/Feedback/BarrierHitShake.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/Feedback/BarrierHitShake.cs
@@ -34,7 +34,7 @@ public class BarrierHitShake : MonoBehaviour
         originalLocalPos = ShakeTarget.localPosition;
 
         if (feedbackChannel != null)
-            feedbackChannel.Raised += OnFeedbackRaised;
+            feedbackChannel.SubscribeTarget(gameObject.GetInstanceID(), OnFeedbackRaised);
 
         if (barrierHealth != null)
             barrierHealth.OnRepaired += ResetShake;
@@ -43,7 +43,7 @@ public class BarrierHitShake : MonoBehaviour
     void OnDisable()
     {
         if (feedbackChannel != null)
-            feedbackChannel.Raised -= OnFeedbackRaised;
+            feedbackChannel.UnsubscribeTarget(gameObject.GetInstanceID(), OnFeedbackRaised);
 
         if (barrierHealth != null)
             barrierHealth.OnRepaired -= ResetShake;

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/Feedback/FeedbackEventChannel.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/Feedback/FeedbackEventChannel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using UnityEngine;
 
 [CreateAssetMenu(menuName = "Castlebound/Combat/Feedback Event Channel")]
@@ -6,8 +7,39 @@ public class FeedbackEventChannel : ScriptableObject
 {
     public event Action<FeedbackCue> Raised;
 
+    readonly Dictionary<int, Action<FeedbackCue>> targetedListeners =
+        new Dictionary<int, Action<FeedbackCue>>();
+
+    public void SubscribeTarget(int targetInstanceId, Action<FeedbackCue> listener)
+    {
+        if (targetInstanceId == 0 || listener == null)
+            return;
+
+        targetedListeners.TryGetValue(targetInstanceId, out Action<FeedbackCue> listeners);
+        targetedListeners[targetInstanceId] = listeners + listener;
+    }
+
+    public void UnsubscribeTarget(int targetInstanceId, Action<FeedbackCue> listener)
+    {
+        if (targetInstanceId == 0 || listener == null ||
+            !targetedListeners.TryGetValue(targetInstanceId, out Action<FeedbackCue> listeners))
+            return;
+
+        listeners -= listener;
+        if (listeners == null)
+            targetedListeners.Remove(targetInstanceId);
+        else
+            targetedListeners[targetInstanceId] = listeners;
+    }
+
     public void Raise(FeedbackCue cue)
     {
         Raised?.Invoke(cue);
+
+        if (cue.TargetInstanceId != 0 &&
+            targetedListeners.TryGetValue(cue.TargetInstanceId, out Action<FeedbackCue> listeners))
+        {
+            listeners?.Invoke(cue);
+        }
     }
 }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/Feedback/HitFlashListener.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/Feedback/HitFlashListener.cs
@@ -23,13 +23,15 @@ public class HitFlashListener : MonoBehaviour
     void OnEnable()
     {
         if (feedbackChannel != null)
-            feedbackChannel.Raised += OnFeedbackRaised;
+            feedbackChannel.SubscribeTarget(gameObject.GetInstanceID(), OnFeedbackRaised);
     }
 
     void OnDisable()
     {
         if (feedbackChannel != null)
-            feedbackChannel.Raised -= OnFeedbackRaised;
+            feedbackChannel.UnsubscribeTarget(gameObject.GetInstanceID(), OnFeedbackRaised);
+
+        ResetFlash();
     }
 
     void OnFeedbackRaised(FeedbackCue cue)
@@ -38,9 +40,6 @@ public class HitFlashListener : MonoBehaviour
             return;
 
         if (targetRenderer == null)
-            return;
-
-        if (cue.TargetInstanceId != 0 && cue.TargetInstanceId != gameObject.GetInstanceID())
             return;
 
         if (flashRoutine != null)
@@ -60,5 +59,17 @@ public class HitFlashListener : MonoBehaviour
             targetRenderer.color = originalColor;
 
         flashRoutine = null;
+    }
+
+    void ResetFlash()
+    {
+        if (flashRoutine != null)
+        {
+            StopCoroutine(flashRoutine);
+            flashRoutine = null;
+        }
+
+        if (targetRenderer != null)
+            targetRenderer.color = originalColor;
     }
 }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/Feedback/PlayerHitScreenFlash.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/Feedback/PlayerHitScreenFlash.cs
@@ -30,6 +30,8 @@ public class PlayerHitScreenFlash : MonoBehaviour
     {
         if (feedbackChannel != null)
             feedbackChannel.Raised -= OnFeedbackRaised;
+
+        ResetFlash();
     }
 
     void OnFeedbackRaised(FeedbackCue cue)
@@ -63,5 +65,17 @@ public class PlayerHitScreenFlash : MonoBehaviour
 
         overlayImage.color = new Color(flashColor.r, flashColor.g, flashColor.b, 0f);
         flashRoutine = null;
+    }
+
+    void ResetFlash()
+    {
+        if (flashRoutine != null)
+        {
+            StopCoroutine(flashRoutine);
+            flashRoutine = null;
+        }
+
+        if (overlayImage != null)
+            overlayImage.color = new Color(flashColor.r, flashColor.g, flashColor.b, 0f);
     }
 }

--- a/Assets/_Project/_Tests/EditMode/Combat/Feedback/FeedbackEventChannelContractTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Combat/Feedback/FeedbackEventChannelContractTests.cs
@@ -91,5 +91,51 @@ namespace Castlebound.Tests.Combat
 
             ScriptableObject.DestroyImmediate(channel);
         }
+
+        [Test]
+        public void Raise_TargetedCue_NotifiesOnlyMatchingTargetListener()
+        {
+            var channel = ScriptableObject.CreateInstance<FeedbackEventChannel>();
+            int matchingCalls = 0;
+            int otherCalls = 0;
+            Action<FeedbackCue> matchingListener = _ => matchingCalls++;
+            Action<FeedbackCue> otherListener = _ => otherCalls++;
+
+            channel.SubscribeTarget(10, matchingListener);
+            channel.SubscribeTarget(20, otherListener);
+            channel.Raise(new FeedbackCue(FeedbackCueType.PlayerHitEnemy, Vector3.zero, 10));
+
+            Assert.That(matchingCalls, Is.EqualTo(1));
+            Assert.That(otherCalls, Is.Zero);
+            ScriptableObject.DestroyImmediate(channel);
+        }
+
+        [Test]
+        public void UnsubscribeTarget_RemovesTargetedListener()
+        {
+            var channel = ScriptableObject.CreateInstance<FeedbackEventChannel>();
+            int calls = 0;
+            Action<FeedbackCue> listener = _ => calls++;
+
+            channel.SubscribeTarget(10, listener);
+            channel.UnsubscribeTarget(10, listener);
+            channel.Raise(new FeedbackCue(FeedbackCueType.PlayerHitEnemy, Vector3.zero, 10));
+
+            Assert.That(calls, Is.Zero);
+            ScriptableObject.DestroyImmediate(channel);
+        }
+
+        [Test]
+        public void Raise_UntargetedCue_StillNotifiesGlobalListener()
+        {
+            var channel = ScriptableObject.CreateInstance<FeedbackEventChannel>();
+            int calls = 0;
+            channel.Raised += _ => calls++;
+
+            channel.Raise(new FeedbackCue(FeedbackCueType.PlayerHit, Vector3.zero));
+
+            Assert.That(calls, Is.EqualTo(1));
+            ScriptableObject.DestroyImmediate(channel);
+        }
     }
 }

--- a/Assets/_Project/_Tests/PlayMode/Combat/FeedbackRoutingPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/Combat/FeedbackRoutingPlayTests.cs
@@ -1,0 +1,94 @@
+using System.Collections;
+using System.Reflection;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEngine.UI;
+
+namespace Castlebound.Tests.Combat
+{
+    public class FeedbackRoutingPlayTests
+    {
+        [UnityTest]
+        public IEnumerator EnemyHitCue_FlashesOnlyTargetedEnemyAndRestoresOnDisable()
+        {
+            var channel = ScriptableObject.CreateInstance<FeedbackEventChannel>();
+            var target = CreateEnemyFlash("Target", channel, Color.white);
+            var other = CreateEnemyFlash("Other", channel, Color.green);
+
+            channel.Raise(new FeedbackCue(
+                FeedbackCueType.PlayerHitEnemy,
+                target.GameObject.transform.position,
+                target.GameObject.GetInstanceID()));
+            yield return null;
+
+            Assert.That(target.Renderer.color, Is.EqualTo(new Color(1f, 0.2f, 0.2f, 1f)));
+            Assert.That(other.Renderer.color, Is.EqualTo(Color.green));
+
+            target.Listener.enabled = false;
+            Assert.That(target.Renderer.color, Is.EqualTo(Color.white));
+
+            Object.Destroy(target.GameObject);
+            Object.Destroy(other.GameObject);
+            Object.Destroy(channel);
+        }
+
+        [UnityTest]
+        public IEnumerator PlayerHitCue_PreservesScreenFlashAndRestoresOnDisable()
+        {
+            var channel = ScriptableObject.CreateInstance<FeedbackEventChannel>();
+            var overlay = new GameObject("PlayerHitFlash", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image));
+            var image = overlay.GetComponent<Image>();
+            var flash = overlay.AddComponent<PlayerHitScreenFlash>();
+            SetField(flash, "feedbackChannel", channel);
+            SetField(flash, "overlayImage", image);
+            flash.enabled = false;
+            flash.enabled = true;
+
+            channel.Raise(new FeedbackCue(FeedbackCueType.PlayerHit, Vector3.zero));
+            yield return null;
+
+            Assert.That(image.color.a, Is.GreaterThan(0f));
+
+            flash.enabled = false;
+            Assert.That(image.color.a, Is.Zero);
+
+            Object.Destroy(overlay);
+            Object.Destroy(channel);
+        }
+
+        private static FlashContext CreateEnemyFlash(string name, FeedbackEventChannel channel, Color originalColor)
+        {
+            var enemy = new GameObject(name);
+            var renderer = enemy.AddComponent<SpriteRenderer>();
+            renderer.color = originalColor;
+            var listener = enemy.AddComponent<HitFlashListener>();
+            SetField(listener, "feedbackChannel", channel);
+            SetField(listener, "targetRenderer", renderer);
+            listener.enabled = false;
+            listener.enabled = true;
+            return new FlashContext(enemy, renderer, listener);
+        }
+
+        private static void SetField(object target, string fieldName, object value)
+        {
+            var field = target.GetType().GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(field, $"Missing field {fieldName}.");
+            field.SetValue(target, value);
+        }
+
+        private readonly struct FlashContext
+        {
+            public GameObject GameObject { get; }
+            public SpriteRenderer Renderer { get; }
+            public HitFlashListener Listener { get; }
+
+            public FlashContext(GameObject gameObject, SpriteRenderer renderer, HitFlashListener listener)
+            {
+                GameObject = gameObject;
+                Renderer = renderer;
+                Listener = listener;
+            }
+        }
+    }
+}

--- a/Assets/_Project/_Tests/PlayMode/Combat/FeedbackRoutingPlayTests.cs.meta
+++ b/Assets/_Project/_Tests/PlayMode/Combat/FeedbackRoutingPlayTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4d0475aa1841467489d570d399030ec1

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,24 @@
 
 ---
 
+## 2026-07-29 - fix-102-targeted-feedback-routing
+
+### Summary
+- Routed targeted enemy-hit and barrier-hit cues directly to their registered listener instead of broadcasting to every active target.
+- Preserved the existing untargeted player red-screen flash behavior and all authored visual tuning.
+- Restored flash visuals to their baseline when listeners are disabled mid-effect.
+
+### New or Updated Tests
+**EditMode**
+- FeedbackEventChannelContractTests — covers matching-target delivery, non-target exclusion, listener removal, and untargeted broadcasts.
+
+**PlayMode**
+- FeedbackRoutingPlayTests — verifies enemy-specific flash routing, unchanged player screen feedback, and disable-time visual restoration.
+- BarrierHitShakeVisualSegmentPlayTests — retains targeted barrier shake and authored-baseline regression coverage.
+
+### Notes
+- EditMode and PlayMode tests pass; manual validation confirmed feedback behavior is unchanged.
+
 ## 2026-07-28 - perf-241-barrier-registry-targeting
 
 ### Summary


### PR DESCRIPTION
## Why
Targeted combat feedback was broadcast to every active enemy or barrier listener, causing unrelated targets to inspect and reject each cue. Route those cues directly while preserving the approved feedback presentation.

## What changed
- Added instance-ID routing for targeted feedback while retaining global delivery for untargeted cues
- Migrated enemy hit flashes and barrier hit shakes to targeted listener registration
- Restored flash visuals when listeners are disabled mid-effect
- Preserved the existing player red-screen flash timing, color, and restart behavior

## How to test
1. Open the MainPrototype scene
2. Press Play → damage enemies, barriers, and the player; verify only the impacted world target reacts and the player screen flash is unchanged
3. Run tests:
   - EditMode
   - PlayMode

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated (N/A - no scene changes required)
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched (TEST_LOG.md updated)

## Related
- Closes #102
