### PR TITLE
feat(ai): add ranged goblin engagement behavior

### DIFF
--- a/Assets/_Project/Prefabs/Enemy_Ranged.prefab
+++ b/Assets/_Project/Prefabs/Enemy_Ranged.prefab
@@ -145,6 +145,7 @@ GameObject:
   - component: {fileID: 8041287619235472017}
   - component: {fileID: 4079797737097160548}
   - component: {fileID: 7088990367442351453}
+  - component: {fileID: 9100000000000000010}
   m_Layer: 7
   m_Name: Enemy_Ranged
   m_TagString: Enemy
@@ -452,6 +453,20 @@ MonoBehaviour:
   m_EditorClassIdentifier:
   knockbackReceiver: {fileID: 0}
   rootReceiver: {fileID: 0}
+  holdMovementPolicySource: {fileID: 9100000000000000010}
+--- !u!114 &9100000000000000010
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6394411849047796180}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4fb4c3d3390e43cc8d063fb9aef53e1b, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  maxHoldSeparationSpeed: 1
 --- !u!114 &8041287619235472015
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyApproachSpread.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyApproachSpread.cs
@@ -92,4 +92,48 @@ public class EnemyApproachSpread : MonoBehaviour
         radial = rawRadial * scale;
         tangent = rawTangent * scale;
     }
+
+    public Vector2 ComputeHoldSeparation(
+        Vector2 directionToTarget,
+        Vector2 localSeparation,
+        bool hasNeighbors,
+        Vector2 stableBias,
+        float speed)
+    {
+        return ComputeHoldSeparation(
+            directionToTarget,
+            localSeparation,
+            hasNeighbors,
+            stableBias,
+            speed,
+            separationStrength,
+            maxLateralRatio);
+    }
+
+    public static Vector2 ComputeHoldSeparation(
+        Vector2 directionToTarget,
+        Vector2 localSeparation,
+        bool hasNeighbors,
+        Vector2 stableBias,
+        float speed,
+        float separationStrength,
+        float maxLateralRatio)
+    {
+        if (!hasNeighbors || directionToTarget.sqrMagnitude <= 0f)
+            return Vector2.zero;
+
+        Vector2 separation = localSeparation.sqrMagnitude > 0.0001f
+            ? localSeparation.normalized
+            : stableBias.normalized;
+        if (separation.sqrMagnitude <= 0f)
+            return Vector2.zero;
+
+        Vector2 forward = directionToTarget.normalized;
+        Vector2 lateralAxis = new Vector2(-forward.y, forward.x);
+        float lateralPreference = Mathf.Clamp(Vector2.Dot(separation, lateralAxis), -1f, 1f);
+        float lateralSpeed = Mathf.Max(0f, speed) *
+                             Mathf.Clamp01(separationStrength) *
+                             Mathf.Clamp01(maxLateralRatio);
+        return lateralAxis * (lateralPreference * lateralSpeed);
+    }
 }

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyController2D.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyController2D.cs
@@ -274,6 +274,16 @@ public class EnemyController2D : MonoBehaviour
             Locomotion.SetMovementState(State.CHASE);
         }
 
+        Locomotion.ApplyHoldMovementPolicy(
+            pos,
+            target,
+            _approachSeparation,
+            _hasApproachNeighbors,
+            _approachSpreadBias,
+            speed,
+            ref radial,
+            ref tangent);
+
         bool movementApplied = Locomotion.ExecuteMovement(_rb, radial, tangent, dt);
         animationPresenter?.SetMovementRequested(movementApplied);
     }
@@ -385,6 +395,15 @@ public class EnemyController2D : MonoBehaviour
             _gapCCW,
             out radial,
             out tangent);
