### PR TITLE
refactor(ai): select nearest barrier when retargeting

### DIFF
--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/CastleTargetSelector.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/CastleTargetSelector.cs
@@ -8,7 +8,7 @@ namespace Castlebound.Gameplay.AI
     /// </summary>
     public static class CastleTargetSelector
     {
-        public static Transform AssignHomeBarrier(Vector2 spawnPosition, IReadOnlyList<BarrierHealth> barriers)
+        public static Transform SelectNearestBarrier(Vector2 enemyPosition, IReadOnlyList<BarrierHealth> barriers)
         {
             if (barriers == null || barriers.Count == 0)
                 return null;
@@ -33,7 +33,7 @@ namespace Castlebound.Gameplay.AI
                     targetPos = anchor;
                 }
 
-                float sqrDist = (targetPos - spawnPosition).sqrMagnitude;
+                float sqrDist = (targetPos - enemyPosition).sqrMagnitude;
                 if (sqrDist < bestSqrDist)
                 {
                     bestSqrDist = sqrDist;

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyController2D.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyController2D.cs
@@ -184,7 +184,7 @@ public class EnemyController2D : MonoBehaviour
 
     private void Start()
     {
-        Targeting.AssignHomeBarrierIfNeeded(transform.position);
+        Targeting.RequestRetarget();
     }
 
     private void FixedUpdate()
@@ -292,11 +292,13 @@ public class EnemyController2D : MonoBehaviour
 
     public Transform Debug_SelectTarget(bool playerInside, bool enemyInside)
     {
+        Targeting.RequestRetarget();
         return SelectTarget(playerInside, enemyInside);
     }
 
     public Transform Debug_SteerTarget(bool playerInside, bool enemyInside)
     {
+        Targeting.RequestRetarget();
         return SelectSteerTarget(playerInside, enemyInside);
     }
 
@@ -311,13 +313,17 @@ public class EnemyController2D : MonoBehaviour
     {
         Targeting.Debug_Setup(playerRef, homeRef);
         barrier = homeRef;
-        Targeting.AssignHomeBarrierIfNeeded(transform.position);
-        barrier = Targeting.HomeBarrier;
+        barrier = Targeting.SelectedBarrier;
     }
 
     public void Debug_SetTargetDecision(Transform steer, Transform attack, EnemyTargetType targetType)
     {
         Targeting.Debug_SetDecision(steer, attack, targetType);
+    }
+
+    public void RequestTargetRefresh()
+    {
+        Targeting?.RequestRetarget();
     }
 
     public void Debug_SetBarrierTargeting(bool value)
@@ -334,9 +340,9 @@ public class EnemyController2D : MonoBehaviour
             Debug.LogWarning("[EnemyController2D] Player reference not found in scene. Enemy will have no target.", this);
         }
 
-        if (Targeting != null && Targeting.UsesBarrierTargeting && Targeting.HomeBarrier == null)
+        if (Targeting != null && Targeting.UsesBarrierTargeting && Targeting.SelectedBarrier == null)
         {
-            Debug.LogWarning("[EnemyController2D] No home barrier found while barrier targeting is enabled.", this);
+            Debug.LogWarning("[EnemyController2D] No barrier target found while barrier targeting is enabled.", this);
         }
     }
 #endif

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyRegionState.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyRegionState.cs
@@ -98,6 +98,7 @@ namespace Castlebound.Gameplay.AI
             if (enemy == controller)
             {
                 enemyInside = true;
+                controller?.RequestTargetRefresh();
             }
         }
 
@@ -106,17 +107,20 @@ namespace Castlebound.Gameplay.AI
             if (enemy == controller)
             {
                 enemyInside = false;
+                controller?.RequestTargetRefresh();
             }
         }
 
         void HandlePlayerEntered()
         {
             playerInside = true;
+            controller?.RequestTargetRefresh();
         }
 
         void HandlePlayerExited()
         {
             playerInside = false;
+            controller?.RequestTargetRefresh();
         }
 
         void HandleRegionReady()

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyTargetSelector.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyTargetSelector.cs
@@ -17,7 +17,7 @@ namespace Castlebound.Gameplay.AI
             public bool EnemyInside;
             public bool PlayerInside;
             public Transform Player;
