### PR TITLE
fix(ai): retarget enemies expelled by barrier repair

### DIFF
--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/CastleRegionTracker.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/CastleRegionTracker.cs
@@ -77,6 +77,15 @@ namespace Castlebound.Gameplay.AI
             return _enemiesInside.Contains(enemy);
         }
 
+        public void ReconcileEnemyOutsideAfterBarrierRepair(EnemyController2D enemy)
+        {
+            if (enemy == null)
+                return;
+
+            _enemiesInside.Remove(enemy);
+            OnEnemyExited?.Invoke(enemy);
+        }
+
 #if UNITY_EDITOR
         public void Debug_ForceInstanceForTests()
         {
@@ -99,6 +108,24 @@ namespace Castlebound.Gameplay.AI
             else
             {
                 OnPlayerExited?.Invoke();
+            }
+        }
+
+
+        public void Debug_SetEnemyInsideForTests(EnemyController2D enemy, bool inside)
+        {
+            if (enemy == null)
+            {
+                return;
+            }
+
+            if (inside && _enemiesInside.Add(enemy))
+            {
+                OnEnemyEntered?.Invoke(enemy);
+            }
+            else if (!inside)
+            {
+                ReconcileEnemyOutsideAfterBarrierRepair(enemy);
             }
         }
 #endif

--- a/Assets/_Project/Scripts/_Project.Gameplay/Barrier/BarrierHealth.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Barrier/BarrierHealth.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 using Castlebound.Gameplay.Stats;
+using Castlebound.Gameplay.AI;
 
 public class BarrierHealth : MonoBehaviour, IDamageable
 {
@@ -187,9 +188,14 @@ public class BarrierHealth : MonoBehaviour, IDamageable
                 continue;
             }
 
-            if (other.GetComponentInParent<EnemyController2D>() != null)
+            var enemy = other.GetComponentInParent<EnemyController2D>();
+            if (enemy != null)
             {
-                BarrierOverlapResolver.ResolveOverlap(barrierCollider, other, false);
+                bool pushedOutside = BarrierOverlapResolver.ResolveOverlap(barrierCollider, other, false);
+                if (pushedOutside)
+                {
+                    CastleRegionTracker.Instance?.ReconcileEnemyOutsideAfterBarrierRepair(enemy);
+                }
             }
         }
     }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Barrier/BarrierOverlapResolver.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Barrier/BarrierOverlapResolver.cs
@@ -39,9 +39,9 @@ public static class BarrierOverlapResolver
         return insideCount >= 3;
     }
 
-    public static void ResolveOverlap(Collider2D barrier, Collider2D actor, bool isPlayer)
+    public static bool ResolveOverlap(Collider2D barrier, Collider2D actor, bool isPlayer)
     {
-        if (barrier == null || actor == null) return;
+        if (barrier == null || actor == null) return false;
 
         Vector2 outward = Vector2.zero;
         Vector2 anchorPos = Vector2.zero;
@@ -75,7 +75,7 @@ public static class BarrierOverlapResolver
         {
             if (desiredDir == Vector2.zero)
             {
-                return;
+                return false;
             }
 
             for (int i = 0; i < maxIterations; i++)
@@ -93,6 +93,8 @@ public static class BarrierOverlapResolver
                 Vector2 target = (Vector2)barrier.bounds.center + dir * (barrierExtent + actorExtent + skin);
                 SetPositionImmediate(actor, target);
             }
+
+            return false;
         }
         else
         {
@@ -105,7 +107,7 @@ public static class BarrierOverlapResolver
                     ColliderDistance2D dist = Physics2D.Distance(barrier, actor);
                     if (!dist.isOverlapped)
                     {
-                        return;
+                        return false;
                     }
 
                     Vector2 normal = dist.normal;
@@ -113,8 +115,10 @@ public static class BarrierOverlapResolver
                     ApplyDelta(actor, separation);
                 }
 
-                return;
+                return false;
             }
+
+            bool pushedOutside = Vector2.Dot(desiredDir, outward) > 0f;
 
             for (int i = 0; i < maxIterations; i++)
             {
@@ -122,7 +126,7 @@ public static class BarrierOverlapResolver
                 ColliderDistance2D dist = Physics2D.Distance(barrier, actor);
                 if (!dist.isOverlapped)
                 {
-                    return;
+                    return pushedOutside;
                 }
 
                 Vector2 dir = desiredDir.normalized;
@@ -131,6 +135,8 @@ public static class BarrierOverlapResolver
                 Vector2 target = (Vector2)barrier.bounds.center + dir * (barrierExtent + actorExtent + skin);
                 SetPositionImmediate(actor, target);
             }
+
+            return pushedOutside;
         }
     }
 