+        Locomotion.ApplyHoldMovementPolicy(
+            _rb.position,
+            Targeting != null ? Targeting.AttackTarget : null,
+            _approachSeparation,
+            _hasApproachNeighbors,
+            _approachSpreadBias,
+            speed,
+            ref radial,
+            ref tangent);
     }
 #endif
 }

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyHoldMovementContext.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyHoldMovementContext.cs
@@ -1,0 +1,24 @@
+using UnityEngine;
+
+public struct EnemyHoldMovementContext
+{
+    public EnemyHoldMovementContext(
+        Vector2 directionToTarget,
+        Vector2 localSeparation,
+        bool hasNeighbors,
+        Vector2 stableBias,
+        float speed)
+    {
+        DirectionToTarget = directionToTarget;
+        LocalSeparation = localSeparation;
+        HasNeighbors = hasNeighbors;
+        StableBias = stableBias;
+        Speed = Mathf.Max(0f, speed);
+    }
+
+    public Vector2 DirectionToTarget { get; }
+    public Vector2 LocalSeparation { get; }
+    public bool HasNeighbors { get; }
+    public Vector2 StableBias { get; }
+    public float Speed { get; }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyHoldMovementContext.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyHoldMovementContext.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 60231e199e154e93bfe49e80eb134bb7

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyLocomotion.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyLocomotion.cs
@@ -5,14 +5,17 @@ public class EnemyLocomotion : MonoBehaviour
 {
     [SerializeField] private EnemyKnockbackReceiver knockbackReceiver;
     [SerializeField] private EnemyRootReceiver rootReceiver;
+    [SerializeField] private MonoBehaviour holdMovementPolicySource;
 
     private float previousDistance;
     private int distanceTrend;
     private Vector2 lastNonZeroDirection = Vector2.right;
+    private IEnemyHoldMovementPolicy holdMovementPolicy;
 
     public EnemyController2D.State CurrentState { get; private set; } = EnemyController2D.State.CHASE;
     public bool IsChaseRequested { get; private set; }
     public bool IsInHoldRange => CurrentState == EnemyController2D.State.HOLD;
+    public MonoBehaviour HoldMovementPolicySource => holdMovementPolicySource;
 
     public void RequestChase()
     {
@@ -71,6 +74,57 @@ public class EnemyLocomotion : MonoBehaviour
             out radial,
             out tangent);
         CurrentState = movementState;
+
+        if (CurrentState == EnemyController2D.State.HOLD)
+        {
+            ResolveHoldMovementPolicy()?.Apply(default, ref radial, ref tangent);
+        }
+    }
+
+    public void ApplyHoldMovementPolicy(
+        EnemyHoldMovementContext context,
+        ref Vector2 radial,
+        ref Vector2 tangent)
+    {
+        if (CurrentState != EnemyController2D.State.HOLD)
+            return;
+
+        ResolveHoldMovementPolicy()?.Apply(context, ref radial, ref tangent);
+    }
+
+    public void ApplyHoldMovementPolicy(
+        Vector2 position,
+        Transform target,
+        Vector2 localSeparation,
+        bool hasNeighbors,
+        Vector2 stableBias,
+        float speed,
+        ref Vector2 radial,
+        ref Vector2 tangent)
+    {
+        Vector2 toTarget = target != null
+            ? (Vector2)target.position - position
+            : Vector2.zero;
+        Vector2 directionToTarget = toTarget.sqrMagnitude > 0f
+            ? toTarget.normalized
+            : Vector2.zero;
+        ApplyHoldMovementPolicy(
+            new EnemyHoldMovementContext(
+                directionToTarget,
+                localSeparation,
+                hasNeighbors,
+                stableBias,
+                speed),
+            ref radial,
+            ref tangent);
+    }
+
+    private IEnemyHoldMovementPolicy ResolveHoldMovementPolicy()
+    {
+        if (holdMovementPolicy == null && holdMovementPolicySource != null)
+            holdMovementPolicy = holdMovementPolicySource as IEnemyHoldMovementPolicy;
+
+        return holdMovementPolicy;
     }
 
     public bool ExecuteMovement(Rigidbody2D body, Vector2 radial, Vector2 tangent, float deltaTime)
@@ -93,4 +147,12 @@ public class EnemyLocomotion : MonoBehaviour
         body.MovePosition(body.position + displacement);
         return displacement.sqrMagnitude > Mathf.Epsilon;
     }
