### PR TITLE
refactor(equipment): add entity-agnostic combat profiles

### DIFF
--- a/Assets/_Project/Items/CombatProfiles.meta
+++ b/Assets/_Project/Items/CombatProfiles.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c402db9d9fe64d3988cd95c35ef2eca4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Items/CombatProfiles/CombatEquipment_Club.asset
+++ b/Assets/_Project/Items/CombatProfiles/CombatEquipment_Club.asset
@@ -1,0 +1,25 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 866fcd4f824d4f07849b32e269a0f5a5, type: 3}
+  m_Name: CombatEquipment_Club
+  m_EditorClassIdentifier:
+  equipmentId: club
+  damageBonus: 3
+  attackRateMultiplier: 1.45
+  rangeBonus: 0.4
+  knockbackBonus: 0.85
+  requiredCapabilities: 5
+  handSprite: {fileID: 21300000, guid: 90a11f2c3d4e5f60718293a4b5c6d702, type: 3}
+  projectilePrefab: {fileID: 0}
+  projectileSpeed: 0
+  projectileLifetime: 0
+  projectileVisualAngleOffsetDegrees: 0

--- a/Assets/_Project/Items/CombatProfiles/CombatEquipment_Club.asset.meta
+++ b/Assets/_Project/Items/CombatProfiles/CombatEquipment_Club.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4e36c42f7c0c455dbb3ad90c9017df87
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Items/CombatProfiles/CombatEquipment_IronClub.asset
+++ b/Assets/_Project/Items/CombatProfiles/CombatEquipment_IronClub.asset
@@ -1,0 +1,25 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 866fcd4f824d4f07849b32e269a0f5a5, type: 3}
+  m_Name: CombatEquipment_IronClub
+  m_EditorClassIdentifier:
+  equipmentId: iron_club
+  damageBonus: 5
+  attackRateMultiplier: 0.95
+  rangeBonus: 0.6
+  knockbackBonus: 1.35
+  requiredCapabilities: 5
+  handSprite: {fileID: 21300000, guid: 90a11f2c3d4e5f60718293a4b5c6d701, type: 3}
+  projectilePrefab: {fileID: 0}
+  projectileSpeed: 0
+  projectileLifetime: 0
+  projectileVisualAngleOffsetDegrees: 0

--- a/Assets/_Project/Items/CombatProfiles/CombatEquipment_IronClub.asset.meta
+++ b/Assets/_Project/Items/CombatProfiles/CombatEquipment_IronClub.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1f8a7644df2641f79d68704cd70a8612
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Items/CombatProfiles/CombatEquipment_Rock.asset
+++ b/Assets/_Project/Items/CombatProfiles/CombatEquipment_Rock.asset
@@ -1,0 +1,25 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 866fcd4f824d4f07849b32e269a0f5a5, type: 3}
+  m_Name: CombatEquipment_Rock
+  m_EditorClassIdentifier:
+  equipmentId: rock
+  damageBonus: 2
+  attackRateMultiplier: 1
+  rangeBonus: 2.5
+  knockbackBonus: 0
+  requiredCapabilities: 6
+  handSprite: {fileID: 21300000, guid: 61bd5abbe3554b65af2a5f6ec3b7d042, type: 3}
+  projectilePrefab: {fileID: 3000000004, guid: e101a4e24f254666b4f76da58f4f311b, type: 3}
+  projectileSpeed: 8
+  projectileLifetime: 4
+  projectileVisualAngleOffsetDegrees: 0

--- a/Assets/_Project/Items/CombatProfiles/CombatEquipment_Rock.asset.meta
+++ b/Assets/_Project/Items/CombatProfiles/CombatEquipment_Rock.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d7556d6cc5174d8c8abc51a5e06296db
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Items/CombatProfiles/CombatEquipment_RustyDagger.asset
+++ b/Assets/_Project/Items/CombatProfiles/CombatEquipment_RustyDagger.asset
@@ -1,0 +1,25 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 866fcd4f824d4f07849b32e269a0f5a5, type: 3}
+  m_Name: CombatEquipment_RustyDagger
+  m_EditorClassIdentifier:
+  equipmentId: rusty_dagger
+  damageBonus: 3
+  attackRateMultiplier: 1.8
+  rangeBonus: 0.2
+  knockbackBonus: 0.55
+  requiredCapabilities: 5
+  handSprite: {fileID: 21300000, guid: 90a11f2c3d4e5f60718293a4b5c6d703, type: 3}
+  projectilePrefab: {fileID: 0}
+  projectileSpeed: 0
+  projectileLifetime: 0
+  projectileVisualAngleOffsetDegrees: 0

--- a/Assets/_Project/Items/CombatProfiles/CombatEquipment_RustyDagger.asset.meta
+++ b/Assets/_Project/Items/CombatProfiles/CombatEquipment_RustyDagger.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1ff4aeff66d74cb7807775a387979864
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Items/CombatProfiles/CombatEquipment_Sword.asset
+++ b/Assets/_Project/Items/CombatProfiles/CombatEquipment_Sword.asset
@@ -1,0 +1,25 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 866fcd4f824d4f07849b32e269a0f5a5, type: 3}
+  m_Name: CombatEquipment_Sword
+  m_EditorClassIdentifier:
+  equipmentId: sword
+  damageBonus: 5
+  attackRateMultiplier: 1.3
+  rangeBonus: 0.5
+  knockbackBonus: 1
+  requiredCapabilities: 5
+  handSprite: {fileID: 21300000, guid: a85120fb50560e4448e516b378dec303, type: 3}
+  projectilePrefab: {fileID: 0}
+  projectileSpeed: 0
+  projectileLifetime: 0
+  projectileVisualAngleOffsetDegrees: 0

--- a/Assets/_Project/Items/CombatProfiles/CombatEquipment_Sword.asset.meta
+++ b/Assets/_Project/Items/CombatProfiles/CombatEquipment_Sword.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 291743f4552f456ba7461cd6f74e28fb
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Items/CombatProfiles/CombatEquipment_Unarmed.asset
+++ b/Assets/_Project/Items/CombatProfiles/CombatEquipment_Unarmed.asset
@@ -1,0 +1,25 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 866fcd4f824d4f07849b32e269a0f5a5, type: 3}
+  m_Name: CombatEquipment_Unarmed
+  m_EditorClassIdentifier:
+  equipmentId: unarmed
+  damageBonus: 0
+  attackRateMultiplier: 1
+  rangeBonus: 0
+  knockbackBonus: 0
+  requiredCapabilities: 1
+  handSprite: {fileID: 0}
+  projectilePrefab: {fileID: 0}
+  projectileSpeed: 0
+  projectileLifetime: 0
+  projectileVisualAngleOffsetDegrees: 0

--- a/Assets/_Project/Items/CombatProfiles/CombatEquipment_Unarmed.asset.meta
+++ b/Assets/_Project/Items/CombatProfiles/CombatEquipment_Unarmed.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5ccf52be623b420cb9a60c8f7fe30f90
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Items/Definitions/EnemyEquipment_Club.asset
+++ b/Assets/_Project/Items/Definitions/EnemyEquipment_Club.asset
@@ -12,17 +12,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2f625f3546fd4b6a831e7c69359ebdfa, type: 3}
   m_Name: EnemyEquipment_Club
   m_EditorClassIdentifier:
-  equipmentId: club
+  combatProfile: {fileID: 11400000, guid: 4e36c42f7c0c455dbb3ad90c9017df87, type: 2}
   compatibleRole: 1
-  handSprite: {fileID: 21300000, guid: 90a11f2c3d4e5f60718293a4b5c6d702, type: 3}
   handlePosition: {x: 0.04, y: 0.04}
   handleRotation: 0
   handleScale: {x: 1, y: 1}
-  projectilePrefab: {fileID: 0}
-  projectileSpeed: 0
-  projectileDamage: 3
-  projectileLifetime: 0
   projectileTargetLayerMask:
     serializedVersion: 2
     m_Bits: 0
-  projectileVisualAngleOffsetDegrees: 0

