### PR TITLE
feat(spawning): add seeded enemy equipment loadouts

### DIFF
--- a/Assets/_Project/Scripts/_Project.Gameplay/Spawning/EnemyEquipmentLoadoutEntry.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Spawning/EnemyEquipmentLoadoutEntry.cs
@@ -1,0 +1,47 @@
+using Castlebound.Gameplay.AI;
+using UnityEngine;
+
+namespace Castlebound.Gameplay.Spawning
+{
+    [System.Serializable]
+    public struct EnemyEquipmentLoadoutEntry
+    {
+        [SerializeField] private EnemyEquipmentDefinition equipment;
+        [SerializeField, Min(1)] private int startWave;
+        [SerializeField, Min(0f)] private float startWeight;
+        [SerializeField, Min(1)] private int endWave;
+        [SerializeField, Min(0f)] private float endWeight;
+
+        public EnemyEquipmentLoadoutEntry(
+            EnemyEquipmentDefinition equipment,
+            int startWave,
+            float startWeight,
+            int endWave,
+            float endWeight)
+        {
+            this.equipment = equipment;
+            this.startWave = Mathf.Max(1, startWave);
+            this.startWeight = Mathf.Max(0f, startWeight);
+            this.endWave = Mathf.Max(this.startWave, endWave);
+            this.endWeight = Mathf.Max(0f, endWeight);
+        }
+
+        public EnemyEquipmentDefinition Equipment => equipment;
+
+        public float GetWeight(int waveIndex)
+        {
+            int safeStartWave = Mathf.Max(1, startWave);
+            int safeEndWave = Mathf.Max(safeStartWave, endWave);
+            float safeStartWeight = Mathf.Max(0f, startWeight);
+            float safeEndWeight = Mathf.Max(0f, endWeight);
+
+            if (safeEndWave == safeStartWave)
+            {
+                return waveIndex < safeStartWave ? safeStartWeight : safeEndWeight;
+            }
+
+            float progress = Mathf.InverseLerp(safeStartWave, safeEndWave, waveIndex);
+            return Mathf.Lerp(safeStartWeight, safeEndWeight, progress);
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Spawning/EnemyEquipmentLoadoutEntry.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Spawning/EnemyEquipmentLoadoutEntry.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3e85f63420e5474cb0d14371d40503b3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/_Project.Gameplay/Spawning/EnemyEquipmentLoadoutSeed.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Spawning/EnemyEquipmentLoadoutSeed.cs
@@ -1,0 +1,17 @@
+namespace Castlebound.Gameplay.Spawning
+{
+    public static class EnemyEquipmentLoadoutSeed
+    {
+        public static int Combine(int scheduleSeed, int waveIndex, int sequenceIndex)
+        {
+            unchecked
+            {
+                int seed = 17;
+                seed = seed * 31 + scheduleSeed;
+                seed = seed * 31 + waveIndex;
+                seed = seed * 31 + sequenceIndex;
+                return seed;
+            }
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Spawning/EnemyEquipmentLoadoutSeed.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Spawning/EnemyEquipmentLoadoutSeed.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a0c92a9a33b34159a248f99c5b598acd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/_Project.Gameplay/Spawning/EnemyEquipmentLoadoutTable.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Spawning/EnemyEquipmentLoadoutTable.cs
@@ -1,0 +1,95 @@
+using Castlebound.Gameplay.AI;
+using UnityEngine;
+using Random = System.Random;
+
+namespace Castlebound.Gameplay.Spawning
+{
+    [CreateAssetMenu(fileName = "EnemyEquipmentLoadout", menuName = "Spawning/Enemy Equipment Loadout")]
+    public class EnemyEquipmentLoadoutTable : ScriptableObject
+    {
+        [SerializeField] private EnemyEquipmentLoadoutEntry[] entries = System.Array.Empty<EnemyEquipmentLoadoutEntry>();
+
+        public EnemyEquipmentLoadoutEntry[] Entries
+        {
+            get => entries;
+            set => entries = value ?? System.Array.Empty<EnemyEquipmentLoadoutEntry>();
+        }
+
+        public EnemyEquipmentDefinition Select(Random random, int waveIndex)
+        {
+            if (random == null || entries == null || entries.Length == 0)
+            {
+                return null;
+            }
+
+            float totalWeight = GetTotalWeight(waveIndex);
+            if (totalWeight <= 0f)
+            {
+                return null;
+            }
+
+            double roll = random.NextDouble() * totalWeight;
+            for (int i = 0; i < entries.Length; i++)
+            {
+                if (entries[i].Equipment == null)
+                {
+                    continue;
+                }
+
+                float weight = entries[i].GetWeight(waveIndex);
+                if (weight <= 0f)
+                {
+                    continue;
+                }
+
+                if (roll < weight)
+                {
+                    return entries[i].Equipment;
+                }
+
+                roll -= weight;
+            }
+
+            return null;
+        }
+
+        public float GetSelectionChance(EnemyEquipmentDefinition equipment, int waveIndex)
+        {
+            if (equipment == null || entries == null)
+            {
+                return 0f;
+            }
+
+            float totalWeight = GetTotalWeight(waveIndex);
+            if (totalWeight <= 0f)
+            {
+                return 0f;
+            }
+
+            float equipmentWeight = 0f;
+            for (int i = 0; i < entries.Length; i++)
+            {
+                if (entries[i].Equipment == equipment)
+                {
+                    equipmentWeight += Mathf.Max(0f, entries[i].GetWeight(waveIndex));
+                }
+            }
+
+            return equipmentWeight / totalWeight;
+        }
+
+        private float GetTotalWeight(int waveIndex)
+        {
+            float totalWeight = 0f;
+            for (int i = 0; i < entries.Length; i++)
+            {
+                if (entries[i].Equipment != null)
+                {
+                    totalWeight += Mathf.Max(0f, entries[i].GetWeight(waveIndex));
+                }
+            }
+
+            return totalWeight;
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Spawning/EnemyEquipmentLoadoutTable.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Spawning/EnemyEquipmentLoadoutTable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c1e172ddccdb4108901cb5ba2fdc8ccc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/_Project.Gameplay/Spawning/EnemySpawnerRunner.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Spawning/EnemySpawnerRunner.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Castlebound.Gameplay.AI;
 using Castlebound.Gameplay.Balance;
 using UnityEngine;
 using Castlebound.Gameplay.Stats;
@@ -169,6 +170,8 @@ namespace Castlebound.Gameplay.Spawning
                 var instance = Instantiate(prefab, request.Position, Quaternion.identity);
                 _aliveCount++;
 
+                ApplyRequestedEquipment(instance, request);
+
                 var facing = instance.GetComponent<EnemyFacing>();
                 if (facing != null && request.ForwardDirection.sqrMagnitude > Mathf.Epsilon)
                 {
@@ -192,6 +195,36 @@ namespace Castlebound.Gameplay.Spawning
                     _aliveCount = Mathf.Max(0, _aliveCount - 1);
                 });
             }
+        }
+
+        private static void ApplyRequestedEquipment(GameObject instance, SpawnRequest request)
+        {
+            if (request.Equipment == null)
+            {
+                return;
+            }
+
+            var equipment = instance.GetComponent<EnemyEquipment>();
+            var attack = instance.GetComponent<EnemyAttack>();
+            var delivery = attack != null ? attack.AttackDeliverySource as IEnemyAttackDelivery : null;
+
+            if (equipment == null || delivery == null)
+            {
+                Debug.LogError(
+                    $"EnemySpawnerRunner: enemy type '{request.EnemyTypeId}' cannot receive equipment " +
+                    $"'{request.Equipment.EquipmentId}'; keeping prefab default.");
+                return;
+            }
+
+            if (!request.Equipment.IsCompatibleWith(delivery.AttackRole))
+            {
+                Debug.LogError(
+                    $"EnemySpawnerRunner: equipment '{request.Equipment.EquipmentId}' is incompatible with " +
+                    $"{delivery.AttackRole} enemy type '{request.EnemyTypeId}'; keeping prefab default.");
+                return;
+            }
+
+            equipment.Equip(request.Equipment);
         }
     }
 }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Spawning/EnemyWaveSpawner.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Spawning/EnemyWaveSpawner.cs
@@ -108,13 +108,23 @@ namespace Castlebound.Gameplay.Spawning
 
             var requests = new List<SpawnRequest>();
 
-            foreach (var seq in _currentWave.Sequences)
+            for (int sequenceIndex = 0; sequenceIndex < _currentWave.Sequences.Count; sequenceIndex++)
             {
+                var seq = _currentWave.Sequences[sequenceIndex];
                 var gateOrder = SpawnMarkerOrderBuilder.BuildGateOrder(_spawnPoints, seq.spawnCount, _currentWave.Strategy, _currentWave.Seed);
                 var startsAt = requests.Count;
+                var loadoutRandom = seq.equipmentLoadout != null
+                    ? new System.Random(EnemyEquipmentLoadoutSeed.Combine(
+                        _currentWave.Seed,
+                        waveIndex,
+                        sequenceIndex))
+                    : null;
                 foreach (var gate in gateOrder)
                 {
-                    requests.Add(new SpawnRequest(seq.enemyTypeId, gate));
+                    var equipment = seq.equipmentLoadout != null
+                        ? seq.equipmentLoadout.Select(loadoutRandom, waveIndex)
+                        : null;
+                    requests.Add(new SpawnRequest(seq.enemyTypeId, gate, equipment));
                 }
 
                 _sequenceTimers.Add(new SequenceTimer

--- a/Assets/_Project/Scripts/_Project.Gameplay/Spawning/RampTier.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Spawning/RampTier.cs
@@ -16,5 +16,8 @@ namespace Castlebound.Gameplay.Spawning
 
         [Tooltip("Apply countPerStep every N waves after this tier unlocks.")]
         public int stepSize;
+
+        [Tooltip("Optional seeded equipment distribution for enemies emitted by this tier.")]
+        public EnemyEquipmentLoadoutTable equipmentLoadout;
     }
 }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Spawning/SpawnRequest.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Spawning/SpawnRequest.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using Castlebound.Gameplay.AI;
 
 namespace Castlebound.Gameplay.Spawning
 {
@@ -9,24 +10,43 @@ namespace Castlebound.Gameplay.Spawning
         public string LaneId { get; }
         public Vector2 Position { get; }
         public Vector2 ForwardDirection { get; }
+        public EnemyEquipmentDefinition Equipment { get; }
 
         public SpawnRequest(string enemyTypeId, string gateId, Vector2 position)
-            : this(enemyTypeId, gateId, "Default", position, Vector2.down)
+            : this(enemyTypeId, gateId, "Default", position, Vector2.down, null)
         {
         }
 
-        public SpawnRequest(string enemyTypeId, SpawnPoint spawnPoint)
-            : this(enemyTypeId, spawnPoint.GateId, spawnPoint.LaneId, spawnPoint.Position, spawnPoint.ForwardDirection)
+        public SpawnRequest(string enemyTypeId, SpawnPoint spawnPoint, EnemyEquipmentDefinition equipment = null)
+            : this(
+                enemyTypeId,
+                spawnPoint.GateId,
+                spawnPoint.LaneId,
+                spawnPoint.Position,
+                spawnPoint.ForwardDirection,
+                equipment)
         {
         }
 
         public SpawnRequest(string enemyTypeId, string gateId, string laneId, Vector2 position, Vector2 forwardDirection)
+            : this(enemyTypeId, gateId, laneId, position, forwardDirection, null)
+        {
+        }
+
+        public SpawnRequest(
+            string enemyTypeId,
+            string gateId,
+            string laneId,
+            Vector2 position,
+            Vector2 forwardDirection,
+            EnemyEquipmentDefinition equipment)
         {
             EnemyTypeId = EnemyArchetypeIds.Canonicalize(enemyTypeId);
             GateId = gateId;
             LaneId = laneId;
             Position = position;
             ForwardDirection = forwardDirection;
+            Equipment = equipment;
         }
     }
 }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Spawning/SpawnSequenceConfig.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Spawning/SpawnSequenceConfig.cs
@@ -7,5 +7,6 @@ namespace Castlebound.Gameplay.Spawning
         public int spawnCount;
         public float intervalSeconds;
         public float initialDelaySeconds;
+        public EnemyEquipmentLoadoutTable equipmentLoadout;
     }
 }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Spawning/WaveScheduleRuntime.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Spawning/WaveScheduleRuntime.cs
@@ -301,7 +301,8 @@ namespace Castlebound.Gameplay.Spawning
                     enemyTypeId = pool[i].Tier.enemyTypeId,
                     spawnCount = count,
                     intervalSeconds = _generationBuild != null ? _generationBuild.IntervalSeconds : 1f,
-                    initialDelaySeconds = _generationBuild != null ? _generationBuild.InitialDelaySeconds : 0f
+                    initialDelaySeconds = _generationBuild != null ? _generationBuild.InitialDelaySeconds : 0f,
+                    equipmentLoadout = pool[i].Tier.equipmentLoadout
                 });
             }
 