+
+#if UNITY_EDITOR
+    public void Debug_SetHoldMovementPolicy(MonoBehaviour source)
+    {
+        holdMovementPolicySource = source;
+        holdMovementPolicy = source as IEnemyHoldMovementPolicy;
+    }
+#endif
 }

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyRangedEngagement.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyRangedEngagement.cs
@@ -1,0 +1,28 @@
+using UnityEngine;
+
+public class EnemyRangedEngagement : MonoBehaviour, IEnemyHoldMovementPolicy
+{
+    [SerializeField, Min(0f)] private float maxHoldSeparationSpeed = 1f;
+
+    private EnemyApproachSpread approachSpread;
+
+    public float MaxHoldSeparationSpeed => Mathf.Max(0f, maxHoldSeparationSpeed);
+
+    public void Apply(EnemyHoldMovementContext context, ref Vector2 radial, ref Vector2 tangent)
+    {
+        tangent = Vector2.zero;
+
+        if (approachSpread == null)
+            approachSpread = GetComponent<EnemyApproachSpread>();
+        if (approachSpread == null)
+            return;
+
+        Vector2 separation = approachSpread.ComputeHoldSeparation(
+            context.DirectionToTarget,
+            context.LocalSeparation,
+            context.HasNeighbors,
+            context.StableBias,
+            context.Speed);
+        tangent = Vector2.ClampMagnitude(separation, MaxHoldSeparationSpeed);
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyRangedEngagement.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyRangedEngagement.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4fb4c3d3390e43cc8d063fb9aef53e1b

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyRingManager.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyRingManager.cs
@@ -53,6 +53,7 @@ public class EnemyRingManager : MonoBehaviour
             if (eligibility == null || !eligibility.IsEligibleFor(player))
             {
                 e.SetAngularGaps(0f, 0f, 0);
+                e.SetApproachSeparation(Vector2.zero, false);
                 continue;
             }
 

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/IEnemyHoldMovementPolicy.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/IEnemyHoldMovementPolicy.cs
@@ -1,0 +1,6 @@
+using UnityEngine;
+
+public interface IEnemyHoldMovementPolicy
+{
+    void Apply(EnemyHoldMovementContext context, ref Vector2 radial, ref Vector2 tangent);
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/IEnemyHoldMovementPolicy.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/IEnemyHoldMovementPolicy.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 96d6ac37ba764f79a17c9eb50266d935

--- a/Assets/_Project/_Tests/EditMode/AI/EnemyApproachSpreadTests.cs
+++ b/Assets/_Project/_Tests/EditMode/AI/EnemyApproachSpreadTests.cs
@@ -118,5 +118,42 @@ namespace Castlebound.Tests.AI
             Assert.That(radial, Is.EqualTo(pursuit));
             Assert.That(tangent, Is.EqualTo(Vector2.zero));
         }
+
+        [Test]
+        public void CrowdedHold_UsesOnlyTangentialSeparation()
+        {
+            Vector2 tangent = EnemyApproachSpread.ComputeHoldSeparation(
+                directionToTarget: Vector2.right,
+                localSeparation: new Vector2(-1f, 1f),
+                hasNeighbors: true,
+                stableBias: Vector2.zero,
+                speed: 8f,
+                separationStrength: 0.8f,
+                maxLateralRatio: 0.35f);
+
+            Assert.That(tangent.x, Is.EqualTo(0f).Within(0.001f));
+            Assert.That(tangent.y, Is.GreaterThan(0f));
+            Assert.That(tangent.magnitude, Is.LessThanOrEqualTo(2.801f));
+        }
+
+        [Test]
+        public void UncrowdedHold_RemainsStationary()
+        {
+            Vector2 tangent = EnemyApproachSpread.ComputeHoldSeparation(
+                Vector2.right, Vector2.up, hasNeighbors: false, stableBias: Vector2.down,
+                speed: 8f, separationStrength: 0.8f, maxLateralRatio: 0.35f);
+
+            Assert.That(tangent, Is.EqualTo(Vector2.zero));
+        }
+
+        [Test]
+        public void CoincidentHoldNeighbors_UseStableTangentialBias()
+        {
+            Vector2 tangent = EnemyApproachSpread.ComputeHoldSeparation(
+                Vector2.right, Vector2.zero, hasNeighbors: true, stableBias: Vector2.down,
+                speed: 8f, separationStrength: 0.8f, maxLateralRatio: 0.35f);
+
+            Assert.That(tangent.y, Is.LessThan(0f));
+        }
     }
 }

--- a/Assets/_Project/_Tests/EditMode/AI/EnemyEngagementTests.cs
+++ b/Assets/_Project/_Tests/EditMode/AI/EnemyEngagementTests.cs
@@ -113,6 +113,7 @@ namespace Castlebound.Tests.AI
         }
 
         [TestCase(false, 0.5f, 0.5f, 0.25f, true)]
+        [TestCase(false, 0f, 5f, 0.25f, true)]
         [TestCase(false, 0.51f, 0.5f, 0.25f, false)]
         [TestCase(true, 0.74f, 0.5f, 0.25f, true)]
         [TestCase(true, 0.75f, 0.5f, 0.25f, false)]