-            public Transform HomeBarrier;
+            public Transform BarrierTarget;
             public float PassThroughRadius;
         }
 
@@ -61,16 +61,16 @@ namespace Castlebound.Gameplay.AI
             }
 
             // Enemy outside, player inside: go for home barrier if known.
-            if (input.HomeBarrier != null)
+            if (input.BarrierTarget != null)
             {
-                var health = input.HomeBarrier.GetComponent<BarrierHealth>();
+                var health = input.BarrierTarget.GetComponent<BarrierHealth>();
                 bool broken = health != null && health.IsBroken;
 
                 // If broken and we're effectively at the barrier opening, switch to player.
                 if (broken && input.PassThroughRadius > 0f)
                 {
-                    float distToHome = Vector2.Distance(input.EnemyPosition, input.HomeBarrier.position);
-                    if (distToHome <= input.PassThroughRadius)
+                    float distToBarrier = Vector2.Distance(input.EnemyPosition, input.BarrierTarget.position);
+                    if (distToBarrier <= input.PassThroughRadius)
                     {
                         decision.SteerTarget = input.Player;
                         decision.AttackTarget = input.Player;
@@ -79,8 +79,8 @@ namespace Castlebound.Gameplay.AI
                     }
                 }
 
-                decision.SteerTarget = input.HomeBarrier;
-                decision.AttackTarget = input.HomeBarrier;
+                decision.SteerTarget = input.BarrierTarget;
+                decision.AttackTarget = input.BarrierTarget;
                 decision.TargetType = EnemyTargetType.Barrier;
                 return decision;
             }

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyTargeting.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyTargeting.cs
@@ -1,50 +1,65 @@
+using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Serialization;
 using Castlebound.Gameplay.AI;
 
 public class EnemyTargeting : MonoBehaviour
 {
     [SerializeField] private Transform player;
-    [SerializeField] private Transform homeBarrier;
+    [FormerlySerializedAs("homeBarrier")]
+    [SerializeField] private Transform selectedBarrier;
     [SerializeField] private float passThroughRadius = 0.6f;
     [SerializeField] private bool useBarrierTargeting = true;
 
     private bool committedThroughBrokenBarrier;
+    private bool retargetRequested = true;
+    private IReadOnlyList<BarrierHealth> barrierCandidatesOverride;
 
     public Transform Player => player;
-    public Transform HomeBarrier => homeBarrier;
+    public Transform SelectedBarrier => selectedBarrier;
     public bool UsesBarrierTargeting => useBarrierTargeting;
     public Transform SteerTarget { get; private set; }
     public Transform AttackTarget { get; private set; }
     public EnemyTargetType CurrentTargetType { get; private set; } = EnemyTargetType.None;
+    public int TargetRevision { get; private set; }
 
     public void Initialize()
     {
         EnsurePlayerReference();
         ApplyFallbackDecision();
+        RequestRetarget();
     }
 
-    public void AssignHomeBarrierIfNeeded(Vector2 enemyPosition)
+    public void RequestRetarget()
     {
-        if (!useBarrierTargeting || homeBarrier != null)
-            return;
-
-        homeBarrier = CastleTargetSelector.AssignHomeBarrier(enemyPosition, BarrierHealth.All);
+        retargetRequested = true;
     }
 
     public void Refresh(Vector2 enemyPosition, bool playerInside, bool enemyInside)
     {
         EnsurePlayerReference();
-        AssignHomeBarrierIfNeeded(enemyPosition);
+
+        if (!retargetRequested && CurrentTargetType == EnemyTargetType.Barrier && IsAtBrokenSelectedBarrier(enemyPosition))
+        {
+            committedThroughBrokenBarrier = true;
+            retargetRequested = true;
+        }
+
+        if (!retargetRequested && SteerTarget != null && AttackTarget != null)
+            return;
+
+        retargetRequested = false;
+        TargetRevision++;
 
         if (!playerInside)
         {
             committedThroughBrokenBarrier = false;
         }
-        else if (committedThroughBrokenBarrier && !enemyInside && !IsHomeBarrierBroken())
+        else if (committedThroughBrokenBarrier && !enemyInside && !IsSelectedBarrierBroken())
         {
             committedThroughBrokenBarrier = false;
         }
-        else if (IsAtBrokenHomeBarrier(enemyPosition))
+        else if (IsAtBrokenSelectedBarrier(enemyPosition))
         {
             committedThroughBrokenBarrier = true;
         }
@@ -55,13 +70,32 @@ public class EnemyTargeting : MonoBehaviour
             return;
         }
 
+        if (!playerInside || enemyInside)
+        {
+            ApplyFallbackDecision();
+            return;
+        }
+
+        selectedBarrier = useBarrierTargeting
+            ? CastleTargetSelector.SelectNearestBarrier(
+                enemyPosition,
+                barrierCandidatesOverride ?? BarrierHealth.All)
+            : null;
+
+        if (IsAtBrokenSelectedBarrier(enemyPosition))
+        {
+            committedThroughBrokenBarrier = true;
+            ApplyFallbackDecision();
+            return;
+        }
+
         EnemyTargetSelector.Decision decision = EnemyTargetSelector.Select(new EnemyTargetSelector.Input
         {
             EnemyPosition = enemyPosition,
             EnemyInside = enemyInside,
             PlayerInside = playerInside,
             Player = player,
-            HomeBarrier = useBarrierTargeting ? homeBarrier : null,
+            BarrierTarget = useBarrierTargeting ? selectedBarrier : null,
             PassThroughRadius = passThroughRadius
         });
 
@@ -70,11 +104,24 @@ public class EnemyTargeting : MonoBehaviour
         CurrentTargetType = decision.TargetType;
     }
 