--- a/Assets/_Project/Items/Definitions/EnemyEquipment_Rock.asset
+++ b/Assets/_Project/Items/Definitions/EnemyEquipment_Rock.asset
@@ -12,17 +12,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2f625f3546fd4b6a831e7c69359ebdfa, type: 3}
   m_Name: EnemyEquipment_Rock
   m_EditorClassIdentifier:
-  equipmentId: rock
+  combatProfile: {fileID: 11400000, guid: d7556d6cc5174d8c8abc51a5e06296db, type: 2}
   compatibleRole: 2
-  handSprite: {fileID: 21300000, guid: 61bd5abbe3554b65af2a5f6ec3b7d042, type: 3}
   handlePosition: {x: 0.05, y: 0.04}
   handleRotation: 0
   handleScale: {x: 0.65, y: 0.65}
-  projectilePrefab: {fileID: 3000000004, guid: e101a4e24f254666b4f76da58f4f311b, type: 3}
-  projectileSpeed: 8
-  projectileDamage: 2
-  projectileLifetime: 4
   projectileTargetLayerMask:
     serializedVersion: 2
     m_Bits: 264
-  projectileVisualAngleOffsetDegrees: 0

--- a/Assets/_Project/Items/Definitions/EnemyEquipment_Unarmed.asset
+++ b/Assets/_Project/Items/Definitions/EnemyEquipment_Unarmed.asset
@@ -12,17 +12,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2f625f3546fd4b6a831e7c69359ebdfa, type: 3}
   m_Name: EnemyEquipment_Unarmed
   m_EditorClassIdentifier:
-  equipmentId: unarmed
-  compatibleRole: 0
-  handSprite: {fileID: 0}
+  combatProfile: {fileID: 11400000, guid: 5ccf52be623b420cb9a60c8f7fe30f90, type: 2}
+  compatibleRole: 1
   handlePosition: {x: 0, y: 0}
   handleRotation: 0
   handleScale: {x: 1, y: 1}
-  projectilePrefab: {fileID: 0}
-  projectileSpeed: 0
-  projectileDamage: 0
-  projectileLifetime: 0
   projectileTargetLayerMask:
     serializedVersion: 2
     m_Bits: 0
-  projectileVisualAngleOffsetDegrees: 0

--- a/Assets/_Project/Items/Definitions/Weapon_Club.asset
+++ b/Assets/_Project/Items/Definitions/Weapon_Club.asset
@@ -15,10 +15,7 @@ MonoBehaviour:
   itemId: weapon_club
   displayName: Club
   icon: {fileID: 21300000, guid: 90a11f2c3d4e5f60718293a4b5c6d702, type: 3}
-  damage: 3
-  attackSpeed: 1.45
+  combatProfile: {fileID: 11400000, guid: 4e36c42f7c0c455dbb3ad90c9017df87, type: 2}
   hitboxSize: {x: 2, y: 2}
-  knockback: 0.85
-  handSprite: {fileID: 21300000, guid: 90a11f2c3d4e5f60718293a4b5c6d702, type: 3}
   handleOffset: {x: 0.04, y: 0.04}
   hitboxOffset: {x: 0, y: -0.04}

--- a/Assets/_Project/Items/Definitions/Weapon_IronClub.asset
+++ b/Assets/_Project/Items/Definitions/Weapon_IronClub.asset
@@ -15,10 +15,7 @@ MonoBehaviour:
   itemId: weapon_iron_club
   displayName: Iron Club
   icon: {fileID: 21300000, guid: 90a11f2c3d4e5f60718293a4b5c6d701, type: 3}
-  damage: 5
-  attackSpeed: 0.95
+  combatProfile: {fileID: 11400000, guid: 1f8a7644df2641f79d68704cd70a8612, type: 2}
   hitboxSize: {x: 2.45, y: 2.45}
-  knockback: 1.35
-  handSprite: {fileID: 21300000, guid: 90a11f2c3d4e5f60718293a4b5c6d701, type: 3}
   handleOffset: {x: 0.05, y: 0.05}
   hitboxOffset: {x: 0, y: -0.05}

--- a/Assets/_Project/Items/Definitions/Weapon_RustyDagger.asset
+++ b/Assets/_Project/Items/Definitions/Weapon_RustyDagger.asset
@@ -15,10 +15,7 @@ MonoBehaviour:
   itemId: weapon_rusty_dagger
   displayName: Rusty Dagger
   icon: {fileID: 21300000, guid: 90a11f2c3d4e5f60718293a4b5c6d703, type: 3}
-  damage: 3
-  attackSpeed: 1.8
+  combatProfile: {fileID: 11400000, guid: 1ff4aeff66d74cb7807775a387979864, type: 2}
   hitboxSize: {x: 1.55, y: 1.55}
-  knockback: 0.55
-  handSprite: {fileID: 21300000, guid: 90a11f2c3d4e5f60718293a4b5c6d703, type: 3}
   handleOffset: {x: 0.03, y: 0.03}
   hitboxOffset: {x: 0, y: -0.03}

--- a/Assets/_Project/Items/Definitions/Weapon_Sword.asset
+++ b/Assets/_Project/Items/Definitions/Weapon_Sword.asset
@@ -15,10 +15,7 @@ MonoBehaviour:
   itemId: weapon_sword
   displayName: Sword
   icon: {fileID: 21300000, guid: a85120fb50560e4448e516b378dec303, type: 3}
-  damage: 5
-  attackSpeed: 1.3
+  combatProfile: {fileID: 11400000, guid: 291743f4552f456ba7461cd6f74e28fb, type: 2}
   hitboxSize: {x: 2.2, y: 2.2}