--- a/Assets/_Project/_Tests/EditMode/AI/EnemyLocomotionTests.cs
+++ b/Assets/_Project/_Tests/EditMode/AI/EnemyLocomotionTests.cs
@@ -72,6 +72,168 @@ public class EnemyLocomotionTests
     }
 
     [Test]
+    public void ComputeBaseMovement_RangedPolicyStopsOrbitWhileHolding()
+    {
+        GameObject enemy = new GameObject("RangedEnemy");
+        GameObject player = new GameObject("Player");
+        player.transform.position = new Vector2(0.5f, 0f);
+
+        try
+        {
+            EnemyLocomotion locomotion = enemy.AddComponent<EnemyLocomotion>();
+            EnemyRangedEngagement rangedEngagement = enemy.AddComponent<EnemyRangedEngagement>();
+            locomotion.Debug_SetHoldMovementPolicy(rangedEngagement);
+
+            locomotion.ComputeBaseMovement(
+                Vector2.zero, player.transform, null,
+                0.5f, 5f, 0.25f, 0.3f, 8f, 2.8f, 2f, 8, 0.01f,
+                0.2f, 1f, out Vector2 radial, out Vector2 tangent);
+
+            Assert.AreEqual(EnemyController2D.State.HOLD, locomotion.CurrentState);
+            Assert.AreEqual(Vector2.zero, radial);
+            Assert.AreEqual(Vector2.zero, tangent);
+        }
+        finally
+        {
+            Object.DestroyImmediate(enemy);
+            Object.DestroyImmediate(player);
+        }
+    }
+
+    [Test]
+    public void ComputeBaseMovement_RangedPolicyApproachesOutsideMaximumDistance()
+    {
+        GameObject enemy = new GameObject("RangedEnemy");
+        GameObject player = new GameObject("Player");
+        player.transform.position = new Vector2(10f, 0f);
+
+        try
+        {
+            EnemyLocomotion locomotion = enemy.AddComponent<EnemyLocomotion>();
+            EnemyRangedEngagement rangedEngagement = enemy.AddComponent<EnemyRangedEngagement>();
+            locomotion.Debug_SetHoldMovementPolicy(rangedEngagement);
+
+            locomotion.ComputeBaseMovement(
+                Vector2.zero, player.transform, null,
+                10f, 5f, 0.25f, 0.3f, 8f, 2.8f, 2f, 8, 0.01f,
+                0.2f, 1f, out Vector2 radial, out Vector2 tangent);
+            locomotion.ApplyHoldMovementPolicy(
+                new EnemyHoldMovementContext(
+                    Vector2.right,
+                    Vector2.up,
+                    hasNeighbors: true,
+                    stableBias: Vector2.down,
+                    speed: 8f),
+                ref radial,
+                ref tangent);
+
+            Assert.AreEqual(EnemyController2D.State.CHASE, locomotion.CurrentState);
+            Assert.That(radial.x, Is.GreaterThan(0f));
+            Assert.AreEqual(0f, radial.y);
+            Assert.AreEqual(Vector2.zero, tangent);
+        }
+        finally
+        {
+            Object.DestroyImmediate(enemy);
+            Object.DestroyImmediate(player);
+        }
+    }
+
+    [Test]
+    public void ComputeBaseMovement_RangedPolicyReseatsInsideReleaseMargin()
+    {
+        GameObject enemy = new GameObject("RangedEnemy");
+        GameObject player = new GameObject("Player");
+        player.transform.position = new Vector2(5.1f, 0f);
+
+        try
+        {
+            EnemyLocomotion locomotion = enemy.AddComponent<EnemyLocomotion>();
+            EnemyRangedEngagement rangedEngagement = enemy.AddComponent<EnemyRangedEngagement>();
+            locomotion.Debug_SetHoldMovementPolicy(rangedEngagement);
+            locomotion.SetMovementState(EnemyController2D.State.HOLD);
+
+            locomotion.ComputeBaseMovement(
+                Vector2.zero, player.transform, null,
+                5.1f, 5f, 0.25f, 0.3f, 8f, 2.8f, 2f, 8, 0.01f,
+                0.2f, 1f, out Vector2 radial, out Vector2 tangent);
+
+            Assert.AreEqual(EnemyController2D.State.HOLD, locomotion.CurrentState);
+            Assert.That(radial.x, Is.GreaterThan(0f));
+            Assert.AreEqual(0f, radial.y);
+            Assert.AreEqual(Vector2.zero, tangent);
+        }
+        finally
+        {
+            Object.DestroyImmediate(enemy);
+            Object.DestroyImmediate(player);
+        }
+    }
+
+    [Test]
+    public void ApplyHoldMovementPolicy_CrowdedRangedEnemySpreadsWithoutRetreating()
+    {
+        GameObject enemy = new GameObject("RangedEnemy");
+
+        try
+        {
+            EnemyLocomotion locomotion = enemy.AddComponent<EnemyLocomotion>();
+            enemy.AddComponent<EnemyApproachSpread>();
+            EnemyRangedEngagement rangedEngagement = enemy.AddComponent<EnemyRangedEngagement>();
+            locomotion.Debug_SetHoldMovementPolicy(rangedEngagement);
+            locomotion.SetMovementState(EnemyController2D.State.HOLD);
+            Vector2 radial = Vector2.zero;
+            Vector2 tangent = Vector2.zero;
+
+            locomotion.ApplyHoldMovementPolicy(
+                new EnemyHoldMovementContext(
+                    Vector2.right,
+                    Vector2.up,
+                    hasNeighbors: true,
+                    stableBias: Vector2.down,
+                    speed: 8f),
+                ref radial,
+                ref tangent);
+
+            Assert.AreEqual(Vector2.zero, radial);
+            Assert.That(tangent.x, Is.EqualTo(0f).Within(0.001f));
+            Assert.That(tangent.y, Is.GreaterThan(0f));
+            Assert.That(tangent.magnitude, Is.LessThanOrEqualTo(1.001f));
+        }
+        finally
+        {
+            Object.DestroyImmediate(enemy);
+        }
+    }
+
+    [Test]
+    public void ComputeBaseMovement_DefaultMeleePolicyPreservesHoldOrbit()
+    {
+        GameObject enemy = new GameObject("MeleeEnemy");
+        GameObject player = new GameObject("Player");
+        player.transform.position = new Vector2(0.5f, 0f);
+
+        try
+        {
+            EnemyLocomotion locomotion = enemy.AddComponent<EnemyLocomotion>();
+
+            locomotion.ComputeBaseMovement(
+                Vector2.zero, player.transform, null,
+                0.5f, 1f, 0.25f, 0.3f, 3f, 0.8f, 2.5f, 8, 0.01f,
+                0.2f, 1f, out Vector2 radial, out Vector2 tangent);
+
+            Assert.AreEqual(EnemyController2D.State.HOLD, locomotion.CurrentState);
+            Assert.AreEqual(Vector2.zero, radial);
+            Assert.That(tangent.sqrMagnitude, Is.GreaterThan(0f));
+        }
+        finally
+        {
+            Object.DestroyImmediate(enemy);
+            Object.DestroyImmediate(player);
+        }
+    }
+
+    [Test]
     public void ExecuteMovement_DoesNotMoveRootedEnemy()
     {
         GameObject enemy = new GameObject("Enemy");

--- a/Assets/_Project/_Tests/EditMode/AI/EnemyRangedPrefabContractTests.cs
+++ b/Assets/_Project/_Tests/EditMode/AI/EnemyRangedPrefabContractTests.cs
@@ -24,8 +24,17 @@ namespace Castlebound.Tests.AI
             Assert.That(meleePrefab.GetComponent<EnemyEquipment>().SpawnEquipment.EquipmentId, Is.EqualTo("unarmed"));
 
             var rangedDelivery = rangedPrefab.GetComponent<EnemyProjectileAttackDelivery>();
+            var rangedEngagement = rangedPrefab.GetComponent<EnemyRangedEngagement>();
+            var rangedLocomotion = rangedPrefab.GetComponent<EnemyLocomotion>();
             var rangedEquipment = rangedPrefab.GetComponent<EnemyEquipment>().SpawnEquipment;
             Assert.NotNull(rangedDelivery);
+            Assert.NotNull(rangedEngagement);
+            Assert.NotNull(rangedPrefab.GetComponent<EnemySurroundEligibility>());
+            Assert.NotNull(rangedPrefab.GetComponent<EnemyApproachSpread>());
+            Assert.That(rangedEngagement.MaxHoldSeparationSpeed, Is.EqualTo(1f).Within(0.001f));
+            Assert.That(rangedLocomotion.HoldMovementPolicySource, Is.EqualTo(rangedEngagement));
+            Assert.Null(meleePrefab.GetComponent<EnemyRangedEngagement>());
+            Assert.Null(meleePrefab.GetComponent<EnemyLocomotion>().HoldMovementPolicySource);
             Assert.IsInstanceOf<EnemyProjectileAttackDelivery>(rangedPrefab.GetComponent<EnemyAttack>().AttackDeliverySource);
             Assert.That(rangedEquipment.EquipmentId, Is.EqualTo("rock"));
             Assert.That(rangedEquipment.CompatibleRole, Is.EqualTo(EnemyAttackRole.Ranged));

--- a/Assets/_Project/_Tests/EditMode/AI/EnemyRingEligibilityTests.cs
+++ b/Assets/_Project/_Tests/EditMode/AI/EnemyRingEligibilityTests.cs
@@ -24,7 +24,9 @@ namespace Castlebound.Tests.AI
                 created[2] = CreateEnemy("Rooted", player.transform, PolarPosition(100f, 15f));
 
                 created[2].GetComponent<EnemyRootReceiver>().RootForSeconds(10f);
-                created[2].GetComponent<EnemyController2D>().SetAngularGaps(1f, 1f);
+                var rootedController = created[2].GetComponent<EnemyController2D>();
+                rootedController.SetAngularGaps(1f, 1f);
+                rootedController.SetApproachSeparation(Vector2.up, true);
 
                 InvokeRefresh(manager);
 
@@ -36,6 +38,10 @@ namespace Castlebound.Tests.AI
                 Assert.That(rootedCw, Is.Zero);
                 Assert.That(rootedCcw, Is.Zero,
                     "An enemy leaving eligibility must not retain stale ring influence.");
+                GetApproachSeparation(rootedController, out Vector2 separation, out bool hasNeighbors);
+                Assert.That(separation, Is.EqualTo(Vector2.zero));
+                Assert.IsFalse(hasNeighbors,
+                    "An enemy leaving eligibility must not retain stale neighbor separation.");
             }
             finally
             {
@@ -160,6 +166,18 @@ namespace Castlebound.Tests.AI
             const BindingFlags flags = BindingFlags.Instance | BindingFlags.NonPublic;
             gapCw = (float)typeof(EnemyController2D).GetField("_gapCW", flags).GetValue(controller);
             gapCcw = (float)typeof(EnemyController2D).GetField("_gapCCW", flags).GetValue(controller);
+        }
+
+        private static void GetApproachSeparation(
+            EnemyController2D controller,
+            out Vector2 separation,
+            out bool hasNeighbors)
+        {
+            const BindingFlags flags = BindingFlags.Instance | BindingFlags.NonPublic;
+            separation = (Vector2)typeof(EnemyController2D)
+                .GetField("_approachSeparation", flags).GetValue(controller);
+            hasNeighbors = (bool)typeof(EnemyController2D)
+                .GetField("_hasApproachNeighbors", flags).GetValue(controller);
         }
 
         private static void DestroyEnemy(GameObject enemy)