-    public void Debug_Setup(Transform playerReference, Transform homeBarrierReference = null)
+    public void Debug_Setup(Transform playerReference, Transform selectedBarrierReference = null)
     {
         player = playerReference;
-        homeBarrier = homeBarrierReference;
+        selectedBarrier = selectedBarrierReference;
+        BarrierHealth explicitBarrier = selectedBarrierReference != null
+            ? selectedBarrierReference.GetComponent<BarrierHealth>()
+            : null;
+        barrierCandidatesOverride = explicitBarrier != null
+            ? new[] { explicitBarrier }
+            : null;
         ApplyFallbackDecision();
+        RequestRetarget();
+    }
+
+    public void Debug_SetBarrierCandidates(IReadOnlyList<BarrierHealth> barriers)
+    {
+        barrierCandidatesOverride = barriers;
+        RequestRetarget();
     }
 
     public void Debug_SetDecision(Transform steer, Transform attack, EnemyTargetType targetType)
@@ -113,24 +160,24 @@ public class EnemyTargeting : MonoBehaviour
             player = playerController.transform;
     }
 
-    private bool IsAtBrokenHomeBarrier(Vector2 enemyPosition)
+    private bool IsAtBrokenSelectedBarrier(Vector2 enemyPosition)
     {
-        if (!useBarrierTargeting || homeBarrier == null || passThroughRadius <= 0f)
+        if (!useBarrierTargeting || selectedBarrier == null || passThroughRadius <= 0f)
             return false;
 
-        if (!IsHomeBarrierBroken())
+        if (!IsSelectedBarrierBroken())
             return false;
 
-        return ((Vector2)homeBarrier.position - enemyPosition).sqrMagnitude <=
+        return ((Vector2)selectedBarrier.position - enemyPosition).sqrMagnitude <=
                passThroughRadius * passThroughRadius;
     }
 
-    private bool IsHomeBarrierBroken()
+    private bool IsSelectedBarrierBroken()
     {
-        if (!useBarrierTargeting || homeBarrier == null)
+        if (!useBarrierTargeting || selectedBarrier == null)
             return false;
 
-        BarrierHealth health = homeBarrier.GetComponent<BarrierHealth>();
+        BarrierHealth health = selectedBarrier.GetComponent<BarrierHealth>();
         return health != null && health.IsBroken;
     }
 

