### PR TITLE
feat(camera): configure adaptive pixel-perfect presentation

### DIFF
--- a/Assets/_Project/Scenes/MainPrototype.unity
+++ b/Assets/_Project/Scenes/MainPrototype.unity
@@ -1015,6 +1015,7 @@ GameObject:
   - component: {fileID: 519420029}
   - component: {fileID: 519420030}
   - component: {fileID: 519420033}
+  - component: {fileID: 519420034}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -1109,7 +1110,7 @@ Camera:
   far clip plane: 1000
   field of view: 34
   orthographic: 1
-  orthographic size: 10
+  orthographic size: 8.4375
   m_Depth: -1
   m_CullingMask:
     serializedVersion: 2
@@ -1154,6 +1155,26 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   target: {fileID: 0}
   offset: {x: 0, y: 0, z: -10}
+--- !u!114 &519420034
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 519420028}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6a160d838ff8b4b4693ac20007e008c7, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  m_AssetsPPU: 32
+  m_RefResolutionX: 960
+  m_RefResolutionY: 540
+  m_UpscaleRT: 1
+  m_PixelSnapping: 0
+  m_CropFrameX: 0
+  m_CropFrameY: 0
+  m_StretchFill: 0
 --- !u!1 &545022177
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/_Project/Scripts/_Project.Gameplay/Camera/CameraFollow.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Camera/CameraFollow.cs
@@ -2,11 +2,12 @@ using UnityEngine;
 
 public class CameraFollow : MonoBehaviour
 {
-    public Transform target; // The player to follow
-    public Vector3 offset = new Vector3(0, 0, -10); // A default offset to position the camera
+    [SerializeField] Transform target;
+    [SerializeField] Vector3 offset = new Vector3(0f, 0f, -10f);
 
-    // LateUpdate is called once per frame, after all Update functions have been called.
-    // This ensures the camera moves after the player has moved.
+    public Transform Target => target;
+    public Vector3 Offset => offset;
+
     void LateUpdate()
     {
         Tick();
@@ -28,7 +29,6 @@ public class CameraFollow : MonoBehaviour
             return;
         }
 
-        // Set the camera's position to the target's position plus the offset
         transform.position = target.position + offset;
     }
 }

--- a/Assets/_Project/_Tests/EditMode/Camera/CameraFollowTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Camera/CameraFollowTests.cs
@@ -14,15 +14,33 @@ namespace Castlebound.Tests.Camera
             var player = new GameObject("Player");
             player.tag = "Player";
 
-            Assert.IsNull(follow.target, "Precondition: target is not assigned.");
+            Assert.IsNull(follow.Target, "Precondition: target is not assigned.");
 
             follow.Tick();
 
-            Assert.IsNotNull(follow.target, "Target should be auto-assigned from Player tag.");
-            Assert.That(follow.target, Is.EqualTo(player.transform));
+            Assert.IsNotNull(follow.Target, "Target should be auto-assigned from Player tag.");
+            Assert.That(follow.Target, Is.EqualTo(player.transform));
 
             Object.DestroyImmediate(player);
             Object.DestroyImmediate(cameraGo);
         }
+
+        [Test]
+        public void Tick_FollowsPlayerWithAuthoredOffset()
+        {
+            var cameraGo = new GameObject("Main Camera");
+            var follow = cameraGo.AddComponent<CameraFollow>();
+            var player = new GameObject("Player");
+            player.tag = "Player";
+            player.transform.position = new Vector3(3f, -2f, 0f);
+
+            follow.Tick();
+
+            Assert.That(cameraGo.transform.position, Is.EqualTo(player.transform.position + follow.Offset));
+
+            Object.DestroyImmediate(player);
+            Object.DestroyImmediate(cameraGo);
+        }
+
     }
 }

--- a/Assets/_Project/_Tests/EditMode/Camera/CameraScaleBaselineTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Camera/CameraScaleBaselineTests.cs
@@ -1,6 +1,7 @@
 using NUnit.Framework;
 using UnityEditor.SceneManagement;
 using UnityEngine;