--- a/Assets/_Project/_Tests/PlayMode/Combat/EnemyRangedAttackPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/Combat/EnemyRangedAttackPlayTests.cs
@@ -45,5 +45,84 @@ namespace Castlebound.Tests.PlayMode.Combat
                 Object.Destroy(enemy);
             }
         }
+
+        [UnityTest]
+        public IEnumerator SpawnedRangedEnemy_HoldsPositionInsideMaximumAttackDistance()
+        {
+            var prefab = AssetDatabase.LoadAssetAtPath<GameObject>("Assets/_Project/Prefabs/Enemy_Ranged.prefab");
+            var enemy = Object.Instantiate(prefab);
+            var target = new GameObject("CloseTarget");
+
+            try
+            {
+                enemy.GetComponent<EnemyController2D>().enabled = false;
+                target.transform.position = enemy.transform.position + Vector3.right * 2f;
+                yield return null;
+
+                var locomotion = enemy.GetComponent<EnemyLocomotion>();
+                var engagement = enemy.GetComponent<EnemyEngagement>();
+                locomotion.ComputeBaseMovement(
+                    (Vector2)enemy.transform.position,
+                    target.transform,
+                    null,
+                    2f,
+                    engagement.EngagementDistance,
+                    engagement.ReleaseMargin,
+                    1f,
+                    8f,
+                    2.8f,
+                    2f,
+                    8,
+                    0.01f,
+                    0.2f,
+                    1f,
+                    out Vector2 radial,
+                    out Vector2 tangent);
+
+                Assert.That(locomotion.CurrentState, Is.EqualTo(EnemyController2D.State.HOLD));
+                Assert.That(radial, Is.EqualTo(Vector2.zero));
+                Assert.That(tangent, Is.EqualTo(Vector2.zero));
+            }
+            finally
+            {
+                Object.Destroy(target);
+                Object.Destroy(enemy);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator SpawnedRangedEnemy_UsesNeighborSeparationWithoutRetreating()
+        {
+            var prefab = AssetDatabase.LoadAssetAtPath<GameObject>("Assets/_Project/Prefabs/Enemy_Ranged.prefab");
+            var enemy = Object.Instantiate(prefab);
+
+            try
+            {
+                enemy.GetComponent<EnemyController2D>().enabled = false;
+                yield return null;
+
+                var locomotion = enemy.GetComponent<EnemyLocomotion>();
+                locomotion.SetMovementState(EnemyController2D.State.HOLD);
+                Vector2 radial = Vector2.zero;
+                Vector2 tangent = Vector2.zero;
+                locomotion.ApplyHoldMovementPolicy(
+                    new EnemyHoldMovementContext(
+                        Vector2.right,
+                        Vector2.up,
+                        hasNeighbors: true,
+                        stableBias: Vector2.down,
+                        speed: 8f),
+                    ref radial,
+                    ref tangent);
+
+                Assert.That(radial, Is.EqualTo(Vector2.zero));
+                Assert.That(tangent.x, Is.EqualTo(0f).Within(0.001f));
+                Assert.That(tangent.y, Is.GreaterThan(0f));
+            }
+            finally
+            {
+                Object.Destroy(enemy);
+            }
+        }
     }
 }