--- a/Assets/_Project/_Tests/EditMode/AI/CastleTargetSelectorHomeBarrierTests.cs
+++ b/Assets/_Project/_Tests/EditMode/AI/CastleTargetSelectorHomeBarrierTests.cs
@@ -12,7 +12,7 @@ namespace Castlebound.Tests.AI
         public void HomeBarrierAssignment_ConsumesHealthRegistryWithoutTransformCollectionBuilder()
         {
             var selectorMethod = typeof(CastleTargetSelector).GetMethod(
-                "AssignHomeBarrier",
+                "SelectNearestBarrier",
                 new[] { typeof(Vector2), typeof(IReadOnlyList<BarrierHealth>) });
             var obsoleteBuilder = typeof(EnemyTargeting).GetMethod(
                 "GetAllBarrierTransforms",
@@ -34,7 +34,7 @@ namespace Castlebound.Tests.AI
             var spawnPosition = new Vector2(-3f, 0f);
             var barriers = new List<BarrierHealth> { barrierFar, barrierNear };
 
-            var homeBarrier = CastleTargetSelector.AssignHomeBarrier(spawnPosition, barriers);
+            var homeBarrier = CastleTargetSelector.SelectNearestBarrier(spawnPosition, barriers);
 
             Assert.AreSame(barrierNear.transform, homeBarrier, "Enemy should assign the nearest barrier to its spawn as the home barrier.");
 
@@ -54,7 +54,7 @@ namespace Castlebound.Tests.AI
             var spawnPosition = new Vector2(-3f, 0f);
             var barriers = new List<BarrierHealth> { barrierOther, barrierHome };
 
-            var homeBarrier = CastleTargetSelector.AssignHomeBarrier(spawnPosition, barriers);
+            var homeBarrier = CastleTargetSelector.SelectNearestBarrier(spawnPosition, barriers);
 
             var player = new GameObject("Player").transform;
             player.position = new Vector2(0f, 0f);
@@ -92,7 +92,7 @@ namespace Castlebound.Tests.AI
             var spawnPosition = new Vector2(-3f, 0f);
             var barriers = new List<BarrierHealth> { health };
 
-            var homeBarrier = CastleTargetSelector.AssignHomeBarrier(spawnPosition, barriers);
+            var homeBarrier = CastleTargetSelector.SelectNearestBarrier(spawnPosition, barriers);
 
             var player = new GameObject("Player").transform;
             player.position = new Vector2(0f, 0f);
@@ -128,7 +128,7 @@ namespace Castlebound.Tests.AI
             var spawnPosition = new Vector2(-3f, 0f);
             var barriers = new List<BarrierHealth> { health };
 
-            var homeBarrier = CastleTargetSelector.AssignHomeBarrier(spawnPosition, barriers);
+            var homeBarrier = CastleTargetSelector.SelectNearestBarrier(spawnPosition, barriers);
 
             var player = new GameObject("Player").transform;
             player.position = new Vector2(0f, 0f);
@@ -160,7 +160,7 @@ namespace Castlebound.Tests.AI
             var barrierA = new GameObject("Barrier_A").AddComponent<BarrierHealth>();
             barrierA.transform.position = Vector2.right;
 
-            var result = CastleTargetSelector.AssignHomeBarrier(
+            var result = CastleTargetSelector.SelectNearestBarrier(
                 Vector2.zero,
                 new List<BarrierHealth> { barrierB, barrierA });
 

--- a/Assets/_Project/_Tests/EditMode/AI/EnemyController/EnemyControllerWarningsTests.cs
+++ b/Assets/_Project/_Tests/EditMode/AI/EnemyController/EnemyControllerWarningsTests.cs
@@ -40,7 +40,7 @@ namespace Castlebound.Tests.AI
             var useBarrierField = typeof(EnemyController2D).GetField("useBarrierTargeting", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
             useBarrierField?.SetValue(controller, true);
 
-            LogAssert.Expect(LogType.Warning, "[EnemyController2D] No home barrier found while barrier targeting is enabled.");
+            LogAssert.Expect(LogType.Warning, "[EnemyController2D] No barrier target found while barrier targeting is enabled.");
             controller.Debug_ValidateRefs();
 
             Object.DestroyImmediate(enemy);

--- a/Assets/_Project/_Tests/EditMode/AI/EnemyTargetSelector/EnemyTargetSelectorTests.cs
+++ b/Assets/_Project/_Tests/EditMode/AI/EnemyTargetSelector/EnemyTargetSelectorTests.cs
@@ -26,7 +26,7 @@ namespace Castlebound.Tests.AI
                 EnemyInside = enemyInside,
                 PlayerInside = playerInside,
                 Player = player,
-                HomeBarrier = barrier
+                BarrierTarget = barrier
             });
 
             Assert.AreSame(barrier, decision.SteerTarget, "Outside while player is inside should steer to home barrier.");
@@ -57,7 +57,7 @@ namespace Castlebound.Tests.AI
                 EnemyInside = enemyInside,
                 PlayerInside = playerInside,
                 Player = player,
-                HomeBarrier = barrier
+                BarrierTarget = barrier
             });
 
             Assert.AreSame(player, decision.SteerTarget, "Once inside, steering should switch to player even if home barrier is broken.");