-  knockback: 1
-  handSprite: {fileID: 21300000, guid: a85120fb50560e4448e516b378dec303, type: 3}
   handleOffset: {x: 0.05, y: 0.05}
   hitboxOffset: {x: 0, y: -0.05}

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyEquipment.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyEquipment.cs
@@ -1,35 +1,49 @@
+using System;
+using Castlebound.Gameplay.Combat;
 using UnityEngine;
 
 namespace Castlebound.Gameplay.AI
 {
-    public class EnemyEquipment : MonoBehaviour
+    public class EnemyEquipment : MonoBehaviour, ICombatEquipmentSource
     {
         [SerializeField] private EnemyEquipmentDefinition spawnEquipment;
         [SerializeField] private SpriteRenderer weaponRenderer;
 
         public EnemyEquipmentDefinition SpawnEquipment => spawnEquipment;
         public EnemyEquipmentDefinition ActiveEquipment { get; private set; }
+        public CombatEquipmentProfile ActiveCombatProfile => ActiveEquipment != null
+            ? ActiveEquipment.CombatProfile
+            : null;
+
+        public event Action<CombatEquipmentProfile> EquipmentChanged;
 
         private void Awake() => Equip(spawnEquipment);
 
         public bool Equip(EnemyEquipmentDefinition equipment)
         {
+            CombatEquipmentProfile previousProfile = ActiveCombatProfile;
             ActiveEquipment = equipment;
             Sprite sprite = equipment != null ? equipment.HandSprite : null;
-            if (weaponRenderer == null)
-                return true;
-            weaponRenderer.sprite = sprite;
-            weaponRenderer.enabled = sprite != null;
-            if (sprite == null)
-                return true;
+            if (weaponRenderer != null)
+            {
+                weaponRenderer.sprite = sprite;
+                weaponRenderer.enabled = sprite != null;
+                if (sprite != null)
+                {
+                    weaponRenderer.transform.localPosition = equipment.HandlePosition;
+                    weaponRenderer.transform.localRotation = Quaternion.Euler(0f, 0f, equipment.HandleRotation);
+                    Vector2 scale = equipment.HandleScale;
+                    weaponRenderer.transform.localScale = new Vector3(
+                        Mathf.Approximately(scale.x, 0f) ? 1f : scale.x,
+                        Mathf.Approximately(scale.y, 0f) ? 1f : scale.y,
+                        1f);
+                }
+            }
 
-            weaponRenderer.transform.localPosition = equipment.HandlePosition;
-            weaponRenderer.transform.localRotation = Quaternion.Euler(0f, 0f, equipment.HandleRotation);
-            Vector2 scale = equipment.HandleScale;
-            weaponRenderer.transform.localScale = new Vector3(
-                Mathf.Approximately(scale.x, 0f) ? 1f : scale.x,
-                Mathf.Approximately(scale.y, 0f) ? 1f : scale.y,
-                1f);
+            if (previousProfile != ActiveCombatProfile)
+            {
+                EquipmentChanged?.Invoke(ActiveCombatProfile);
+            }
             return true;
         }
     }

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyEquipmentDefinition.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyEquipmentDefinition.cs
@@ -1,3 +1,4 @@
+using Castlebound.Gameplay.Combat;
 using Castlebound.Gameplay.Projectile;
 using UnityEngine;
 
@@ -6,43 +7,53 @@ namespace Castlebound.Gameplay.AI
     [CreateAssetMenu(menuName = "Castlebound/Enemies/Equipment Definition")]
     public class EnemyEquipmentDefinition : ScriptableObject
     {
-        [SerializeField] private string equipmentId = "unarmed";
+        [SerializeField] private CombatEquipmentProfile combatProfile;
         [SerializeField] private EnemyAttackRole compatibleRole;
-        [SerializeField] private Sprite handSprite;
         [SerializeField] private Vector2 handlePosition;
         [SerializeField] private float handleRotation;
         [SerializeField] private Vector2 handleScale = Vector2.one;
-        [Header("Projectile")]
-        [SerializeField] private ProjectileRuntime projectilePrefab;
-        [SerializeField, Min(0f)] private float projectileSpeed = 6f;
-        [SerializeField, Min(0)] private int projectileDamage = 1;
-        [SerializeField, Min(0f)] private float projectileLifetime = 3f;
+        [Header("Enemy Targeting")]
         [SerializeField] private LayerMask projectileTargetLayerMask;
-        [SerializeField] private float projectileVisualAngleOffsetDegrees;
 
-        public string EquipmentId { get => equipmentId; set => equipmentId = value; }
+        public CombatEquipmentProfile CombatProfile { get => combatProfile; set => combatProfile = value; }
+        public string EquipmentId => combatProfile != null ? combatProfile.EquipmentId : null;
         public EnemyAttackRole CompatibleRole { get => compatibleRole; set => compatibleRole = value; }
-        public Sprite HandSprite { get => handSprite; set => handSprite = value; }
+        public Sprite HandSprite => combatProfile != null ? combatProfile.HandSprite : null;
         public Vector2 HandlePosition { get => handlePosition; set => handlePosition = value; }
         public float HandleRotation { get => handleRotation; set => handleRotation = value; }
         public Vector2 HandleScale { get => handleScale; set => handleScale = value; }
-        public ProjectileRuntime ProjectilePrefab { get => projectilePrefab; set => projectilePrefab = value; }
-        public float ProjectileSpeed { get => projectileSpeed; set => projectileSpeed = Mathf.Max(0f, value); }
-        public int ProjectileDamage { get => projectileDamage; set => projectileDamage = Mathf.Max(0, value); }
-        public float ProjectileLifetime { get => projectileLifetime; set => projectileLifetime = Mathf.Max(0f, value); }
+        public ProjectileRuntime ProjectilePrefab => combatProfile != null ? combatProfile.ProjectilePrefab : null;
+        public float ProjectileSpeed => combatProfile != null ? combatProfile.ProjectileSpeed : 0f;
+        public int ProjectileDamage => combatProfile != null ? combatProfile.DamageBonus : 0;
+        public float ProjectileLifetime => combatProfile != null ? combatProfile.ProjectileLifetime : 0f;
         public LayerMask ProjectileTargetLayerMask { get => projectileTargetLayerMask; set => projectileTargetLayerMask = value; }
-        public float ProjectileVisualAngleOffsetDegrees { get => projectileVisualAngleOffsetDegrees; set => projectileVisualAngleOffsetDegrees = value; }
+        public float ProjectileVisualAngleOffsetDegrees => combatProfile != null
+            ? combatProfile.ProjectileVisualAngleOffsetDegrees
+            : 0f;
 
         public bool IsCompatibleWith(EnemyAttackRole attackRole)
         {
-            return compatibleRole == EnemyAttackRole.None || compatibleRole == attackRole;
+            if (combatProfile == null ||
+                (compatibleRole != EnemyAttackRole.None && compatibleRole != attackRole))
+            {
+                return false;
+            }
+
+            CombatEquipmentCapability capabilities = CombatEquipmentCapability.HandSocket;
+            if (attackRole == EnemyAttackRole.Melee)
+            {
+                capabilities |= CombatEquipmentCapability.MeleeDelivery;
+            }
+            else if (attackRole == EnemyAttackRole.Ranged)
+            {
+                capabilities |= CombatEquipmentCapability.ProjectileDelivery;
+            }
+
+            return combatProfile.CanEquip(capabilities);
         }
 
         private void OnValidate()
         {
-            projectileSpeed = Mathf.Max(0f, projectileSpeed);
-            projectileDamage = Mathf.Max(0, projectileDamage);
-            projectileLifetime = Mathf.Max(0f, projectileLifetime);
             handleScale = new Vector2(
                 Mathf.Approximately(handleScale.x, 0f) ? 1f : handleScale.x,
                 Mathf.Approximately(handleScale.y, 0f) ? 1f : handleScale.y);

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/Equipment.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/Equipment.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c0497ea888b947b886636980201f636a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/Equipment/CombatBaseStats.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/Equipment/CombatBaseStats.cs
@@ -1,0 +1,18 @@
+namespace Castlebound.Gameplay.Combat
+{
+    public readonly struct CombatBaseStats
+    {
+        public int Damage { get; }
+        public float AttackRate { get; }
+        public float Range { get; }
+        public float Knockback { get; }
+
+        public CombatBaseStats(int damage, float attackRate, float range, float knockback)
+        {
+            Damage = damage;
+            AttackRate = attackRate;
+            Range = range;
+            Knockback = knockback;
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/Equipment/CombatBaseStats.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/Equipment/CombatBaseStats.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c010d68a78104f07aa4064498841fc31
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/Equipment/CombatEquipmentCapability.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/Equipment/CombatEquipmentCapability.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Castlebound.Gameplay.Combat
+{
+    [Flags]
+    public enum CombatEquipmentCapability
+    {
+        None = 0,
+        MeleeDelivery = 1 << 0,
+        ProjectileDelivery = 1 << 1,
+        HandSocket = 1 << 2
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/Equipment/CombatEquipmentCapability.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/Equipment/CombatEquipmentCapability.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d43351ce2bd742b0b4431800162fc167
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/Equipment/CombatEquipmentProfile.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/Equipment/CombatEquipmentProfile.cs
@@ -1,0 +1,48 @@
+using Castlebound.Gameplay.Projectile;
+using UnityEngine;
+
+namespace Castlebound.Gameplay.Combat
+{
+    [CreateAssetMenu(menuName = "Castlebound/Combat/Equipment Profile")]
+    public class CombatEquipmentProfile : ScriptableObject
+    {
+        [SerializeField] private string equipmentId;
+        [SerializeField, Min(0)] private int damageBonus;
+        [SerializeField, Min(0.01f)] private float attackRateMultiplier = 1f;
+        [SerializeField] private float rangeBonus;
+        [SerializeField] private float knockbackBonus;
+        [SerializeField] private CombatEquipmentCapability requiredCapabilities;
+        [Header("Presentation")]
+        [SerializeField] private Sprite handSprite;
+        [Header("Projectile Delivery")]
+        [SerializeField] private ProjectileRuntime projectilePrefab;
+        [SerializeField, Min(0f)] private float projectileSpeed;
+        [SerializeField, Min(0f)] private float projectileLifetime;
+        [SerializeField] private float projectileVisualAngleOffsetDegrees;
+
+        public string EquipmentId { get => equipmentId; set => equipmentId = value; }
+        public int DamageBonus { get => damageBonus; set => damageBonus = Mathf.Max(0, value); }
+        public float AttackRateMultiplier { get => attackRateMultiplier; set => attackRateMultiplier = Mathf.Max(0.01f, value); }
+        public float RangeBonus { get => rangeBonus; set => rangeBonus = value; }
+        public float KnockbackBonus { get => knockbackBonus; set => knockbackBonus = value; }
+        public CombatEquipmentCapability RequiredCapabilities { get => requiredCapabilities; set => requiredCapabilities = value; }
+        public Sprite HandSprite { get => handSprite; set => handSprite = value; }
+        public ProjectileRuntime ProjectilePrefab { get => projectilePrefab; set => projectilePrefab = value; }
+        public float ProjectileSpeed { get => projectileSpeed; set => projectileSpeed = Mathf.Max(0f, value); }
+        public float ProjectileLifetime { get => projectileLifetime; set => projectileLifetime = Mathf.Max(0f, value); }
+        public float ProjectileVisualAngleOffsetDegrees { get => projectileVisualAngleOffsetDegrees; set => projectileVisualAngleOffsetDegrees = value; }
+
+        public bool CanEquip(CombatEquipmentCapability holderCapabilities)
+        {
+            return (holderCapabilities & requiredCapabilities) == requiredCapabilities;
+        }
+
+        private void OnValidate()
+        {
+            damageBonus = Mathf.Max(0, damageBonus);
+            attackRateMultiplier = Mathf.Max(0.01f, attackRateMultiplier);
+            projectileSpeed = Mathf.Max(0f, projectileSpeed);
+            projectileLifetime = Mathf.Max(0f, projectileLifetime);
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/Equipment/CombatEquipmentProfile.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/Equipment/CombatEquipmentProfile.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 866fcd4f824d4f07849b32e269a0f5a5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/Equipment/CombatEquipmentResolver.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/Equipment/CombatEquipmentResolver.cs
@@ -1,0 +1,36 @@
+using UnityEngine;
+
+namespace Castlebound.Gameplay.Combat
+{
+    public static class CombatEquipmentResolver
+    {
+        public const float MinimumAttackRate = 0.1f;
+
+        public static bool TryResolve(
+            CombatBaseStats wearerStats,
+            CombatEquipmentCapability holderCapabilities,
+            CombatEquipmentProfile profile,
+            out CombatEquipmentSnapshot snapshot)
+        {
+            if (profile == null || !profile.CanEquip(holderCapabilities))
+            {
+                snapshot = default;
+                return false;
+            }
+
+            snapshot = new CombatEquipmentSnapshot(
+                profile.EquipmentId,
+                Mathf.Max(0, wearerStats.Damage + profile.DamageBonus),
+                Mathf.Max(MinimumAttackRate, wearerStats.AttackRate * profile.AttackRateMultiplier),
+                Mathf.Max(0f, wearerStats.Range + profile.RangeBonus),
+                Mathf.Max(0f, wearerStats.Knockback + profile.KnockbackBonus),
+                profile.RequiredCapabilities,
+                profile.HandSprite,
+                profile.ProjectilePrefab,
+                profile.ProjectileSpeed,
+                profile.ProjectileLifetime,
+                profile.ProjectileVisualAngleOffsetDegrees);
+            return true;
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/Equipment/CombatEquipmentResolver.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/Equipment/CombatEquipmentResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f4a29db745b64d5ba6bcf4e0f4a59d11
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/Equipment/CombatEquipmentSnapshot.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/Equipment/CombatEquipmentSnapshot.cs
@@ -1,0 +1,46 @@
+using Castlebound.Gameplay.Projectile;
+using UnityEngine;
+
+namespace Castlebound.Gameplay.Combat
+{
+    public readonly struct CombatEquipmentSnapshot
+    {
+        public string EquipmentId { get; }
+        public int Damage { get; }
+        public float AttackRate { get; }
+        public float Range { get; }
+        public float Knockback { get; }
+        public CombatEquipmentCapability RequiredCapabilities { get; }
+        public Sprite HandSprite { get; }
+        public ProjectileRuntime ProjectilePrefab { get; }
+        public float ProjectileSpeed { get; }
+        public float ProjectileLifetime { get; }
+        public float ProjectileVisualAngleOffsetDegrees { get; }
+
+        public CombatEquipmentSnapshot(
+            string equipmentId,
+            int damage,
+            float attackRate,
+            float range,
+            float knockback,
+            CombatEquipmentCapability requiredCapabilities,
+            Sprite handSprite,
+            ProjectileRuntime projectilePrefab,
+            float projectileSpeed,
+            float projectileLifetime,
+            float projectileVisualAngleOffsetDegrees)
+        {
+            EquipmentId = equipmentId;
+            Damage = damage;
+            AttackRate = attackRate;
+            Range = range;
+            Knockback = knockback;
+            RequiredCapabilities = requiredCapabilities;
+            HandSprite = handSprite;
+            ProjectilePrefab = projectilePrefab;
+            ProjectileSpeed = projectileSpeed;
+            ProjectileLifetime = projectileLifetime;
+            ProjectileVisualAngleOffsetDegrees = projectileVisualAngleOffsetDegrees;
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/Equipment/CombatEquipmentSnapshot.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/Equipment/CombatEquipmentSnapshot.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6abc6be7a14a4e7f84fb4fba154919b6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/Equipment/ICombatEquipmentSource.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/Equipment/ICombatEquipmentSource.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Castlebound.Gameplay.Combat
+{
+    public interface ICombatEquipmentSource
+    {
+        CombatEquipmentProfile ActiveCombatProfile { get; }
+        event Action<CombatEquipmentProfile> EquipmentChanged;
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/Equipment/ICombatEquipmentSource.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/Equipment/ICombatEquipmentSource.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 05c7cdd5f98748d1a7d57c463b123eb6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/Weapons/PlayerWeaponController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/Weapons/PlayerWeaponController.cs
@@ -1,9 +1,10 @@
+using System;
 using UnityEngine;
 using Castlebound.Gameplay.Inventory;
 
 namespace Castlebound.Gameplay.Combat
 {
-    public class PlayerWeaponController : MonoBehaviour
+    public class PlayerWeaponController : MonoBehaviour, ICombatEquipmentSource
     {
         [SerializeField] private InventoryStateComponent inventorySource;
         [SerializeField] private MonoBehaviour resolverSource;
@@ -13,6 +14,11 @@ namespace Castlebound.Gameplay.Combat
         private InventoryState inventory;
 
         public string CurrentWeaponId => equippedDefinition != null ? equippedDefinition.ItemId : null;
+        public CombatEquipmentProfile ActiveCombatProfile => equippedDefinition != null
+            ? equippedDefinition.CombatProfile
+            : null;
+
+        public event Action<CombatEquipmentProfile> EquipmentChanged;
 
         public WeaponStats CurrentWeaponStats
         {
@@ -40,14 +46,25 @@ namespace Castlebound.Gameplay.Combat
 
         public void RefreshEquippedWeapon(InventoryState inventory)
         {
+            CombatEquipmentProfile previousProfile = ActiveCombatProfile;
             if (inventory == null || resolver == null)
             {
                 equippedDefinition = null;
+                PublishEquipmentChange(previousProfile);
                 return;
             }
 
             string weaponId = inventory.GetWeaponId(inventory.ActiveWeaponSlotIndex);
             equippedDefinition = resolver.Resolve(weaponId);
+            PublishEquipmentChange(previousProfile);
+        }
+
+        private void PublishEquipmentChange(CombatEquipmentProfile previousProfile)
+        {
+            if (previousProfile != ActiveCombatProfile)
+            {
+                EquipmentChanged?.Invoke(ActiveCombatProfile);
+            }
         }
 
         private void OnEnable()

--- a/Assets/_Project/Scripts/_Project.Gameplay/Inventory/WeaponDefinition.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Inventory/WeaponDefinition.cs
@@ -1,3 +1,4 @@
+using Castlebound.Gameplay.Combat;
 using UnityEngine;
 
 namespace Castlebound.Gameplay.Inventory
@@ -5,25 +6,14 @@ namespace Castlebound.Gameplay.Inventory
     [CreateAssetMenu(menuName = "Castlebound/Items/Weapon Definition")]
     public class WeaponDefinition : ItemDefinition
     {
-        [SerializeField] private int damage = 1;
-        [SerializeField] private float attackSpeed = 1f;
+        [SerializeField] private CombatEquipmentProfile combatProfile;
         [SerializeField] private Vector2 hitboxSize = new Vector2(1f, 1f);
-        [SerializeField] private float knockback = 1f;
-        [SerializeField] private Sprite handSprite;
         [SerializeField] private Vector2 handleOffset = Vector2.zero;
         [SerializeField] private Vector2 hitboxOffset = Vector2.zero;
 
-        public int Damage
-        {
-            get => damage;
-            set => damage = value;
-        }
-
-        public float AttackSpeed
-        {
-            get => attackSpeed;
-            set => attackSpeed = value;
-        }
+        public CombatEquipmentProfile CombatProfile { get => combatProfile; set => combatProfile = value; }
+        public int Damage => combatProfile != null ? combatProfile.DamageBonus : 0;
+        public float AttackSpeed => combatProfile != null ? combatProfile.AttackRateMultiplier : 1f;
 
         public Vector2 HitboxSize
         {
@@ -31,17 +21,8 @@ namespace Castlebound.Gameplay.Inventory
             set => hitboxSize = value;
         }
 
-        public float Knockback
-        {
-            get => knockback;
-            set => knockback = value;
-        }
-
-        public Sprite HandSprite
-        {
-            get => handSprite;
-            set => handSprite = value;
-        }
+        public float Knockback => combatProfile != null ? combatProfile.KnockbackBonus : 0f;
+        public Sprite HandSprite => combatProfile != null ? combatProfile.HandSprite : null;
 
         public Vector2 HandleOffset
         {

--- a/Assets/_Project/_Tests/EditMode/AI/EnemyEquipmentTests.cs
+++ b/Assets/_Project/_Tests/EditMode/AI/EnemyEquipmentTests.cs
@@ -1,4 +1,5 @@
 using Castlebound.Gameplay.AI;
+using Castlebound.Gameplay.Combat;
 using NUnit.Framework;
 using UnityEngine;
 
@@ -11,16 +12,23 @@ namespace Castlebound.Tests.AI
         {
             var enemy = new GameObject("EnemyEquipmentTests");
             var definition = ScriptableObject.CreateInstance<EnemyEquipmentDefinition>();
+            var profile = ScriptableObject.CreateInstance<CombatEquipmentProfile>();
             try
             {
                 var equipment = enemy.AddComponent<EnemyEquipment>();
-                definition.EquipmentId = "unarmed";
+                profile.EquipmentId = "unarmed";
+                definition.CombatProfile = profile;
+                CombatEquipmentProfile publishedProfile = null;
+                equipment.EquipmentChanged += changedProfile => publishedProfile = changedProfile;
 
                 Assert.IsTrue(equipment.Equip(definition));
                 Assert.That(equipment.ActiveEquipment, Is.SameAs(definition));
+                Assert.That(equipment.ActiveCombatProfile, Is.SameAs(profile));
+                Assert.That(publishedProfile, Is.SameAs(profile));
             }
             finally
             {
+                Object.DestroyImmediate(profile);
                 Object.DestroyImmediate(definition);
                 Object.DestroyImmediate(enemy);
             }
@@ -30,8 +38,11 @@ namespace Castlebound.Tests.AI
         public void Definition_ReportsCompatibleAttackRoleWithoutEnumBranches()
         {
             var definition = ScriptableObject.CreateInstance<EnemyEquipmentDefinition>();
+            var profile = ScriptableObject.CreateInstance<CombatEquipmentProfile>();
             try
             {
+                profile.RequiredCapabilities = CombatEquipmentCapability.ProjectileDelivery;
+                definition.CombatProfile = profile;
                 definition.CompatibleRole = EnemyAttackRole.Ranged;
 
                 Assert.IsTrue(definition.IsCompatibleWith(EnemyAttackRole.Ranged));
@@ -39,6 +50,7 @@ namespace Castlebound.Tests.AI
             }
             finally
             {
+                Object.DestroyImmediate(profile);
                 Object.DestroyImmediate(definition);
             }
         }

--- a/Assets/_Project/_Tests/EditMode/Combat/CombatEquipmentAssetTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Combat/CombatEquipmentAssetTests.cs
@@ -1,0 +1,59 @@
+using Castlebound.Gameplay.AI;
+using Castlebound.Gameplay.Combat;
+using Castlebound.Gameplay.Inventory;
+using NUnit.Framework;
+using UnityEditor;
+
+namespace Castlebound.Tests.Combat
+{
+    public class CombatEquipmentAssetTests
+    {
+        [Test]
+        public void Club_PlayerItemAndEnemyLoadoutReferenceSameCombatProfile()
+        {
+            var playerClub = AssetDatabase.LoadAssetAtPath<WeaponDefinition>(
+                "Assets/_Project/Items/Definitions/Weapon_Club.asset");
+            var enemyClub = AssetDatabase.LoadAssetAtPath<EnemyEquipmentDefinition>(
+                "Assets/_Project/Items/Definitions/EnemyEquipment_Club.asset");
+
+            Assert.That(playerClub, Is.Not.Null);
+            Assert.That(enemyClub, Is.Not.Null);
+            Assert.That(playerClub.CombatProfile, Is.Not.Null);
+            Assert.That(enemyClub.CombatProfile, Is.SameAs(playerClub.CombatProfile));
+            Assert.That(playerClub.ItemId, Is.EqualTo("weapon_club"));
+            Assert.That(enemyClub.CompatibleRole, Is.EqualTo(EnemyAttackRole.Melee));
+        }
+
+        [Test]
+        public void AuthoredDagger_ResolvesFasterThanAuthoredClubForEnemyCapabilities()
+        {
+            var dagger = AssetDatabase.LoadAssetAtPath<CombatEquipmentProfile>(
+                "Assets/_Project/Items/CombatProfiles/CombatEquipment_RustyDagger.asset");
+            var club = AssetDatabase.LoadAssetAtPath<CombatEquipmentProfile>(
+                "Assets/_Project/Items/CombatProfiles/CombatEquipment_Club.asset");
+            var enemyStats = new CombatBaseStats(1, 1f, 0.5f, 0f);
+            var enemyCapabilities =
+                CombatEquipmentCapability.MeleeDelivery |
+                CombatEquipmentCapability.HandSocket;
+
+            Assert.That(CombatEquipmentResolver.TryResolve(
+                enemyStats, enemyCapabilities, dagger, out var daggerSnapshot), Is.True);
+            Assert.That(CombatEquipmentResolver.TryResolve(
+                enemyStats, enemyCapabilities, club, out var clubSnapshot), Is.True);
+            Assert.That(daggerSnapshot.AttackRate, Is.GreaterThan(clubSnapshot.AttackRate));
+        }
+
+        [Test]
+        public void Rock_ProfileOwnsProjectilePayloadWhileEnemyAdapterOwnsTargetLayer()
+        {
+            var rock = AssetDatabase.LoadAssetAtPath<EnemyEquipmentDefinition>(
+                "Assets/_Project/Items/Definitions/EnemyEquipment_Rock.asset");
+
+            Assert.That(rock.CombatProfile, Is.Not.Null);
+            Assert.That(rock.CombatProfile.ProjectilePrefab, Is.Not.Null);
+            Assert.That(rock.CombatProfile.DamageBonus, Is.EqualTo(2));
+            Assert.That(rock.CombatProfile.ProjectileSpeed, Is.EqualTo(8f));
+            Assert.That(rock.ProjectileTargetLayerMask.value, Is.Not.Zero);
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Combat/CombatEquipmentAssetTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Combat/CombatEquipmentAssetTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d4341f425f1949f7b8f35dfbe6de3e3c

--- a/Assets/_Project/_Tests/EditMode/Combat/CombatEquipmentProfileTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Combat/CombatEquipmentProfileTests.cs
@@ -1,0 +1,161 @@
+using Castlebound.Gameplay.Combat;
+using Castlebound.Gameplay.AI;
+using Castlebound.Gameplay.Inventory;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Castlebound.Tests.Combat
+{
+    public class CombatEquipmentProfileTests
+    {
+        [Test]
+        public void CanEquip_RequiresEveryCapabilityWithoutEntityTypeChecks()
+        {
+            var profile = ScriptableObject.CreateInstance<CombatEquipmentProfile>();
+            try
+            {
+                profile.RequiredCapabilities =
+                    CombatEquipmentCapability.MeleeDelivery |
+                    CombatEquipmentCapability.HandSocket;
+
+                Assert.IsTrue(profile.CanEquip(
+                    CombatEquipmentCapability.MeleeDelivery |
+                    CombatEquipmentCapability.HandSocket |
+                    CombatEquipmentCapability.ProjectileDelivery));
+                Assert.IsFalse(profile.CanEquip(CombatEquipmentCapability.MeleeDelivery));
+            }
+            finally
+            {
+                Object.DestroyImmediate(profile);
+            }
+        }
+
+        [Test]
+        public void TryResolve_CombinesWearerStatsWithEquipmentEffects()
+        {
+            var profile = CreateProfile("club", 3, 1.45f, 0.4f, 0.85f);
+            try
+            {
+                var wearerStats = new CombatBaseStats(2, 1.2f, 0.6f, 0.15f);
+
+                bool resolved = CombatEquipmentResolver.TryResolve(
+                    wearerStats,
+                    CombatEquipmentCapability.MeleeDelivery | CombatEquipmentCapability.HandSocket,
+                    profile,
+                    out CombatEquipmentSnapshot snapshot);
+
+                Assert.IsTrue(resolved);
+                Assert.That(snapshot.EquipmentId, Is.EqualTo("club"));
+                Assert.That(snapshot.Damage, Is.EqualTo(5));
+                Assert.That(snapshot.AttackRate, Is.EqualTo(1.74f).Within(0.0001f));
+                Assert.That(snapshot.Range, Is.EqualTo(1f).Within(0.0001f));
+                Assert.That(snapshot.Knockback, Is.EqualTo(1f).Within(0.0001f));
+            }
+            finally
+            {
+                Object.DestroyImmediate(profile);
+            }
+        }
+
+        [Test]
+        public void ResolvedSnapshot_DoesNotChangeWhenProfileIsRetuned()
+        {
+            var profile = CreateProfile("club", 3, 1.45f, 0.4f, 0.85f);
+            try
+            {
+                CombatEquipmentResolver.TryResolve(
+                    new CombatBaseStats(1, 1f, 0.5f, 0f),
+                    CombatEquipmentCapability.MeleeDelivery | CombatEquipmentCapability.HandSocket,
+                    profile,
+                    out CombatEquipmentSnapshot snapshot);
+
+                profile.DamageBonus = 20;
+                profile.AttackRateMultiplier = 4f;
+
+                Assert.That(snapshot.Damage, Is.EqualTo(4));
+                Assert.That(snapshot.AttackRate, Is.EqualTo(1.45f).Within(0.0001f));
+            }
+            finally
+            {
+                Object.DestroyImmediate(profile);
+            }
+        }
+
+        [Test]
+        public void Dagger_ResolvesFasterAttackRateThanClubForSameWearer()
+        {
+            var dagger = CreateProfile("rusty_dagger", 3, 1.8f, 0.2f, 0.55f);
+            var club = CreateProfile("club", 3, 1.45f, 0.4f, 0.85f);
+            try
+            {
+                var wearerStats = new CombatBaseStats(1, 1f, 0.5f, 0f);
+                var capabilities = CombatEquipmentCapability.MeleeDelivery | CombatEquipmentCapability.HandSocket;
+
+                CombatEquipmentResolver.TryResolve(wearerStats, capabilities, dagger, out var daggerSnapshot);
+                CombatEquipmentResolver.TryResolve(wearerStats, capabilities, club, out var clubSnapshot);
+
+                Assert.That(daggerSnapshot.AttackRate, Is.GreaterThan(clubSnapshot.AttackRate));
+            }
+            finally
+            {
+                Object.DestroyImmediate(dagger);
+                Object.DestroyImmediate(club);
+            }
+        }
+
+        [Test]
+        public void SharedProfile_CanBackPlayerAndEnemyAdaptersWithoutSharingHolderData()
+        {
+            var profile = CreateProfile("club", 3, 1.45f, 0.4f, 0.85f);
+            var playerItem = ScriptableObject.CreateInstance<WeaponDefinition>();
+            var enemyLoadoutItem = ScriptableObject.CreateInstance<EnemyEquipmentDefinition>();
+            try
+            {
+                playerItem.CombatProfile = profile;
+                playerItem.HitboxSize = new Vector2(2f, 2f);
+                enemyLoadoutItem.CombatProfile = profile;
+                enemyLoadoutItem.CompatibleRole = EnemyAttackRole.Melee;
+                enemyLoadoutItem.HandleScale = new Vector2(0.75f, 0.75f);
+
+                Assert.That(playerItem.CombatProfile, Is.SameAs(profile));
+                Assert.That(enemyLoadoutItem.CombatProfile, Is.SameAs(profile));
+                Assert.That(playerItem.Damage, Is.EqualTo(3));
+                Assert.That(enemyLoadoutItem.ProjectileDamage, Is.EqualTo(3));
+                Assert.That(playerItem.HitboxSize, Is.EqualTo(new Vector2(2f, 2f)));
+                Assert.That(enemyLoadoutItem.HandleScale, Is.EqualTo(new Vector2(0.75f, 0.75f)));
+            }
+            finally
+            {
+                Object.DestroyImmediate(enemyLoadoutItem);
+                Object.DestroyImmediate(playerItem);
+                Object.DestroyImmediate(profile);
+            }
+        }
+
+        [Test]
+        public void RuntimeEquipmentComponents_ExposeOneHolderNeutralSourceContract()
+        {
+            Assert.That(typeof(ICombatEquipmentSource).IsAssignableFrom(typeof(PlayerWeaponController)), Is.True);
+            Assert.That(typeof(ICombatEquipmentSource).IsAssignableFrom(typeof(EnemyEquipment)), Is.True);
+        }
+
+        private static CombatEquipmentProfile CreateProfile(
+            string equipmentId,
+            int damageBonus,
+            float attackRateMultiplier,
+            float rangeBonus,
+            float knockbackBonus)
+        {
+            var profile = ScriptableObject.CreateInstance<CombatEquipmentProfile>();
+            profile.EquipmentId = equipmentId;
+            profile.DamageBonus = damageBonus;
+            profile.AttackRateMultiplier = attackRateMultiplier;
+            profile.RangeBonus = rangeBonus;
+            profile.KnockbackBonus = knockbackBonus;
+            profile.RequiredCapabilities =
+                CombatEquipmentCapability.MeleeDelivery |
+                CombatEquipmentCapability.HandSocket;
+            return profile;
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Combat/CombatEquipmentProfileTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Combat/CombatEquipmentProfileTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4d2ef899645a46cdb38912285581d692

--- a/Assets/_Project/_Tests/EditMode/Combat/EnemyProjectileAttackDeliveryTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Combat/EnemyProjectileAttackDeliveryTests.cs
@@ -1,4 +1,5 @@
 using Castlebound.Gameplay.AI;
+using Castlebound.Gameplay.Combat;
 using Castlebound.Gameplay.Projectile;
 using NUnit.Framework;
 using UnityEngine;
@@ -17,6 +18,7 @@ namespace Castlebound.Tests.Combat
             prefabObject.AddComponent<Rigidbody2D>();
             var projectilePrefab = prefabObject.AddComponent<ProjectileRuntime>();
             var equipment = ScriptableObject.CreateInstance<EnemyEquipmentDefinition>();
+            var profile = ScriptableObject.CreateInstance<CombatEquipmentProfile>();
             ProjectileRuntime launched = null;
 
             try
@@ -25,10 +27,12 @@ namespace Castlebound.Tests.Combat
                 enemy.transform.position = new Vector3(1f, 2f);
                 target.transform.position = new Vector3(4f, 2f);
                 equipment.CompatibleRole = EnemyAttackRole.Ranged;
-                equipment.ProjectilePrefab = projectilePrefab;
-                equipment.ProjectileSpeed = 7f;
-                equipment.ProjectileDamage = 2;
-                equipment.ProjectileLifetime = 3f;
+                equipment.CombatProfile = profile;
+                profile.RequiredCapabilities = CombatEquipmentCapability.ProjectileDelivery;
+                profile.ProjectilePrefab = projectilePrefab;
+                profile.ProjectileSpeed = 7f;
+                profile.DamageBonus = 2;
+                profile.ProjectileLifetime = 3f;
                 equipment.ProjectileTargetLayerMask = 1 << 6;
 
                 Assert.IsTrue(delivery.TryDeliver(target.transform, equipment));
@@ -43,6 +47,7 @@ namespace Castlebound.Tests.Combat
                     Object.DestroyImmediate(launched.gameObject);
                 }
 
+                Object.DestroyImmediate(profile);
                 Object.DestroyImmediate(equipment);
                 Object.DestroyImmediate(prefabObject);
                 Object.DestroyImmediate(target);
@@ -56,8 +61,11 @@ namespace Castlebound.Tests.Combat
             var enemy = new GameObject("RangedEnemy");
             var target = new GameObject("LockedTarget");
             var equipment = ScriptableObject.CreateInstance<EnemyEquipmentDefinition>();
+            var profile = ScriptableObject.CreateInstance<CombatEquipmentProfile>();
             try
             {
+                equipment.CombatProfile = profile;
+                profile.RequiredCapabilities = CombatEquipmentCapability.MeleeDelivery;
                 equipment.CompatibleRole = EnemyAttackRole.Melee;
                 var delivery = enemy.AddComponent<EnemyProjectileAttackDelivery>();
 
@@ -65,6 +73,7 @@ namespace Castlebound.Tests.Combat
             }
             finally
             {
+                Object.DestroyImmediate(profile);
                 Object.DestroyImmediate(equipment);
                 Object.DestroyImmediate(target);
                 Object.DestroyImmediate(enemy);

--- a/Assets/_Project/_Tests/EditMode/Combat/PlayerWeaponControllerTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Combat/PlayerWeaponControllerTests.cs
@@ -14,22 +14,29 @@ namespace Castlebound.Tests.Combat
             var inventoryComponent = playerGo.AddComponent<InventoryStateComponent>();
 
             var weapon = ScriptableObject.CreateInstance<WeaponDefinition>();
+            var profile = ScriptableObject.CreateInstance<CombatEquipmentProfile>();
             weapon.ItemId = "weapon_basic";
-            weapon.Damage = 5;
-            weapon.AttackSpeed = 1.2f;
+            weapon.CombatProfile = profile;
+            profile.DamageBonus = 5;
+            profile.AttackRateMultiplier = 1.2f;
             weapon.HitboxSize = new Vector2(1.2f, 0.6f);
-            weapon.Knockback = 3f;
+            profile.KnockbackBonus = 3f;
 
             var controller = playerGo.AddComponent<PlayerWeaponController>();
             controller.SetWeaponDefinitionResolver(new TestWeaponResolver(weapon));
+            CombatEquipmentProfile publishedProfile = null;
+            controller.EquipmentChanged += changedProfile => publishedProfile = changedProfile;
 
             inventoryComponent.State.AddWeapon("weapon_basic");
 
             controller.RefreshEquippedWeapon(inventoryComponent.State);
 
             Assert.AreEqual("weapon_basic", controller.CurrentWeaponId);
+            Assert.That(controller.ActiveCombatProfile, Is.SameAs(profile));
+            Assert.That(publishedProfile, Is.SameAs(profile));
 
             Object.DestroyImmediate(playerGo);
+            Object.DestroyImmediate(profile);
             Object.DestroyImmediate(weapon);
         }
 
@@ -40,11 +47,13 @@ namespace Castlebound.Tests.Combat
             var inventoryComponent = playerGo.AddComponent<InventoryStateComponent>();
 
             var weapon = ScriptableObject.CreateInstance<WeaponDefinition>();
+            var profile = ScriptableObject.CreateInstance<CombatEquipmentProfile>();
             weapon.ItemId = "weapon_basic";
-            weapon.Damage = 7;
-            weapon.AttackSpeed = 2.5f;
+            weapon.CombatProfile = profile;
+            profile.DamageBonus = 7;
+            profile.AttackRateMultiplier = 2.5f;
             weapon.HitboxSize = new Vector2(2f, 1f);
-            weapon.Knockback = 4f;
+            profile.KnockbackBonus = 4f;
 
             var controller = playerGo.AddComponent<PlayerWeaponController>();
             controller.SetWeaponDefinitionResolver(new TestWeaponResolver(weapon));
@@ -61,6 +70,7 @@ namespace Castlebound.Tests.Combat
             Assert.AreEqual(4f, stats.Knockback);
 
             Object.DestroyImmediate(playerGo);
+            Object.DestroyImmediate(profile);
             Object.DestroyImmediate(weapon);
         }
 
@@ -71,11 +81,13 @@ namespace Castlebound.Tests.Combat
             var inventoryComponent = playerGo.AddComponent<InventoryStateComponent>();
 
             var weapon = ScriptableObject.CreateInstance<WeaponDefinition>();
+            var profile = ScriptableObject.CreateInstance<CombatEquipmentProfile>();
             weapon.ItemId = "weapon_basic";
-            weapon.Damage = 7;
-            weapon.AttackSpeed = 2.5f;
+            weapon.CombatProfile = profile;
+            profile.DamageBonus = 7;
+            profile.AttackRateMultiplier = 2.5f;
             weapon.HitboxSize = new Vector2(2f, 1f);
-            weapon.Knockback = 4f;
+            profile.KnockbackBonus = 4f;
 
             var controller = playerGo.AddComponent<PlayerWeaponController>();
             controller.SetWeaponDefinitionResolver(new TestWeaponResolver(weapon));
@@ -95,6 +107,7 @@ namespace Castlebound.Tests.Combat
             Assert.AreEqual(0f, stats.Knockback);
 
             Object.DestroyImmediate(playerGo);
+            Object.DestroyImmediate(profile);
             Object.DestroyImmediate(weapon);
         }
 

--- a/Assets/_Project/_Tests/EditMode/Inventory/ItemDefinitionTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Inventory/ItemDefinitionTests.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using UnityEngine;
+using Castlebound.Gameplay.Combat;
 using Castlebound.Gameplay.Inventory;
 
 namespace Castlebound.Tests.Inventory
@@ -10,19 +11,24 @@ namespace Castlebound.Tests.Inventory
         public void WeaponDefinition_ValidFields_AreAccepted()
         {
             var asset = ScriptableObject.CreateInstance<WeaponDefinition>();
+            var profile = ScriptableObject.CreateInstance<CombatEquipmentProfile>();
 
             asset.ItemId = "weapon_basic";
             asset.DisplayName = "Basic Sword";
-            asset.Damage = 5;
-            asset.AttackSpeed = 1.2f;
+            asset.CombatProfile = profile;
+            profile.DamageBonus = 5;
+            profile.AttackRateMultiplier = 1.2f;
             asset.HitboxSize = new Vector2(1.2f, 0.6f);
-            asset.Knockback = 3f;
+            profile.KnockbackBonus = 3f;
 
             Assert.IsTrue(asset.IsValidId);
             Assert.Greater(asset.Damage, 0);
             Assert.Greater(asset.AttackSpeed, 0f);
             Assert.Greater(asset.HitboxSize.x, 0f);
             Assert.Greater(asset.HitboxSize.y, 0f);
+
+            Object.DestroyImmediate(profile);
+            Object.DestroyImmediate(asset);
         }
 
         [Test]

--- a/Assets/_Project/_Tests/EditMode/Player/WeaponHandTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Player/WeaponHandTests.cs
@@ -65,7 +65,7 @@ namespace Castlebound.Tests.Player
 
             Object.DestroyImmediate(root);
             Object.DestroyImmediate(resolverObject);
-            Object.DestroyImmediate(weaponA);
+            DestroyWeaponDefinition(weaponA);
         }
 
         [Test]
@@ -101,7 +101,7 @@ namespace Castlebound.Tests.Player
 
             Object.DestroyImmediate(root);
             Object.DestroyImmediate(resolverObject);
-            Object.DestroyImmediate(weaponA);
+            DestroyWeaponDefinition(weaponA);
         }
 
         [Test]
@@ -139,8 +139,8 @@ namespace Castlebound.Tests.Player
 
             Object.DestroyImmediate(root);
             Object.DestroyImmediate(resolverObject);
-            Object.DestroyImmediate(weaponA);
-            Object.DestroyImmediate(weaponB);
+            DestroyWeaponDefinition(weaponA);
+            DestroyWeaponDefinition(weaponB);
         }
 
         [Test]
@@ -179,15 +179,28 @@ namespace Castlebound.Tests.Player
 
             Object.DestroyImmediate(root);
             Object.DestroyImmediate(resolverObject);
-            Object.DestroyImmediate(weaponA);
+            DestroyWeaponDefinition(weaponA);
         }
 
         private static WeaponDefinition CreateWeaponDefinition(string id, Sprite sprite)
         {
             var definition = ScriptableObject.CreateInstance<WeaponDefinition>();
+            var profile = ScriptableObject.CreateInstance<CombatEquipmentProfile>();
             definition.ItemId = id;
-            definition.HandSprite = sprite;
+            definition.CombatProfile = profile;
+            profile.HandSprite = sprite;
             return definition;
+        }
+
+        private static void DestroyWeaponDefinition(WeaponDefinition definition)
+        {
+            if (definition == null)
+            {
+                return;
+            }
+
+            Object.DestroyImmediate(definition.CombatProfile);
+            Object.DestroyImmediate(definition);
         }
 
         private static Sprite CreateSprite(int size, Vector2 pivot)

--- a/Assets/_Project/_Tests/PlayMode/Spawning/GoblinEquipmentWavePlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/Spawning/GoblinEquipmentWavePlayTests.cs
@@ -2,6 +2,8 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
 using Castlebound.Gameplay.AI;
+using Castlebound.Gameplay.Combat;
+using Castlebound.Gameplay.Inventory;
 using Castlebound.Gameplay.Spawning;
 using NUnit.Framework;
 using UnityEngine;
@@ -16,6 +18,8 @@ namespace Castlebound.Tests.PlayMode.Spawning
         {
             var unarmed = CreateEquipment("unarmed", EnemyAttackRole.Melee);
             var club = CreateEquipment("club", EnemyAttackRole.Melee);
+            var playerClub = ScriptableObject.CreateInstance<WeaponDefinition>();
+            playerClub.CombatProfile = club.CombatProfile;
             var prefab = CreateEnemyPrefab("EquipmentMeleePrefab", unarmed, ranged: false);
             var runnerObject = new GameObject("EquipmentSpawnerRunner");
             var runner = runnerObject.AddComponent<EnemySpawnerRunner>();
@@ -34,6 +38,9 @@ namespace Castlebound.Tests.PlayMode.Spawning
                 var clone = GameObject.Find("EquipmentMeleePrefab(Clone)");
                 Assert.NotNull(clone);
                 Assert.That(clone.GetComponent<EnemyEquipment>().ActiveEquipment, Is.SameAs(club));
+                Assert.That(
+                    clone.GetComponent<EnemyEquipment>().ActiveEquipment.CombatProfile,
+                    Is.SameAs(playerClub.CombatProfile));
                 yield return null;
                 Assert.That(clone.GetComponent<EnemyEquipment>().ActiveEquipment, Is.SameAs(club));
             }
@@ -42,8 +49,9 @@ namespace Castlebound.Tests.PlayMode.Spawning
                 DestroyByName("EquipmentMeleePrefab(Clone)");
                 Object.DestroyImmediate(runnerObject);
                 Object.DestroyImmediate(prefab);
-                Object.DestroyImmediate(club);
-                Object.DestroyImmediate(unarmed);
+                Object.DestroyImmediate(playerClub);
+                DestroyEquipment(club);
+                DestroyEquipment(unarmed);
             }
         }
 
@@ -80,17 +88,33 @@ namespace Castlebound.Tests.PlayMode.Spawning
                 DestroyByName("EquipmentRangedPrefab(Clone)");
                 Object.DestroyImmediate(runnerObject);
                 Object.DestroyImmediate(prefab);
-                Object.DestroyImmediate(club);
-                Object.DestroyImmediate(rock);
+                DestroyEquipment(club);
+                DestroyEquipment(rock);
             }
         }
 
         private static EnemyEquipmentDefinition CreateEquipment(string id, EnemyAttackRole role)
         {
             var definition = ScriptableObject.CreateInstance<EnemyEquipmentDefinition>();
-            definition.EquipmentId = id;
+            var profile = ScriptableObject.CreateInstance<CombatEquipmentProfile>();
+            profile.EquipmentId = id;
+            profile.RequiredCapabilities = role == EnemyAttackRole.Ranged
+                ? CombatEquipmentCapability.ProjectileDelivery
+                : CombatEquipmentCapability.MeleeDelivery;
+            definition.CombatProfile = profile;
             definition.CompatibleRole = role;
             return definition;
+        }
+
+        private static void DestroyEquipment(EnemyEquipmentDefinition definition)
+        {
+            if (definition == null)
+            {
+                return;
+            }
+
+            Object.DestroyImmediate(definition.CombatProfile);
+            Object.DestroyImmediate(definition);
         }
 
         private static GameObject CreateEnemyPrefab(

--- a/TEST_LOG.md
+++ b/TEST_LOG.md
@@ -1,3 +1,20 @@
+## 2026-08-03 - refactor-equipment-entity-agnostic-profiles
+
+### Summary
+- Added wearer-neutral combat equipment profiles, capability validation, immutable resolved combat snapshots, and a shared runtime equipment-source contract.
+- Separated shared combat effects from player inventory/presentation data and enemy spawning, role, grip, and target-layer data.
+- Migrated player weapons and enemy unarmed, club, and rock definitions, with one shared club profile used by both player and enemy adapters.
+
+### New or Updated Tests
+**EditMode**
+- CombatEquipmentProfileTests, CombatEquipmentAssetTests, ItemDefinitionTests, PlayerWeaponControllerTests, WeaponHandTests, EnemyEquipmentTests, and EnemyProjectileAttackDeliveryTests — capability checks, stat resolution, immutable snapshots, source events, shared-profile ownership, authored asset migration, and player/enemy regressions.
+
+**PlayMode**
+- GoblinEquipmentWavePlayTests — spawned enemy equipment retains the same shared profile referenced by a player weapon adapter.
+
+### Notes
+- EditMode and PlayMode suites pass per user validation; manual behavior validation confirmed existing equipment and combat behavior remain unchanged.
+
 ## 2026-08-03 - feat-spawning-enemy-equipment-distribution
 
 ### Summary


### PR DESCRIPTION
## Why
Player and enemy equipment stored overlapping combat data in separate definitions, preventing one weapon profile from affecting any capable holder consistently. This establishes a wearer-neutral equipment boundary while keeping player inventory data and enemy spawning/AI data separate.

## What changed
- Added shared combat equipment profiles for damage, attack-rate, range, knockback, delivery requirements, projectile payload, and visual identity
- Added capability-based stat resolution into immutable combat snapshots
- Added a holder-neutral runtime equipment-source contract implemented by player and enemy equipment components
- Migrated authored player weapons and enemy unarmed, club, and rock definitions, including one club profile shared across player and enemy adapters
- Kept live attack cadence and animation-speed consumption deferred to #269

## How to test
1. Open the MainPrototype scene and inspect representative player and enemy equipment behavior
2. Press Play → verify existing weapons and goblin loadouts behave unchanged
3. Run tests:
   - EditMode
   - PlayMode

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated (N/A - no scene changes required)
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched (TEST_LOG.md updated)

## Related
- Closes #281