--- a/Assets/_Project/Spawning/BasicSpawnSchedule.asset
+++ b/Assets/_Project/Spawning/BasicSpawnSchedule.asset
@@ -21,6 +21,7 @@ MonoBehaviour:
       spawnCount: 5
       intervalSeconds: 1
       initialDelaySeconds: 0.5
+      equipmentLoadout: {fileID: 11400000, guid: d24a0a3038dd4c91b76364bc00412471, type: 2}
     useStrategyOverride: 0
     strategyOverride: 0
     useSeedOverride: 0
@@ -33,10 +34,12 @@ MonoBehaviour:
       spawnCount: 6
       intervalSeconds: 0.5
       initialDelaySeconds: 0
+      equipmentLoadout: {fileID: 11400000, guid: d24a0a3038dd4c91b76364bc00412471, type: 2}
     - enemyTypeId: goblin_ranged
       spawnCount: 2
       intervalSeconds: 0.5
       initialDelaySeconds: 0
+      equipmentLoadout: {fileID: 11400000, guid: a402cb2b12cc4926a1ef9392a33dc48b, type: 2}
     useStrategyOverride: 0
     strategyOverride: 0
     useSeedOverride: 0
@@ -57,6 +60,7 @@ MonoBehaviour:
         baseSpawnCount: 0
         countPerStep: 0
         stepSize: 0