@@ -88,7 +88,7 @@ namespace Castlebound.Tests.AI
                 EnemyInside = enemyInside,
                 PlayerInside = playerInside,
                 Player = player,
-                HomeBarrier = barrier,
+                BarrierTarget = barrier,
                 PassThroughRadius = 0.6f
             });
 

--- a/Assets/_Project/_Tests/EditMode/AI/EnemyTargetingTests.cs
+++ b/Assets/_Project/_Tests/EditMode/AI/EnemyTargetingTests.cs
@@ -102,7 +102,9 @@ public class EnemyTargetingTests
             targeting.Debug_Setup(player.transform, barrier.transform);
 
             targeting.Refresh(new Vector2(0.5f, 0f), playerInside: true, enemyInside: false);
+            targeting.RequestRetarget();
             targeting.Refresh(new Vector2(2f, 0f), playerInside: false, enemyInside: false);
+            targeting.RequestRetarget();
             targeting.Refresh(new Vector2(2f, 0f), playerInside: true, enemyInside: false);
 
             Assert.AreSame(barrier.transform, targeting.SteerTarget,
@@ -135,6 +137,7 @@ public class EnemyTargetingTests
             Assert.AreEqual(EnemyTargetType.Player, targeting.CurrentTargetType);
 
             barrierHealth.Repair();
+            targeting.RequestRetarget();
             targeting.Refresh(new Vector2(2f, 0f), playerInside: true, enemyInside: false);
 
             Assert.AreSame(barrier.transform, targeting.SteerTarget);
@@ -146,6 +149,51 @@ public class EnemyTargetingTests
             Object.DestroyImmediate(enemy);
             Object.DestroyImmediate(player);
             Object.DestroyImmediate(barrier);
+        }
+    }
+
+    [Test]
+    public void Refresh_CachesBarrierUntilEnemyLocalRetargetIsRequested()
+    {
+        GameObject enemy = new GameObject("Enemy");
+        GameObject player = new GameObject("Player");
+        GameObject firstBarrier = new GameObject("FirstBarrier");
+        firstBarrier.transform.position = Vector2.zero;
+        BarrierHealth firstHealth = firstBarrier.AddComponent<BarrierHealth>();
+        GameObject secondBarrier = new GameObject("SecondBarrier");
+        secondBarrier.transform.position = Vector2.right * 10f;
+        BarrierHealth secondHealth = secondBarrier.AddComponent<BarrierHealth>();
+
+        try
+        {
+            EnemyTargeting targeting = enemy.AddComponent<EnemyTargeting>();
+            targeting.Debug_Setup(player.transform);
+            targeting.Debug_SetBarrierCandidates(new[] { firstHealth, secondHealth });
+
+            targeting.RequestRetarget();
+            targeting.Refresh(Vector2.left, playerInside: true, enemyInside: false);
+            int initialRevision = targeting.TargetRevision;
+            Assert.AreSame(firstBarrier.transform, targeting.AttackTarget);
+
+            targeting.Refresh(Vector2.right * 9f, playerInside: true, enemyInside: false);
+
+            Assert.AreSame(firstBarrier.transform, targeting.AttackTarget,
+                "A valid cached barrier must not trigger a nearest-barrier scan each refresh.");
+            Assert.That(targeting.TargetRevision, Is.EqualTo(initialRevision));
+
+            targeting.RequestRetarget();
+            targeting.Refresh(Vector2.right * 9f, playerInside: true, enemyInside: false);
+
+            Assert.AreSame(secondBarrier.transform, targeting.AttackTarget,
+                "An explicit enemy-local retarget should select the nearest barrier from the current position.");
+            Assert.That(targeting.TargetRevision, Is.EqualTo(initialRevision + 1));
+        }
+        finally
+        {
+            Object.DestroyImmediate(enemy);
+            Object.DestroyImmediate(player);
+            Object.DestroyImmediate(firstBarrier);
+            Object.DestroyImmediate(secondBarrier);
         }
     }
 