--- a/Assets/_Project/_Tests/EditMode/Barrier/BarrierEnemyPushThresholdTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Barrier/BarrierEnemyPushThresholdTests.cs
@@ -31,10 +31,11 @@ namespace Castlebound.Tests.Gate
             Physics2D.SyncTransforms();
 
             Vector2 before = enemyGo.transform.position;
-            BarrierOverlapResolver.ResolveOverlap(barrierCollider, enemy, isPlayer: false);
+            bool pushedOutside = BarrierOverlapResolver.ResolveOverlap(barrierCollider, enemy, isPlayer: false);
             Vector2 after = enemyGo.transform.position;
 
             Assert.Greater(after.x, before.x, "Enemy should be pushed out before passing the anchor threshold.");
+            Assert.IsTrue(pushedOutside, "Outward resolution should request castle-region reconciliation.");
 
             Object.DestroyImmediate(enemyGo);
             Object.DestroyImmediate(anchorGo);

--- a/Assets/_Project/_Tests/EditMode/Barrier/BarrierRepairOverlapPushTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Barrier/BarrierRepairOverlapPushTests.cs
@@ -54,10 +54,11 @@ namespace Castlebound.Tests.Gate
             Physics2D.SyncTransforms();
 
             Vector2 before = enemyGo.transform.position;
-            BarrierOverlapResolver.ResolveOverlap(barrier, enemy, isPlayer: false);
+            bool pushedOutside = BarrierOverlapResolver.ResolveOverlap(barrier, enemy, isPlayer: false);
 
             Vector2 after = enemyGo.transform.position;
             Assert.Greater(after.x, before.x, "Enemy should be pushed out of the barrier.");
+            Assert.IsFalse(pushedOutside, "Without an authored approach anchor, region ownership cannot be reconciled.");
 
             Object.DestroyImmediate(enemyGo);
             Object.DestroyImmediate(barrierGo);

--- a/Assets/_Project/_Tests/PlayMode/Barrier/BarrierRepairEnemyRetargetPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/Barrier/BarrierRepairEnemyRetargetPlayTests.cs
@@ -1,0 +1,119 @@
+using System.Collections;
+using Castlebound.Gameplay.AI;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Castlebound.Tests.Gate
+{
+    public class BarrierRepairEnemyRetargetPlayTests
+    {
+        [UnityTest]
+        public IEnumerator Repair_WhenEnemyIsExpelled_ReconcilesRegionAndRetargetsBarrier()
+        {
+            var regionObject = new GameObject("CastleRegion");
+            var region = regionObject.AddComponent<CastleRegionTracker>();
+            region.Debug_ForceInstanceForTests();
+            region.Debug_SetPlayerInsideForTests(true);
+
+            var playerObject = new GameObject("Player");
+            playerObject.tag = "Player";
+
+            var barrierObject = new GameObject("Barrier");
+            var barrierCollider = barrierObject.AddComponent<BoxCollider2D>();
+            barrierCollider.size = new Vector2(2f, 2f);
+            barrierObject.AddComponent<SpriteRenderer>();
+
+            var anchorObject = new GameObject("ApproachAnchor");
+            anchorObject.transform.position = new Vector2(2f, 0f);
+            var hold = barrierObject.AddComponent<EnemyBarrierHoldBehavior>();
+            hold.Debug_SetAnchor(anchorObject.transform);
+
+            var barrierHealth = barrierObject.AddComponent<BarrierHealth>();
+            barrierHealth.TakeDamage(barrierHealth.MaxHealth);
+
+            var enemyObject = new GameObject("Enemy");
+            enemyObject.tag = "Enemy";
+            enemyObject.layer = LayerMask.NameToLayer("Enemies");
+            var body = enemyObject.AddComponent<Rigidbody2D>();
+            body.gravityScale = 0f;
+            var enemyCollider = enemyObject.AddComponent<CircleCollider2D>();
+            enemyCollider.radius = 0.4f;
+            var controller = enemyObject.AddComponent<EnemyController2D>();
+            controller.Debug_SetupRefs(playerObject.transform, barrierObject.transform);
+            var regionState = enemyObject.AddComponent<EnemyRegionState>();
+            regionState.Debug_EnsureBound();
+
+            region.Debug_SetEnemyInsideForTests(controller, true);
+            enemyObject.transform.position = new Vector2(1.2f, 0f);
+            Physics2D.SyncTransforms();
+
+            Assert.IsTrue(regionState.EnemyInside, "Precondition: enemy should be recorded inside.");
+            Assert.AreSame(
+                playerObject.transform,
+                controller.Debug_SelectTarget(playerInside: true, enemyInside: true),
+                "Precondition: an inside enemy should target the player.");
+
+            barrierHealth.Repair();
+            yield return new WaitForFixedUpdate();
+
+            Assert.IsFalse(regionState.EnemyInside, "An enemy expelled by repair must be reconciled outside.");
+            Assert.AreSame(
+                barrierObject.transform,
+                controller.Target,
+                "The expelled enemy should reacquire its repaired home barrier.");
+
+            Object.Destroy(enemyObject);
+            Object.Destroy(barrierObject);
+            Object.Destroy(anchorObject);
+            Object.Destroy(playerObject);
+            Object.Destroy(regionObject);
+        }
+
+        [UnityTest]
+        public IEnumerator RepairExpulsion_WhenEnemyWasNeverRegisteredInside_StillRetargetsBarrier()
+        {
+            var regionObject = new GameObject("CastleRegion");
+            var region = regionObject.AddComponent<CastleRegionTracker>();
+            region.Debug_ForceInstanceForTests();
+            region.Debug_SetPlayerInsideForTests(true);
+
+            var playerObject = new GameObject("Player");
+            playerObject.tag = "Player";
+
+            var barrierObject = new GameObject("Barrier");
+            var barrierHealth = barrierObject.AddComponent<BarrierHealth>();
+            barrierHealth.TakeDamage(barrierHealth.MaxHealth);
+
+            var enemyObject = new GameObject("Enemy");
+            enemyObject.tag = "Enemy";
+            var body = enemyObject.AddComponent<Rigidbody2D>();
+            body.gravityScale = 0f;
+            var controller = enemyObject.AddComponent<EnemyController2D>();
+            controller.Debug_SetupRefs(playerObject.transform, barrierObject.transform);
+            var regionState = enemyObject.AddComponent<EnemyRegionState>();
+            regionState.Debug_EnsureBound();
+
+            Assert.IsFalse(region.EnemyInside(controller),
+                "Precondition: the partially advanced enemy was never registered inside.");
+            Assert.AreSame(
+                playerObject.transform,
+                controller.Debug_SelectTarget(playerInside: true, enemyInside: false),
+                "Precondition: the enemy committed through the nearby broken barrier toward the player.");
+
+            barrierHealth.Repair();
+            region.ReconcileEnemyOutsideAfterBarrierRepair(controller);
+            yield return new WaitForFixedUpdate();
+
+            Assert.IsFalse(regionState.EnemyInside,
+                "Repair reconciliation must keep an unregistered expelled enemy outside.");
+            Assert.AreSame(barrierObject.transform, controller.Target,
+                "The expelled outside enemy must target the repaired barrier instead of retaining the player.");
+
+            Object.Destroy(enemyObject);
+            Object.Destroy(barrierObject);
+            Object.Destroy(playerObject);
+            Object.Destroy(regionObject);
+        }
+    }
+}