--- a/TEST_LOG.md
+++ b/TEST_LOG.md
@@ -1,3 +1,21 @@
+## 2026-08-02 - feat-ai-ranged-engagement
+
+### Summary
+- Added maximum-only ranged engagement movement: ranged goblins approach from outside attack distance and remain stationary anywhere inside it.
+- Added an optional hold-movement policy contract so melee enemies retain their existing surround orbit without duplicating range ownership.
+- Assigned the stationary hold policy only to the ranged goblin prefab, preventing lateral orbit movement while preserving inward recovery at the range boundary.
+- Reused the existing player-ring neighbor feed for speed-limited tangential ranged spacing while clearing stale separation when enemies leave player-targeting eligibility.
+
+### New or Updated Tests
+**EditMode**
+- EnemyApproachSpreadTests, EnemyEngagementTests, EnemyLocomotionTests, EnemyRingEligibilityTests, and EnemyRangedPrefabContractTests — close-range eligibility, tangential hold spacing, stale-state cleanup, policy wiring, and melee orbit regression coverage.
+
+**PlayMode**
+- EnemyRangedAttackPlayTests — spawned ranged goblin stationary hold and neighbor separation behavior inside maximum attack distance.
+
+### Notes
+- EditMode and PlayMode suites pass per user validation, including the ranged spacing follow-up.
+
 ## 2026-08-01 - feat-enemies-ranged-goblin-rock-throw
 
 ### Summary


### PR DESCRIPTION
## Why
Ranged goblins need stable, readable positioning without enforcing a minimum distance, backing into walls, or collapsing into stationary clusters.

## What changed
- Added maximum-only ranged engagement that approaches from outside range and accepts every closer attack distance
- Added a composable hold-movement policy that preserves melee orbit behavior
- Reused existing neighbor separation for gentle, speed-limited tangential ranged spacing
- Cleared stale separation when enemies leave player-targeting eligibility
- Added EditMode, PlayMode, prefab-contract, and melee regression coverage

## How to test
1. Open MainPrototype and spawn isolated and clustered ranged goblins
2. Press Play → verify they approach from outside range, attack at any closer distance without retreating, and gently separate when crowded
3. Run tests:
   - EditMode
   - PlayMode

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated (N/A - temporary validation scene changes were reverted)
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched (N/A - behavior is covered by tests and TEST_LOG.md)

## Related
- Closes #234