+using UnityEngine.U2D;
 
 namespace Castlebound.Tests.Scale
 {
@@ -18,8 +19,20 @@ namespace Castlebound.Tests.Scale
                 var camera = FindInScene<UnityEngine.Camera>(scene);
                 Assert.NotNull(camera, "Expected a Camera in MainPrototype.");
                 Assert.IsTrue(camera.orthographic, "Main camera must be orthographic for 2D scale baseline.");
-                Assert.That(camera.orthographicSize, Is.GreaterThanOrEqualTo(9f).And.LessThanOrEqualTo(12f),
-                    "Orthographic size should be in a readable baseline range for PPU=32.");
+                Assert.That(camera.orthographicSize, Is.EqualTo(8.4375f).Within(0.001f),
+                    "Main camera should author the strict 540-pixel vertical view.");
+
+                var pixelPerfect = camera.GetComponent<PixelPerfectCamera>();
+                Assert.NotNull(pixelPerfect, "Main camera must own the pixel-perfect rendering contract.");
+                Assert.That(pixelPerfect.assetsPPU, Is.EqualTo(32));
+                Assert.That(pixelPerfect.refResolutionX, Is.EqualTo(960));
+                Assert.That(pixelPerfect.refResolutionY, Is.EqualTo(540));
+                Assert.IsTrue(pixelPerfect.upscaleRT);
+                Assert.IsFalse(pixelPerfect.cropFrameX,
+                    "Wider displays should reveal additional world instead of adding side borders.");
+                Assert.IsFalse(pixelPerfect.cropFrameY,
+                    "Taller landscape displays should reveal additional world instead of adding top/bottom borders.");
+                Assert.IsFalse(pixelPerfect.stretchFill);
             }
             finally
             {

--- a/Assets/_Project/_Tests/EditMode/Camera/MobilePresentationSettingsTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Camera/MobilePresentationSettingsTests.cs
@@ -1,0 +1,18 @@
+using NUnit.Framework;
+using UnityEditor;
+
+namespace Castlebound.Tests.Scale
+{
+    public class MobilePresentationSettingsTests
+    {
+        [Test]
+        public void PlayerSettings_AllowOnlyLandscapeAutorotation()
+        {
+            Assert.That(PlayerSettings.defaultInterfaceOrientation, Is.EqualTo(UIOrientation.AutoRotation));
+            Assert.IsFalse(PlayerSettings.allowedAutorotateToPortrait);
+            Assert.IsFalse(PlayerSettings.allowedAutorotateToPortraitUpsideDown);
+            Assert.IsTrue(PlayerSettings.allowedAutorotateToLandscapeLeft);
+            Assert.IsTrue(PlayerSettings.allowedAutorotateToLandscapeRight);
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Camera/MobilePresentationSettingsTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Camera/MobilePresentationSettingsTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d03f0ce4ec564a71858a596440ab95a7

--- a/Assets/_Project/_Tests/EditMode/_Project.Tests.EditMode.asmdef
+++ b/Assets/_Project/_Tests/EditMode/_Project.Tests.EditMode.asmdef
@@ -1,7 +1,7 @@
 {
   "name": "_Project.Tests.EditMode",
   "rootNamespace": "",
-  "references": ["_Project.Core", "_Project.Gameplay", "Unity.TextMeshPro"],
+  "references": ["_Project.Core", "_Project.Gameplay", "Unity.TextMeshPro", "GUID:476f7c6c6dfeed041b063446a926e656"],
   "includePlatforms": ["Editor"],
   "excludePlatforms": [],
   "allowUnsafeCode": false,

--- a/Assets/_Project/_Tests/PlayMode/ScaleBaselineSmokePlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/ScaleBaselineSmokePlayTests.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.TestTools;
+using UnityEngine.U2D;
 
 namespace Castlebound.Tests.PlayMode.Scale
 {
@@ -22,8 +23,14 @@ namespace Castlebound.Tests.PlayMode.Scale
             var camera = Object.FindObjectOfType<Camera>();
             Assert.NotNull(camera, "Expected main camera in MainPrototype.");
             Assert.IsTrue(camera.orthographic, "Main camera should remain orthographic in scale baseline.");
-            Assert.That(camera.orthographicSize, Is.GreaterThanOrEqualTo(9f).And.LessThanOrEqualTo(12f),
-                "Camera size should remain in baseline readable range after scale migration.");
+            Assert.That(camera.orthographicSize, Is.EqualTo(8.4375f).Within(0.001f),
+                "Pixel-perfect camera should preserve the authored 540-pixel vertical view.");
+
+            var pixelPerfect = camera.GetComponent<PixelPerfectCamera>();
+            Assert.NotNull(pixelPerfect, "Main camera should include PixelPerfectCamera at runtime.");
+            Assert.That(pixelPerfect.assetsPPU, Is.EqualTo(32));
+            Assert.That(pixelPerfect.refResolutionX, Is.EqualTo(960));
+            Assert.That(pixelPerfect.refResolutionY, Is.EqualTo(540));
 
             var player = Object.FindObjectOfType<PlayerController>();
             Assert.NotNull(player, "Expected PlayerController in MainPrototype.");

--- a/Assets/_Project/_Tests/PlayMode/_Project.Tests.PlayMode.asmdef
+++ b/Assets/_Project/_Tests/PlayMode/_Project.Tests.PlayMode.asmdef
@@ -4,7 +4,8 @@
   "references": [
     "_Project.Core",
     "_Project.Gameplay",
-    "Unity.TextMeshPro"
+    "Unity.TextMeshPro",
+    "GUID:476f7c6c6dfeed041b063446a926e656"
   ],
   "includePlatforms": [],
   "excludePlatforms": [],

--- a/Docs/CAMERA_SETUP.md
+++ b/Docs/CAMERA_SETUP.md
@@ -1,0 +1,19 @@
+# Camera Setup
+
+`MainPrototype` uses a scene-authored orthographic `Main Camera` with Unity's `PixelPerfectCamera` and `CameraFollow` components. Cinemachine is not part of the camera contract.
+
+## Pixel-perfect baseline
+
+- Assets PPU: `32`
+- Reference resolution: `960 x 540` (16:9)
+- Authored orthographic size: `8.4375`
+- Vertical world view: `16.875` units
+- Upscale Render Texture: enabled
+- Crop Frame X/Y: disabled so the world fills the display and wider screens reveal additional surroundings
+- Stretch Fill: disabled because non-integer stretching produces uneven source-pixel sizes
+
+The reference height is the view-range tuning value: `orthographic size = reference height / (2 x assets PPU)`. Keep the reference width at the same 16:9 ratio when tuning it. The Unity Game view should use a fixed compatible resolution such as `1920 x 1080`, where this baseline renders at exactly 2x.
+
+Mobile presentation uses landscape-only autorotation. Pixel-perfect integer scaling fills the available landscape display; wider or taller aspect ratios expose additional world instead of stretching pixels or adding fixed-frame borders. Keep critical gameplay composition inside the 16:9 baseline and treat additional space as bonus visibility.
+
+Level-based view-range progression is intentionally deferred. A future system should change the camera's reference resolution through one view-range contract rather than independently adjusting both `Camera.orthographicSize` and `PixelPerfectCamera`.

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,25 @@
 
 ---
 
+## 2026-07-29 - feat-60-pixel-perfect-camera
+
+### Summary
+- Configured the MainPrototype camera for PPU32 pixel-perfect rendering with a tunable 960x540 reference resolution.
+- Applied a strict size-8.4375 view while preserving scene-authored camera ownership and the existing follow behavior.
+- Filled adaptive landscape displays with additional world visibility instead of borders or fractional stretching.
+
+### New or Updated Tests
+**EditMode**
+- CameraScaleBaselineTests — verifies the scene-authored PixelPerfectCamera component, PPU, reference resolution, framing, and scaling options.
+- CameraFollowTests — verifies automatic Player resolution and authored-offset following.
+- MobilePresentationSettingsTests — verifies landscape-only autorotation on mobile.
+
+**PlayMode**
+- ScaleBaselineSmokePlayTests — verifies the pixel-perfect camera contract and strict 540-pixel framing in MainPrototype.
+
+### Notes
+- EditMode and PlayMode tests pass; manual validation confirmed uniform pixels, adaptive full-screen framing, acceptable zoom, and landscape presentation.
+
 ## 2026-07-29 - fix-102-targeted-feedback-routing
 
 ### Summary

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -58,8 +58,8 @@ PlayerSettings:
   iosShowActivityIndicatorOnLoading: -1
   androidShowActivityIndicatorOnLoading: -1
   iosUseCustomAppBackgroundBehavior: 0
-  allowedAutorotateToPortrait: 1
-  allowedAutorotateToPortraitUpsideDown: 1
+  allowedAutorotateToPortrait: 0
+  allowedAutorotateToPortraitUpsideDown: 0
   allowedAutorotateToLandscapeRight: 1
   allowedAutorotateToLandscapeLeft: 1
   useOSAutorotation: 1


### PR DESCRIPTION
## Why
Castlebound needed crisp, stable pixel-art rendering that fills modern landscape displays naturally without fractional stretching or fixed-frame borders.

## What changed
- Added a scene-authored Pixel Perfect Camera contract using PPU32 and a tunable 960x540 reference resolution
- Applied a slightly closer baseline view while allowing wider displays to reveal additional world
- Disabled fixed-frame cropping and stretch fill so adaptive displays remain full and undistorted
- Restricted mobile autorotation to landscape orientations
- Clarified camera-follow ownership and documented view-range tuning

## How to test
1. Open MainPrototype and inspect 16:9 plus ultrawide Game View or Device Simulator presets
2. Press Play → verify uniform pixels, full-screen adaptive framing, acceptable castle visibility, and landscape presentation
3. Run tests:
   - EditMode
   - PlayMode

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched (CAMERA_SETUP.md and TEST_LOG.md updated)

## Related
- Closes #60