--- a/Assets/_Project/_Tests/PlayMode/Barrier/BarrierRepairEnemyRetargetPlayTests.cs.meta
+++ b/Assets/_Project/_Tests/PlayMode/Barrier/BarrierRepairEnemyRetargetPlayTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8ca6ab27a5d642f2bf7c308aa8c64847

--- a/TEST_LOG.md
+++ b/TEST_LOG.md
@@ -1,3 +1,20 @@
+## 2026-07-30 - barrier-repair-enemy-retarget
+
+### Summary
+- Reconciled castle-region membership when barrier repair expels an overlapping enemy.
+- Restored barrier targeting after enemies are pushed outside.
+- Preserved inward overlap resolution and ordinary trigger-owned region tracking.
+
+### New or Updated Tests
+**EditMode**
+- BarrierEnemyPushThresholdTests — outward overlap resolution reports that region reconciliation is required.
+
+**PlayMode**
+- BarrierRepairEnemyRetargetPlayTests — expelled enemies reacquire the repaired barrier whether or not they had entered the castle trigger.
+
+### Notes
+- Relevant barrier, enemy targeting, engagement, and attack-lock regressions pass.
+
 ## 2026-07-30 - melee-goblin-animation
 
 ### Summary


### PR DESCRIPTION
## Why
Repairing a broken barrier can push nearby enemies back outside the castle while leaving their recorded region state stale. Those enemies can remain idle or continue targeting the player instead of reacquiring the repaired barrier.

## What changed
- Report whether barrier overlap resolution expelled an enemy outward
- Reconcile only the expelled enemy through the castle-region event contract
- Preserve ordinary trigger-owned region tracking and inward overlap behavior
- Add EditMode coverage for the expulsion signal and PlayMode regressions for registered and partially advanced enemies

## How to test
1. Break a barrier and allow enemies to enter or partially cross its opening
2. Repair the barrier while enemies overlap it
3. Verify expelled enemies return to targeting the repaired barrier
4. Run tests:
   - EditMode
   - PlayMode

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated (N/A - existing scene and prefab contracts are unchanged)
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched (N/A - behavior fix requires no user-facing documentation)

## Related
- Refs #262