--- a/Assets/_Project/_Tests/PlayMode/AI/EnemyTargetingPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/AI/EnemyTargetingPlayTests.cs
@@ -28,16 +28,18 @@ namespace Castlebound.Tests.PlayMode.AI
 
             try
             {
-                targeting.AssignHomeBarrierIfNeeded(Vector2.zero);
-                Assert.AreSame(nearBarrier.transform, targeting.HomeBarrier,
+                targeting.RequestRetarget();
+                targeting.Refresh(Vector2.zero, playerInside: true, enemyInside: false);
+                Assert.AreSame(nearBarrier.transform, targeting.SelectedBarrier,
                     "Disabled barriers must leave the live registry before home-barrier selection.");
 
                 Object.Destroy(nearBarrier);
                 yield return null;
 
+                targeting.RequestRetarget();
                 targeting.Refresh(Vector2.zero, playerInside: true, enemyInside: false);
 
-                Assert.AreSame(farBarrier.transform, targeting.HomeBarrier,
+                Assert.AreSame(farBarrier.transform, targeting.SelectedBarrier,
                     "Destroyed barriers must leave the registry so targeting can safely reassign.");
             }
             finally
@@ -69,6 +71,7 @@ namespace Castlebound.Tests.PlayMode.AI
                 enemy.transform.position = new Vector2(2f, 0f);
                 yield return null;
 
+                targeting.RequestRetarget();
                 targeting.Refresh(enemy.transform.position, playerInside: true, enemyInside: false);
 
                 Assert.AreSame(barrier.transform, targeting.SteerTarget);

--- a/TEST_LOG.md
+++ b/TEST_LOG.md
@@ -1,3 +1,20 @@
+## 2026-07-30 - event-driven-enemy-retargeting
+
+### Summary
+- Replaced spawn-owned home barriers with cached, event-driven barrier target decisions.
+- Selected the nearest barrier from the affected enemy's current position only when retargeting is requested.
+- Connected enemy and player region transitions to enemy-local target refresh requests.
+
+### New or Updated Tests
+**EditMode**
+- EnemyTargetingTests — valid targets remain cached without polling and explicit retarget requests recompute the nearest barrier.
+
+**PlayMode**
+- EnemyTargetingPlayTests and BarrierRepairEnemyRetargetPlayTests — destroyed targets and repair expulsion trigger safe local retargeting.
+
+### Notes
+- Relevant targeting, steering, repair, engagement, and attack-lock regressions pass.
+
 ## 2026-07-30 - barrier-repair-enemy-retarget
 
 ### Summary


### PR DESCRIPTION
## Why
Enemies retained a spawn-assigned “home barrier,” so a later retarget could select a distant or irrelevant barrier. Target selection should respond to the affected enemy’s current position without continuously polling every barrier.

## What changed
- Replace persistent home-barrier ownership with a cached selected-barrier target
- Compute the nearest barrier only when an enemy-local retarget request occurs
- Connect enemy and player castle-region transitions to explicit target refresh requests
- Preserve cached decisions between events and retain broken-barrier pass-through behavior
- Update EditMode and PlayMode targeting regressions for event-driven selection

## How to test
1. Place an enemy outside while the player is inside the castle
2. Trigger a target refresh and verify the enemy selects its nearest barrier
3. Move the enemy without a targeting event and verify its cached target remains stable
4. Trigger another relevant region or repair event and verify only that enemy recomputes its target
5. Run tests:
   - EditMode
   - PlayMode

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated (N/A - no scene changes are required)
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched (N/A - internal targeting contract only)

## Related
- Refs #262