+        equipmentLoadout: {fileID: 11400000, guid: d24a0a3038dd4c91b76364bc00412471, type: 2}
     - waveIndex: 2
       tiers:
       - enemyTypeId: goblin_ranged
@@ -64,6 +68,7 @@ MonoBehaviour:
         baseSpawnCount: 2
         countPerStep: 1
         stepSize: 2
+        equipmentLoadout: {fileID: 11400000, guid: a402cb2b12cc4926a1ef9392a33dc48b, type: 2}
     - waveIndex: 3
       tiers:
       - enemyTypeId: lurker
@@ -71,6 +76,7 @@ MonoBehaviour:
         baseSpawnCount: 1
         countPerStep: 1
         stepSize: 2
+        equipmentLoadout: {fileID: 0}
   sequences:
   - enemyTypeId: 
     spawnCount: 0

--- a/Assets/_Project/Spawning/Loadouts.meta
+++ b/Assets/_Project/Spawning/Loadouts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2504e3a2abb1442085d899e2ae4b58b0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Spawning/Loadouts/GoblinMeleeEquipmentLoadout.asset
+++ b/Assets/_Project/Spawning/Loadouts/GoblinMeleeEquipmentLoadout.asset
@@ -1,0 +1,25 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c1e172ddccdb4108901cb5ba2fdc8ccc, type: 3}
+  m_Name: GoblinMeleeEquipmentLoadout
+  m_EditorClassIdentifier:
+  entries:
+  - equipment: {fileID: 11400000, guid: 9f044d61a53b44d7aa0dfb050f92ec93, type: 2}
+    startWave: 1
+    startWeight: 80
+    endWave: 10
+    endWeight: 0
+  - equipment: {fileID: 11400000, guid: 0b6d55c5c6c1488f8a64daf3e5f28b03, type: 2}
+    startWave: 1
+    startWeight: 20
+    endWave: 10
+    endWeight: 100

--- a/Assets/_Project/Spawning/Loadouts/GoblinMeleeEquipmentLoadout.asset.meta
+++ b/Assets/_Project/Spawning/Loadouts/GoblinMeleeEquipmentLoadout.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d24a0a3038dd4c91b76364bc00412471
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Spawning/Loadouts/GoblinRangedEquipmentLoadout.asset
+++ b/Assets/_Project/Spawning/Loadouts/GoblinRangedEquipmentLoadout.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c1e172ddccdb4108901cb5ba2fdc8ccc, type: 3}
+  m_Name: GoblinRangedEquipmentLoadout
+  m_EditorClassIdentifier:
+  entries:
+  - equipment: {fileID: 11400000, guid: b37cd143d2164fd4bb578d12f8e0351d, type: 2}
+    startWave: 1
+    startWeight: 100
+    endWave: 1
+    endWeight: 100

--- a/Assets/_Project/Spawning/Loadouts/GoblinRangedEquipmentLoadout.asset.meta
+++ b/Assets/_Project/Spawning/Loadouts/GoblinRangedEquipmentLoadout.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a402cb2b12cc4926a1ef9392a33dc48b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/_Tests/EditMode/Spawning/EnemyEquipmentLoadoutTableTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Spawning/EnemyEquipmentLoadoutTableTests.cs
@@ -1,0 +1,85 @@
+using Castlebound.Gameplay.AI;
+using Castlebound.Gameplay.Spawning;
+using NUnit.Framework;
+using UnityEngine;
+using Random = System.Random;
+
+namespace Castlebound.Tests.Spawning
+{
+    public class EnemyEquipmentLoadoutTableTests
+    {
+        [Test]
+        public void ClubChance_RampsLinearlyFromTwentyPercentToCertainByWaveTen()
+        {
+            var unarmed = ScriptableObject.CreateInstance<EnemyEquipmentDefinition>();
+            var club = ScriptableObject.CreateInstance<EnemyEquipmentDefinition>();
+            var table = ScriptableObject.CreateInstance<EnemyEquipmentLoadoutTable>();
+
+            try
+            {
+                table.Entries = new[]
+                {
+                    new EnemyEquipmentLoadoutEntry(unarmed, 1, 80f, 10, 0f),
+                    new EnemyEquipmentLoadoutEntry(club, 1, 20f, 10, 100f)
+                };
+
+                Assert.That(table.GetSelectionChance(club, 1), Is.EqualTo(0.2f).Within(0.0001f));
+                Assert.That(table.GetSelectionChance(club, 5), Is.EqualTo(5f / 9f).Within(0.0001f));
+                Assert.That(table.GetSelectionChance(club, 10), Is.EqualTo(1f).Within(0.0001f));
+                Assert.That(table.GetSelectionChance(club, 20), Is.EqualTo(1f).Within(0.0001f));
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(table);
+                UnityEngine.Object.DestroyImmediate(club);
+                UnityEngine.Object.DestroyImmediate(unarmed);
+            }
+        }
+
+        [Test]
+        public void Select_SameSeedAndWave_ReplaysSameEquipmentOrder()
+        {
+            var unarmed = ScriptableObject.CreateInstance<EnemyEquipmentDefinition>();
+            var club = ScriptableObject.CreateInstance<EnemyEquipmentDefinition>();
+            var table = ScriptableObject.CreateInstance<EnemyEquipmentLoadoutTable>();
+
+            try
+            {
+                table.Entries = new[]
+                {
+                    new EnemyEquipmentLoadoutEntry(unarmed, 1, 80f, 10, 0f),
+                    new EnemyEquipmentLoadoutEntry(club, 1, 20f, 10, 100f)
+                };
+                var firstRandom = new Random(236);
+                var replayRandom = new Random(236);
+
+                for (int i = 0; i < 20; i++)
+                {
+                    Assert.That(table.Select(firstRandom, 4), Is.SameAs(table.Select(replayRandom, 4)));
+                }
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(table);
+                UnityEngine.Object.DestroyImmediate(club);
+                UnityEngine.Object.DestroyImmediate(unarmed);
+            }
+        }
+
+        [Test]
+        public void Select_NoPositiveValidWeight_ReturnsNoOverride()
+        {
+            var table = ScriptableObject.CreateInstance<EnemyEquipmentLoadoutTable>();
+            try
+            {
+                table.Entries = System.Array.Empty<EnemyEquipmentLoadoutEntry>();
+
+                Assert.That(table.Select(new Random(1), 1), Is.Null);
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(table);
+            }
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Spawning/EnemyEquipmentLoadoutTableTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Spawning/EnemyEquipmentLoadoutTableTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6e14933d4ca74f408968350cf0f44f23
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/_Tests/EditMode/Spawning/GoblinEquipmentDistributionTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Spawning/GoblinEquipmentDistributionTests.cs
@@ -1,0 +1,211 @@
+using System.Collections.Generic;
+using Castlebound.Gameplay.AI;
+using Castlebound.Gameplay.Spawning;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+
+namespace Castlebound.Tests.Spawning
+{
+    public class GoblinEquipmentDistributionTests
+    {
+        private const string SchedulePath = "Assets/_Project/Spawning/BasicSpawnSchedule.asset";
+        private const string MeleeLoadoutPath =
+            "Assets/_Project/Spawning/Loadouts/GoblinMeleeEquipmentLoadout.asset";
+        private const string RangedLoadoutPath =
+            "Assets/_Project/Spawning/Loadouts/GoblinRangedEquipmentLoadout.asset";
+
+        [Test]
+        public void BasicSchedule_AuthorsExpandableGoblinLoadoutsAndWaveChanceRamp()
+        {
+            var scheduleAsset = AssetDatabase.LoadAssetAtPath<EnemySpawnScheduleAsset>(SchedulePath);
+            var meleeLoadout = AssetDatabase.LoadAssetAtPath<EnemyEquipmentLoadoutTable>(MeleeLoadoutPath);
+            var rangedLoadout = AssetDatabase.LoadAssetAtPath<EnemyEquipmentLoadoutTable>(RangedLoadoutPath);
+            var club = AssetDatabase.LoadAssetAtPath<EnemyEquipmentDefinition>(
+                "Assets/_Project/Items/Definitions/EnemyEquipment_Club.asset");
+            var rock = AssetDatabase.LoadAssetAtPath<EnemyEquipmentDefinition>(
+                "Assets/_Project/Items/Definitions/EnemyEquipment_Rock.asset");
+
+            Assert.NotNull(scheduleAsset);
+            Assert.NotNull(meleeLoadout);
+            Assert.NotNull(rangedLoadout);
+            Assert.That(meleeLoadout.GetSelectionChance(club, 1), Is.EqualTo(0.2f).Within(0.0001f));
+            Assert.That(meleeLoadout.GetSelectionChance(club, 5), Is.EqualTo(5f / 9f).Within(0.0001f));
+            Assert.That(meleeLoadout.GetSelectionChance(club, 10), Is.EqualTo(1f).Within(0.0001f));
+            Assert.That(rangedLoadout.GetSelectionChance(rock, 1), Is.EqualTo(1f));
+
+            var schedule = scheduleAsset.ToRuntimeWaveSchedule();
+            Assert.That(FindSequence(schedule.GetWave(1), EnemyArchetypeIds.GoblinMelee).equipmentLoadout,
+                Is.SameAs(meleeLoadout));
+            Assert.That(FindSequence(schedule.GetWave(2), EnemyArchetypeIds.GoblinRanged).equipmentLoadout,
+                Is.SameAs(rangedLoadout));
+            Assert.That(FindSequence(schedule.GetWave(3), EnemyArchetypeIds.GoblinMelee).equipmentLoadout,
+                Is.SameAs(meleeLoadout));
+            Assert.That(FindSequence(schedule.GetWave(3), EnemyArchetypeIds.GoblinRanged).equipmentLoadout,
+                Is.SameAs(rangedLoadout));
+        }
+
+        [Test]
+        public void AuthoredSequence_EmitsSelectedEquipmentWithoutChangingArchetypeCount()
+        {
+            var unarmed = ScriptableObject.CreateInstance<EnemyEquipmentDefinition>();
+            var club = ScriptableObject.CreateInstance<EnemyEquipmentDefinition>();
+            var table = ScriptableObject.CreateInstance<EnemyEquipmentLoadoutTable>();
+
+            try
+            {
+                table.Entries = new[]
+                {
+                    new EnemyEquipmentLoadoutEntry(unarmed, 1, 0f, 1, 0f),
+                    new EnemyEquipmentLoadoutEntry(club, 1, 100f, 1, 100f)
+                };
+                var wave = new WaveConfig
+                {
+                    sequences = new List<SpawnSequenceConfig>
+                    {
+                        new SpawnSequenceConfig
+                        {
+                            enemyTypeId = EnemyArchetypeIds.GoblinMelee,
+                            spawnCount = 5,
+                            equipmentLoadout = table
+                        }
+                    },
+                    waitForClear = false
+                };
+
+                var requests = CreateSpawner(wave).Tick(0.1f, currentAlive: 0);
+
+                Assert.That(requests, Has.Count.EqualTo(5));
+                for (int i = 0; i < requests.Count; i++)
+                {
+                    Assert.That(requests[i].EnemyTypeId, Is.EqualTo(EnemyArchetypeIds.GoblinMelee));
+                    Assert.That(requests[i].Equipment, Is.SameAs(club));
+                }
+            }
+            finally
+            {
+                Object.DestroyImmediate(table);
+                Object.DestroyImmediate(club);
+                Object.DestroyImmediate(unarmed);
+            }
+        }
+
+        [Test]
+        public void AuthoredSequence_SameSeed_ReplaysSelectedEquipmentOrder()
+        {
+            var unarmed = ScriptableObject.CreateInstance<EnemyEquipmentDefinition>();
+            var club = ScriptableObject.CreateInstance<EnemyEquipmentDefinition>();
+            var table = ScriptableObject.CreateInstance<EnemyEquipmentLoadoutTable>();
+
+            try
+            {
+                table.Entries = new[]
+                {
+                    new EnemyEquipmentLoadoutEntry(unarmed, 1, 50f, 1, 50f),
+                    new EnemyEquipmentLoadoutEntry(club, 1, 50f, 1, 50f)
+                };
+                var wave = new WaveConfig
+                {
+                    useSeedOverride = true,
+                    seedOverride = 236,
+                    sequences = new List<SpawnSequenceConfig>
+                    {
+                        new SpawnSequenceConfig
+                        {
+                            enemyTypeId = EnemyArchetypeIds.GoblinMelee,
+                            spawnCount = 12,
+                            equipmentLoadout = table
+                        }
+                    },
+                    waitForClear = false
+                };
+
+                var firstRun = CreateSpawner(wave).Tick(0.1f, currentAlive: 0);
+                var replay = CreateSpawner(wave).Tick(0.1f, currentAlive: 0);
+
+                Assert.That(replay, Has.Count.EqualTo(firstRun.Count));
+                for (int i = 0; i < firstRun.Count; i++)
+                {
+                    Assert.That(replay[i].Equipment, Is.SameAs(firstRun[i].Equipment));
+                }
+            }
+            finally
+            {
+                Object.DestroyImmediate(table);
+                Object.DestroyImmediate(club);
+                Object.DestroyImmediate(unarmed);
+            }
+        }
+
+        [Test]
+        public void GeneratedTier_PreservesAuthoredEquipmentLoadoutReference()
+        {
+            var table = ScriptableObject.CreateInstance<EnemyEquipmentLoadoutTable>();
+            try
+            {
+                var ramp = new RampConfig
+                {
+                    startWave = 1,
+                    baseSpawnCount = 2,
+                    unlocks = new List<RampTierUnlock>
+                    {
+                        new RampTierUnlock
+                        {
+                            waveIndex = 1,
+                            tiers = new List<RampTier>
+                            {
+                                new RampTier
+                                {
+                                    enemyTypeId = EnemyArchetypeIds.GoblinMelee,
+                                    weight = 1f,
+                                    equipmentLoadout = table
+                                }
+                            }
+                        }
+                    }
+                };
+                var schedule = new WaveScheduleRuntime(
+                    SpawnMarkerStrategy.RoundRobin,
+                    defaultSeed: 0,
+                    waves: null,
+                    ramp: ramp);
+
+                var generated = schedule.GetWave(1);
+
+                Assert.That(generated.Sequences, Has.Count.EqualTo(1));
+                Assert.That(generated.Sequences[0].equipmentLoadout, Is.SameAs(table));
+            }
+            finally
+            {
+                Object.DestroyImmediate(table);
+            }
+        }
+
+        private static EnemyWaveSpawner CreateSpawner(WaveConfig wave)
+        {
+            var schedule = new WaveScheduleRuntime(
+                SpawnMarkerStrategy.RoundRobin,
+                defaultSeed: 0,
+                waves: new[] { wave },
+                ramp: null);
+
+            return new EnemyWaveSpawner(
+                schedule,
+                new[] { new SpawnPoint("GateA", Vector2.zero) });
+        }
+
+        private static SpawnSequenceConfig FindSequence(WaveRuntime wave, string enemyTypeId)
+        {
+            for (int i = 0; i < wave.Sequences.Count; i++)
+            {
+                if (wave.Sequences[i].enemyTypeId == enemyTypeId)
+                {
+                    return wave.Sequences[i];
+                }
+            }
+
+            Assert.Fail($"Expected sequence for '{enemyTypeId}'.");
+            return default;
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Spawning/GoblinEquipmentDistributionTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Spawning/GoblinEquipmentDistributionTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4f2fa12158644d90b928da59a493b679
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/_Tests/PlayMode/Spawning/GoblinEquipmentWavePlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/Spawning/GoblinEquipmentWavePlayTests.cs
@@ -1,0 +1,140 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using Castlebound.Gameplay.AI;
+using Castlebound.Gameplay.Spawning;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Castlebound.Tests.PlayMode.Spawning
+{
+    public class GoblinEquipmentWavePlayTests
+    {
+        [UnityTest]
+        public IEnumerator SpawnReady_AppliesCompatibleRequestedEquipmentBeforeFirstUpdate()
+        {
+            var unarmed = CreateEquipment("unarmed", EnemyAttackRole.Melee);
+            var club = CreateEquipment("club", EnemyAttackRole.Melee);
+            var prefab = CreateEnemyPrefab("EquipmentMeleePrefab", unarmed, ranged: false);
+            var runnerObject = new GameObject("EquipmentSpawnerRunner");
+            var runner = runnerObject.AddComponent<EnemySpawnerRunner>();
+
+            try
+            {
+                SetPrefabMap(runner, EnemyArchetypeIds.GoblinMelee, prefab);
+                InvokeSpawnReady(runner, new SpawnRequest(
+                    EnemyArchetypeIds.GoblinMelee,
+                    "GateA",
+                    "Center",
+                    Vector2.zero,
+                    Vector2.down,
+                    club));
+
+                var clone = GameObject.Find("EquipmentMeleePrefab(Clone)");
+                Assert.NotNull(clone);
+                Assert.That(clone.GetComponent<EnemyEquipment>().ActiveEquipment, Is.SameAs(club));
+                yield return null;
+                Assert.That(clone.GetComponent<EnemyEquipment>().ActiveEquipment, Is.SameAs(club));
+            }
+            finally
+            {
+                DestroyByName("EquipmentMeleePrefab(Clone)");
+                Object.DestroyImmediate(runnerObject);
+                Object.DestroyImmediate(prefab);
+                Object.DestroyImmediate(club);
+                Object.DestroyImmediate(unarmed);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator SpawnReady_IncompatibleEquipmentKeepsSafePrefabDefault()
+        {
+            var rock = CreateEquipment("rock", EnemyAttackRole.Ranged);
+            var club = CreateEquipment("club", EnemyAttackRole.Melee);
+            var prefab = CreateEnemyPrefab("EquipmentRangedPrefab", rock, ranged: true);
+            var runnerObject = new GameObject("EquipmentSpawnerRunner");
+            var runner = runnerObject.AddComponent<EnemySpawnerRunner>();
+
+            try
+            {
+                SetPrefabMap(runner, EnemyArchetypeIds.GoblinRanged, prefab);
+                LogAssert.Expect(
+                    LogType.Error,
+                    "EnemySpawnerRunner: equipment 'club' is incompatible with Ranged enemy type 'goblin_ranged'; keeping prefab default.");
+                InvokeSpawnReady(runner, new SpawnRequest(
+                    EnemyArchetypeIds.GoblinRanged,
+                    "GateA",
+                    "Center",
+                    Vector2.zero,
+                    Vector2.down,
+                    club));
+
+                var clone = GameObject.Find("EquipmentRangedPrefab(Clone)");
+                Assert.NotNull(clone);
+                Assert.That(clone.GetComponent<EnemyEquipment>().ActiveEquipment, Is.SameAs(rock));
+                yield return null;
+            }
+            finally
+            {
+                DestroyByName("EquipmentRangedPrefab(Clone)");
+                Object.DestroyImmediate(runnerObject);
+                Object.DestroyImmediate(prefab);
+                Object.DestroyImmediate(club);
+                Object.DestroyImmediate(rock);
+            }
+        }
+
+        private static EnemyEquipmentDefinition CreateEquipment(string id, EnemyAttackRole role)
+        {
+            var definition = ScriptableObject.CreateInstance<EnemyEquipmentDefinition>();
+            definition.EquipmentId = id;
+            definition.CompatibleRole = role;
+            return definition;
+        }
+
+        private static GameObject CreateEnemyPrefab(
+            string name,
+            EnemyEquipmentDefinition defaultEquipment,
+            bool ranged)
+        {
+            var prefab = new GameObject(name);
+            var equipment = prefab.AddComponent<EnemyEquipment>();
+            typeof(EnemyEquipment).GetField("spawnEquipment", BindingFlags.NonPublic | BindingFlags.Instance)
+                ?.SetValue(equipment, defaultEquipment);
+            var attack = prefab.AddComponent<EnemyAttack>();
+            if (ranged)
+            {
+                var delivery = prefab.AddComponent<EnemyProjectileAttackDelivery>();
+                attack.AttackDeliverySource = delivery;
+            }
+
+            return prefab;
+        }
+
+        private static void SetPrefabMap(EnemySpawnerRunner runner, string enemyTypeId, GameObject prefab)
+        {
+            var map = new Dictionary<string, GameObject> { [enemyTypeId] = prefab };
+            typeof(EnemySpawnerRunner).GetField("_prefabMap", BindingFlags.NonPublic | BindingFlags.Instance)
+                ?.SetValue(runner, map);
+        }
+
+        private static void InvokeSpawnReady(EnemySpawnerRunner runner, SpawnRequest request)
+        {
+            var spawnReady = typeof(EnemySpawnerRunner).GetMethod(
+                "SpawnReady",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(spawnReady);
+            spawnReady.Invoke(runner, new object[] { new List<SpawnRequest> { request } });
+        }
+
+        private static void DestroyByName(string objectName)
+        {
+            var instance = GameObject.Find(objectName);
+            if (instance != null)
+            {
+                Object.DestroyImmediate(instance);
+            }
+        }
+    }
+}

--- a/Assets/_Project/_Tests/PlayMode/Spawning/GoblinEquipmentWavePlayTests.cs.meta
+++ b/Assets/_Project/_Tests/PlayMode/Spawning/GoblinEquipmentWavePlayTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7608c91bdd624d8cb0ea404af98d4892
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/TEST_LOG.md
+++ b/TEST_LOG.md
@@ -1,3 +1,20 @@
+## 2026-08-03 - feat-spawning-enemy-equipment-distribution
+
+### Summary
+- Added reusable weighted enemy equipment loadout assets with deterministic seeded selection.
+- Authored melee goblin club chance from 20% on wave 1 to 100% on wave 10 while keeping ranged goblins on rock equipment.
+- Propagated selected equipment through spawn requests with compatible application and safe prefab-default fallback.
+
+### New or Updated Tests
+**EditMode**
+- EnemyEquipmentLoadoutTableTests and GoblinEquipmentDistributionTests — weight progression, seeded replay, authored and generated loadout propagation, and archetype-count regression coverage.
+
+**PlayMode**
+- GoblinEquipmentWavePlayTests — compatible equipment application before first update and incompatible-equipment fallback.
+
+### Notes
+- EditMode and PlayMode suites pass per user validation; manual behavior validation confirmed the authored equipment distribution.
+
 ## 2026-08-02 - feat-spawning-goblin-wave-composition
 
 ### Summary


### PR DESCRIPTION
## Why
Enemy equipment variety needs to ramp intentionally without coupling spawning to future universal equipment-stat work. Seeded loadout selection keeps the authored probability curve reproducible for testing and balance.

## What changed
- Added reusable weighted enemy equipment loadout assets with deterministic per-wave selection
- Authored melee club chance from 20% on wave 1 to 100% on wave 10 and kept ranged goblins on rock equipment
- Propagated selected equipment through spawn requests with compatibility validation and safe prefab-default fallback
- Added EditMode and PlayMode coverage for progression, replay, generated waves, application, fallback, and archetype-count regressions

## How to test
1. Open MainPrototype and run representative authored and generated waves
2. Press Play → verify melee equipment variety, ranged rock equipment, and all-club melee goblins at wave 10
3. Run tests:
   - EditMode: EnemyEquipmentLoadoutTableTests, GoblinEquipmentDistributionTests, and spawning regressions
   - PlayMode: GoblinEquipmentWavePlayTests and EnemySpawnerRunnerPlayTests

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated (N/A - the existing MainPrototype schedule reference consumes the updated asset)
- [x] Prefab links, tags, and layers validated (N/A - no prefab, tag, or layer changes)
- [x] README / Docs touched (N/A - TEST_LOG records validation; no reader documentation change required)

## Related
- Closes #236