### PR TITLE
feat(player): add frontal block and timed parry

### DIFF
--- a/Assets/_Project/Prefabs/Player.prefab
+++ b/Assets/_Project/Prefabs/Player.prefab
@@ -126,6 +126,8 @@ GameObject:
   - component: {fileID: 9150000000000000205}
   - component: {fileID: 9150000000000000301}
   - component: {fileID: 9150000000000000401}
+  - component: {fileID: 9150000000000000701}
+  - component: {fileID: 9150000000000000702}
   m_Layer: 3
   m_Name: Player
   m_TagString: Player
@@ -260,6 +262,7 @@ MonoBehaviour:
   facingPolicyResolver: {fileID: 9150000000000000203}
   attackAnimationDriver: {fileID: 9150000000000000204}
   attackLoop: {fileID: 9150000000000000205}
+  defenseController: {fileID: 9150000000000000701}
   baseAttackDamage: 1
   baseAttackRate: 1.5
   movementOrchestrator:
@@ -793,3 +796,42 @@ MonoBehaviour:
   m_EditorClassIdentifier:
   balanceStation: {fileID: 11400000, guid: d70caaeb4e66400f8127d62f459cae21, type: 2}
   waveRunner: {fileID: 0}
+--- !u!114 &9150000000000000701
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8325390509751579795}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: efd27fd73d1843d6bdd161aed5429f8c, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  parryWindowDuration: 0.15
+  recoveryDuration: 0.15
+  blockArcDegrees: 120
+  guardingMovementMultiplier: 0.6
+  health: {fileID: 2634735562689669640}
+  playerController: {fileID: 4369444282720785943}
+--- !u!114 &9150000000000000702
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8325390509751579795}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0409bb1fc5514739a10fb70ce8a6fb18, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  defenseController: {fileID: 9150000000000000701}
+  arcRenderer: {fileID: 0}
+  segmentCount: 16
+  radius: 1.15
+  lineWidth: 0.08
+  parryFlashDuration: 0.12
+  parryWindowColor: {r: 0.25, g: 0.95, b: 1, a: 0.7}
+  blockingColor: {r: 0.25, g: 0.6, b: 1, a: 0.55}
+  parrySuccessColor: {r: 1, g: 0.9, b: 0.2, a: 0.95}

--- a/Assets/_Project/Scenes/MainPrototype.unity
+++ b/Assets/_Project/Scenes/MainPrototype.unity
@@ -2751,6 +2751,7 @@ RectTransform:
   - {fileID: 3001000001}
   - {fileID: 3002000001}
   - {fileID: 3003000001}
+  - {fileID: 3004000001}
   - {fileID: 904751786}
   - {fileID: 769406675}
   - {fileID: 1856670276}
@@ -5434,6 +5435,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   movementZone: {fileID: 3001000004}
   aimAttackZone: {fileID: 3002000004}
+  defenseAimButton: {fileID: 3004000004}
   repairButton: {fileID: 3003000004}
   playerInput: {fileID: 0}
   rightStickAttackDeadzone: 160
@@ -5631,6 +5633,96 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   <AttackDeadzone>k__BackingField: 50
+--- !u!1 &3004000000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3004000001}
+  - component: {fileID: 3004000002}
+  - component: {fileID: 3004000003}
+  - component: {fileID: 3004000004}
+  m_Layer: 5
+  m_Name: TouchDefenseAimButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3004000001
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3004000000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 977390126}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.82, y: 0.22}
+  m_AnchorMax: {x: 0.82, y: 0.22}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 120, y: 120}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3004000002
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3004000000}
+  m_CullTransparentMesh: 1
+--- !u!114 &3004000003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3004000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.2, g: 0.55, b: 0.9, a: 0.5}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &3004000004
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3004000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c1bd09cfd2464bd89a759fac2ba047df, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  softAnchorRadius: 160
+  maxAnchorDrift: 170
 --- !u!1 &3003000000
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/CombatDamageType.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/CombatDamageType.cs
@@ -1,0 +1,9 @@
+namespace Castlebound.Gameplay.Combat
+{
+    public enum CombatDamageType
+    {
+        Other,
+        Melee,
+        Projectile
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/CombatDamageType.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/CombatDamageType.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 574921f987804a51ba4aa4e4825bb980

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/EnemyMeleeAttackDelivery.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/EnemyMeleeAttackDelivery.cs
@@ -76,8 +76,38 @@ public class EnemyMeleeAttackDelivery : MonoBehaviour, IEnemyAttackDelivery
             return true;
         }
 
+        if (TryResolvePlayerHitReceiver(target, out var playerHitReceiver))
+        {
+            playerHitReceiver.ReceiveHit(new PlayerHitRequest(
+                resolvedDamage,
+                gameObject,
+                transform.position,
+                CombatDamageType.Melee));
+            return true;
+        }
+
         target.TakeDamage(resolvedDamage);
         return true;
+    }
+
+    private static bool TryResolvePlayerHitReceiver(
+        IDamageable target,
+        out IPlayerHitReceiver playerHitReceiver)
+    {
+        playerHitReceiver = null;
+        if (!(target is Component targetComponent))
+            return false;
+
+        playerHitReceiver = targetComponent.GetComponent<IPlayerHitReceiver>();
+        if (playerHitReceiver != null)
+            return true;
+
+        playerHitReceiver = targetComponent.GetComponentInParent<IPlayerHitReceiver>();
+        if (playerHitReceiver != null)
+            return true;
+
+        playerHitReceiver = targetComponent.GetComponentInChildren<IPlayerHitReceiver>();
+        return playerHitReceiver != null;
     }
 
     private static IDamageable ResolveDamageable(Transform lockedTarget)

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/Health.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/Health.cs
@@ -30,15 +30,21 @@ public class Health : MonoBehaviour, IDamageable, IHealable
 
     public void TakeDamage(int amount)
     {
-        if (current <= 0 || amount <= 0) return;
+        ApplyDamage(amount);
+    }
+
+    public int ApplyDamage(int amount)
+    {
+        if (current <= 0 || amount <= 0) return 0;
         int previous = current;
         current = Mathf.Max(0, current - amount);
+        int appliedDamage = previous - current;
         OnHealthChanged?.Invoke(current, maxHealth);
 
         if (CompareTag("Enemy"))
-            RunStatsEvents.RaiseDamageDealt(previous - current);
+            RunStatsEvents.RaiseDamageDealt(appliedDamage);
         else if (CompareTag("Player"))
-            RunStatsEvents.RaiseDamageTaken(previous - current);
+            RunStatsEvents.RaiseDamageTaken(appliedDamage);
 
         if (CompareTag("Player") && playerHitFeedbackChannel != null)
         {
@@ -46,6 +52,7 @@ public class Health : MonoBehaviour, IDamageable, IHealable
         }
 
         if (current <= 0) Die();
+        return appliedDamage;
     }
 
     public void Heal(int amount)

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/IPlayerHitReceiver.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/IPlayerHitReceiver.cs
@@ -1,0 +1,7 @@
+namespace Castlebound.Gameplay.Combat
+{
+    public interface IPlayerHitReceiver
+    {
+        PlayerHitResult ReceiveHit(PlayerHitRequest request);
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/IPlayerHitReceiver.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/IPlayerHitReceiver.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0dd5f1d230514e28bb11a734b8975197

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/PlayerDefenseHitResolver.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/PlayerDefenseHitResolver.cs
@@ -1,0 +1,67 @@
+using UnityEngine;
+
+namespace Castlebound.Gameplay.Combat
+{
+    public static class PlayerDefenseHitResolver
+    {
+        private const float DirectionEpsilon = 0.000001f;
+        private const float AngleTolerance = 0.0001f;
+
+        public static PlayerHitResult Resolve(
+            PlayerHitRequest request,
+            PlayerDefenseState defenseState,
+            Vector2 playerPosition,
+            Vector2 facingDirection,
+            float blockArcDegrees)
+        {
+            if (request.DamageType != CombatDamageType.Melee
+                || !IsGuarding(defenseState)
+                || !IsWithinBlockArc(
+                    playerPosition,
+                    facingDirection,
+                    request.AttackOrigin,
+                    blockArcDegrees))
+            {
+                return new PlayerHitResult(request, PlayerHitOutcome.Damaged, request.Damage);
+            }
+
+            PlayerHitOutcome outcome = defenseState == PlayerDefenseState.ParryWindow
+                ? PlayerHitOutcome.Parried
+                : PlayerHitOutcome.Blocked;
+            return new PlayerHitResult(request, outcome, 0);
+        }
+
+        public static bool IsWithinBlockArc(
+            Vector2 playerPosition,
+            Vector2 facingDirection,
+            Vector2 attackOrigin,
+            float blockArcDegrees)
+        {
+            Vector2 directionToAttacker = attackOrigin - playerPosition;
+            if (facingDirection.sqrMagnitude <= DirectionEpsilon
+                || directionToAttacker.sqrMagnitude <= DirectionEpsilon)
+            {
+                return false;
+            }
+
+            float safeArc = NormalizeArc(blockArcDegrees);
+            float angle = Vector2.Angle(facingDirection, directionToAttacker);
+            return angle <= safeArc * 0.5f + AngleTolerance;
+        }
+
+        private static bool IsGuarding(PlayerDefenseState defenseState)
+        {
+            return defenseState == PlayerDefenseState.ParryWindow
+                || defenseState == PlayerDefenseState.Blocking;
+        }
+
+        private static float NormalizeArc(float blockArcDegrees)
+        {
+            if (float.IsNaN(blockArcDegrees) || blockArcDegrees <= 0f)
+                return 0f;
+            if (float.IsPositiveInfinity(blockArcDegrees))
+                return 360f;
+            return Mathf.Clamp(blockArcDegrees, 0f, 360f);
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/PlayerDefenseHitResolver.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/PlayerDefenseHitResolver.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 43e0465c7c9e43ae9a7a427f4ed02bf9

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/PlayerDefenseState.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/PlayerDefenseState.cs
@@ -1,0 +1,10 @@
+namespace Castlebound.Gameplay.Combat
+{
+    public enum PlayerDefenseState
+    {
+        Idle,
+        ParryWindow,
+        Blocking,
+        Recovery
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/PlayerDefenseState.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/PlayerDefenseState.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f31b50d17ad74283b67c3db37453d92f

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/PlayerDefenseStateMachine.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/PlayerDefenseStateMachine.cs
@@ -1,0 +1,83 @@
+using UnityEngine;
+
+namespace Castlebound.Gameplay.Combat
+{
+    public sealed class PlayerDefenseStateMachine
+    {
+        private const float BoundaryTolerance = 0.000001f;
+
+        private readonly float parryWindowDuration;
+        private readonly float recoveryDuration;
+        private float elapsed;
+
+        public PlayerDefenseStateMachine(float parryWindowDuration, float recoveryDuration)
+        {
+            this.parryWindowDuration = NormalizeDuration(parryWindowDuration);
+            this.recoveryDuration = NormalizeDuration(recoveryDuration);
+        }
+
+        public PlayerDefenseState State { get; private set; } = PlayerDefenseState.Idle;
+        public bool IsGuarding => State == PlayerDefenseState.ParryWindow
+            || State == PlayerDefenseState.Blocking;
+        public bool CanAttack => State == PlayerDefenseState.Idle;
+
+        public bool BeginDefense()
+        {
+            if (State != PlayerDefenseState.Idle)
+                return false;
+
+            elapsed = 0f;
+            State = PlayerDefenseState.ParryWindow;
+            return true;
+        }
+
+        public bool ReleaseDefense()
+        {
+            if (!IsGuarding)
+                return false;
+
+            elapsed = 0f;
+            State = PlayerDefenseState.Recovery;
+            return true;
+        }
+
+        public void Advance(float deltaTime)
+        {
+            float safeDelta = NormalizeDelta(deltaTime);
+
+            if (State == PlayerDefenseState.ParryWindow)
+            {
+                elapsed += safeDelta;
+                if (elapsed > parryWindowDuration + BoundaryTolerance)
+                    State = PlayerDefenseState.Blocking;
+                return;
+            }
+
+            if (State != PlayerDefenseState.Recovery)
+                return;
+
+            elapsed += safeDelta;
+            if (elapsed + BoundaryTolerance < recoveryDuration)
+                return;
+
+            elapsed = 0f;
+            State = PlayerDefenseState.Idle;
+        }
+
+        private static float NormalizeDuration(float duration)
+        {
+            if (float.IsNaN(duration) || float.IsInfinity(duration) || duration <= 0f)
+                return 0f;
+            return duration;
+        }
+
+        private static float NormalizeDelta(float deltaTime)
+        {
+            if (float.IsNaN(deltaTime) || float.IsNegativeInfinity(deltaTime) || deltaTime <= 0f)
+                return 0f;
+            if (float.IsPositiveInfinity(deltaTime))
+                return float.MaxValue;
+            return deltaTime;
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/PlayerDefenseStateMachine.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/PlayerDefenseStateMachine.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: dcf7eb5fc3024df885ad37053226c3c1

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/PlayerHitOutcome.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/PlayerHitOutcome.cs
@@ -1,0 +1,9 @@
+namespace Castlebound.Gameplay.Combat
+{
+    public enum PlayerHitOutcome
+    {
+        Damaged,
+        Blocked,
+        Parried
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/PlayerHitOutcome.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/PlayerHitOutcome.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c68fb98dcb9d47178e516582639ef0e7

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/PlayerHitRequest.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/PlayerHitRequest.cs
@@ -1,0 +1,24 @@
+using UnityEngine;
+
+namespace Castlebound.Gameplay.Combat
+{
+    public readonly struct PlayerHitRequest
+    {
+        public PlayerHitRequest(
+            int damage,
+            GameObject attacker,
+            Vector2 attackOrigin,
+            CombatDamageType damageType)
+        {
+            Damage = Mathf.Max(0, damage);
+            Attacker = attacker;
+            AttackOrigin = attackOrigin;
+            DamageType = damageType;
+        }
+
+        public int Damage { get; }
+        public GameObject Attacker { get; }
+        public Vector2 AttackOrigin { get; }
+        public CombatDamageType DamageType { get; }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/PlayerHitRequest.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/PlayerHitRequest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 609109ee12b94887bccd7686fc6044f2

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/PlayerHitResult.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/PlayerHitResult.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+
+namespace Castlebound.Gameplay.Combat
+{
+    public readonly struct PlayerHitResult
+    {
+        public PlayerHitResult(PlayerHitRequest request, PlayerHitOutcome outcome, int appliedDamage)
+        {
+            Request = request;
+            Outcome = outcome;
+            AppliedDamage = Mathf.Clamp(appliedDamage, 0, request.Damage);
+        }
+
+        public PlayerHitRequest Request { get; }
+        public PlayerHitOutcome Outcome { get; }
+        public int AppliedDamage { get; }
+        public int RequestedDamage => Request.Damage;
+        public GameObject Attacker => Request.Attacker;
+        public Vector2 AttackOrigin => Request.AttackOrigin;
+        public CombatDamageType DamageType => Request.DamageType;
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/PlayerHitResult.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/PlayerHitResult.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 841c1f1d63924444bde296b82d0370a2

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerDefenseController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerDefenseController.cs
@@ -1,0 +1,181 @@
+using System;
+using Castlebound.Gameplay.Combat;
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+[RequireComponent(typeof(Health))]
+public class PlayerDefenseController : MonoBehaviour, IPlayerHitReceiver
+{
+    [Header("Timing")]
+    [SerializeField, Min(0f)] private float parryWindowDuration = 0.15f;
+    [SerializeField, Min(0f)] private float recoveryDuration = 0.15f;
+
+    [Header("Guard")]
+    [SerializeField, Range(0f, 360f)] private float blockArcDegrees = 120f;
+    [SerializeField, Range(0f, 1f)] private float guardingMovementMultiplier = 0.6f;
+
+    [Header("References")]
+    [SerializeField] private Health health;
+    [SerializeField] private PlayerController playerController;
+    [SerializeField] private bool useReleaseFallbackPolling = true;
+
+    private PlayerDefenseStateMachine stateMachine;
+    private Func<bool> isDefenseStillPressedEvaluator;
+    private bool releaseFallbackArmed;
+
+    public PlayerDefenseState State => EnsureStateMachine().State;
+    public bool IsGuarding => EnsureStateMachine().IsGuarding;
+    public bool CanAttack => EnsureStateMachine().CanAttack;
+    public float MovementSpeedMultiplier => IsGuarding ? guardingMovementMultiplier : 1f;
+    public float BlockArcDegrees => blockArcDegrees;
+
+    public event Action<PlayerDefenseState> StateChanged;
+    public event Action<PlayerHitResult> HitResolved;
+
+    private void Awake()
+    {
+        EnsureReferences();
+        RebuildStateMachine();
+    }
+
+    private void FixedUpdate()
+    {
+        Tick(Time.fixedDeltaTime);
+    }
+
+    private void OnValidate()
+    {
+        parryWindowDuration = Mathf.Max(0f, parryWindowDuration);
+        recoveryDuration = Mathf.Max(0f, recoveryDuration);
+        blockArcDegrees = Mathf.Clamp(blockArcDegrees, 0f, 360f);
+        guardingMovementMultiplier = Mathf.Clamp01(guardingMovementMultiplier);
+    }
+
+    public void OnDefend(InputValue value)
+    {
+        OnDefensePressedStateChanged(value.isPressed);
+    }
+
+    public void OnDefensePressedStateChanged(bool isPressed)
+    {
+        releaseFallbackArmed = isPressed;
+        SetDefensePressed(isPressed);
+    }
+
+    public void SetDefensePressed(bool isPressed)
+    {
+        PlayerDefenseState previous = State;
+        bool changed = isPressed
+            ? stateMachine.BeginDefense()
+            : stateMachine.ReleaseDefense();
+
+        if (!changed)
+            return;
+
+        if (isPressed)
+        {
+            EnsureReferences();
+            playerController?.ClearAttackInputState();
+        }
+
+        PublishStateChange(previous);
+    }
+
+    public void Tick(float deltaTime)
+    {
+        if (releaseFallbackArmed && IsGuarding && useReleaseFallbackPolling && !IsDefenseStillPressed())
+        {
+            releaseFallbackArmed = false;
+            SetDefensePressed(false);
+        }
+
+        PlayerDefenseState previous = State;
+        stateMachine.Advance(deltaTime);
+        PublishStateChange(previous);
+    }
+
+    public PlayerHitResult ReceiveHit(PlayerHitRequest request)
+    {
+        EnsureReferences();
+        PlayerHitResult result = PlayerDefenseHitResolver.Resolve(
+            request,
+            State,
+            transform.position,
+            ResolveFacingDirection(),
+            blockArcDegrees);
+
+        if (result.AppliedDamage > 0)
+        {
+            int appliedDamage = health != null ? health.ApplyDamage(result.AppliedDamage) : 0;
+            result = new PlayerHitResult(request, result.Outcome, appliedDamage);
+        }
+
+        HitResolved?.Invoke(result);
+        return result;
+    }
+
+    public void Configure(
+        float parryWindowSeconds,
+        float recoverySeconds,
+        float arcDegrees,
+        float movementMultiplier,
+        Func<bool> pressedEvaluator = null)
+    {
+        parryWindowDuration = Mathf.Max(0f, parryWindowSeconds);
+        recoveryDuration = Mathf.Max(0f, recoverySeconds);
+        blockArcDegrees = Mathf.Clamp(arcDegrees, 0f, 360f);
+        guardingMovementMultiplier = Mathf.Clamp01(movementMultiplier);
+        isDefenseStillPressedEvaluator = pressedEvaluator;
+        RebuildStateMachine();
+    }
+
+    private PlayerDefenseStateMachine EnsureStateMachine()
+    {
+        if (stateMachine == null)
+            RebuildStateMachine();
+        return stateMachine;
+    }
+
+    private void RebuildStateMachine()
+    {
+        stateMachine = new PlayerDefenseStateMachine(parryWindowDuration, recoveryDuration);
+    }
+
+    private void EnsureReferences()
+    {
+        if (health == null)
+            health = GetComponent<Health>();
+        if (playerController == null)
+            playerController = GetComponent<PlayerController>();
+    }
+
+    private Vector2 ResolveFacingDirection()
+    {
+        return playerController != null
+            ? playerController.CurrentFacingDirection
+            : -(Vector2)transform.up;
+    }
+
+    private bool IsDefenseStillPressed()
+    {
+        if (isDefenseStillPressedEvaluator != null)
+            return isDefenseStillPressedEvaluator();
+
+        if (Mouse.current != null && Mouse.current.rightButton.isPressed)
+            return true;
+
+        foreach (Gamepad gamepad in Gamepad.all)
+        {
+            if (gamepad.leftTrigger.ReadValue() > 0.5f)
+                return true;
+        }
+
+        return false;
+    }
+
+    private void PublishStateChange(PlayerDefenseState previous)
+    {
+        if (previous != State)
+            StateChanged?.Invoke(State);
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerDefenseController.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerDefenseController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: efd27fd73d1843d6bdd161aed5429f8c

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerGuardArcPresenter.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerGuardArcPresenter.cs
@@ -1,0 +1,182 @@
+using Castlebound.Gameplay.Combat;
+using UnityEngine;
+
+public class PlayerGuardArcPresenter : MonoBehaviour
+{
+    [SerializeField] private PlayerDefenseController defenseController;
+    [SerializeField] private LineRenderer arcRenderer;
+    [SerializeField, Min(2)] private int segmentCount = 16;
+    [SerializeField, Min(0f)] private float radius = 1.15f;
+    [SerializeField, Min(0f)] private float lineWidth = 0.08f;
+    [SerializeField, Min(0f)] private float parryFlashDuration = 0.12f;
+    [SerializeField] private Color parryWindowColor = new Color(0.25f, 0.95f, 1f, 0.7f);
+    [SerializeField] private Color blockingColor = new Color(0.25f, 0.6f, 1f, 0.55f);
+    [SerializeField] private Color parrySuccessColor = new Color(1f, 0.9f, 0.2f, 0.95f);
+
+    private float parryFlashRemaining;
+    private Material runtimeMaterial;
+    private PlayerDefenseController subscribedDefenseController;
+
+    public Color ParrySuccessColor => parrySuccessColor;
+
+    private void OnEnable()
+    {
+        EnsureReferences();
+        BindDefenseEvents();
+        RefreshPresentation();
+    }
+
+    private void OnDisable() => UnbindDefenseEvents();
+
+    private void OnDestroy()
+    {
+        if (runtimeMaterial == null)
+            return;
+
+        if (Application.isPlaying)
+            Destroy(runtimeMaterial);
+        else
+            DestroyImmediate(runtimeMaterial);
+    }
+
+    private void Update()
+    {
+        if (parryFlashRemaining <= 0f)
+            return;
+
+        parryFlashRemaining = Mathf.Max(0f, parryFlashRemaining - Time.deltaTime);
+        if (parryFlashRemaining <= 0f)
+            ApplyStateColor();
+    }
+
+    private void OnValidate()
+    {
+        segmentCount = Mathf.Max(2, segmentCount);
+        radius = Mathf.Max(0f, radius);
+        lineWidth = Mathf.Max(0f, lineWidth);
+        parryFlashDuration = Mathf.Max(0f, parryFlashDuration);
+    }
+
+    public void RefreshPresentation()
+    {
+        EnsureReferences();
+        BindDefenseEvents();
+        ConfigureRenderer();
+        BuildArc();
+        ApplyStateColor();
+    }
+
+    private void HandleStateChanged(PlayerDefenseState state)
+    {
+        parryFlashRemaining = 0f;
+        ApplyStateColor();
+    }
+
+    private void HandleHitResolved(PlayerHitResult result)
+    {
+        if (result.Outcome != PlayerHitOutcome.Parried || arcRenderer == null)
+            return;
+
+        parryFlashRemaining = parryFlashDuration;
+        SetColor(parrySuccessColor);
+    }
+
+    private void ConfigureRenderer()
+    {
+        if (arcRenderer == null)
+            return;
+
+        arcRenderer.useWorldSpace = false;
+        arcRenderer.loop = false;
+        arcRenderer.widthMultiplier = lineWidth;
+        arcRenderer.numCapVertices = 2;
+        arcRenderer.sortingOrder = 2;
+        if (arcRenderer.sharedMaterial == null)
+        {
+            Shader shader = Shader.Find("Sprites/Default");
+            if (shader != null)
+            {
+                runtimeMaterial = new Material(shader);
+                arcRenderer.sharedMaterial = runtimeMaterial;
+            }
+        }
+    }
+
+    private void BuildArc()
+    {
+        if (arcRenderer == null)
+            return;
+
+        float arcDegrees = defenseController != null ? defenseController.BlockArcDegrees : 120f;
+        arcRenderer.positionCount = segmentCount + 1;
+        for (int index = 0; index <= segmentCount; index++)
+        {
+            float progress = index / (float)segmentCount;
+            float angle = Mathf.Lerp(-arcDegrees * 0.5f, arcDegrees * 0.5f, progress);
+            Vector2 direction = Quaternion.Euler(0f, 0f, angle) * Vector2.down;
+            arcRenderer.SetPosition(index, direction * radius);
+        }
+    }
+
+    private void ApplyStateColor()
+    {
+        if (arcRenderer == null)
+            return;
+
+        PlayerDefenseState state = defenseController != null
+            ? defenseController.State
+            : PlayerDefenseState.Idle;
+        arcRenderer.enabled = state == PlayerDefenseState.ParryWindow ||
+                              state == PlayerDefenseState.Blocking;
+
+        switch (state)
+        {
+            case PlayerDefenseState.ParryWindow:
+                SetColor(parryWindowColor);
+                break;
+            case PlayerDefenseState.Blocking:
+                SetColor(blockingColor);
+                break;
+        }
+    }
+
+    private void SetColor(Color color)
+    {
+        arcRenderer.startColor = color;
+        arcRenderer.endColor = color;
+    }
+
+    private void EnsureReferences()
+    {
+        if (defenseController == null)
+            defenseController = GetComponentInParent<PlayerDefenseController>();
+        if (arcRenderer == null)
+            arcRenderer = GetComponent<LineRenderer>();
+        if (arcRenderer == null)
+            arcRenderer = gameObject.AddComponent<LineRenderer>();
+    }
+
+    private void BindDefenseEvents()
+    {
+        if (subscribedDefenseController == defenseController)
+            return;
+
+        UnbindDefenseEvents();
+        if (defenseController == null)
+            return;
+
+        defenseController.StateChanged += HandleStateChanged;
+        defenseController.HitResolved += HandleHitResolved;
+        subscribedDefenseController = defenseController;
+    }
+
+    private void UnbindDefenseEvents()
+    {
+        if (subscribedDefenseController == null)
+            return;
+
+        subscribedDefenseController.StateChanged -= HandleStateChanged;
+        subscribedDefenseController.HitResolved -= HandleHitResolved;
+        subscribedDefenseController = null;
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerGuardArcPresenter.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerGuardArcPresenter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0409bb1fc5514739a10fb70ce8a6fb18

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerMovementOrchestrator.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerMovementOrchestrator.cs
@@ -10,19 +10,31 @@ public class PlayerMovementOrchestrator
     [SerializeField] private bool flipDirection = false;
 
     public Vector2 LastMoveDirection { get; private set; } = new Vector2(0f, 1f);
+    public Vector2 LastFacingDirection { get; private set; } = new Vector2(0f, 1f);
 
-    public void Tick(PlayerCollisionMove2D mover, Transform playerTransform, Vector2 movementInput, Vector2 aimInput, float deltaTime)
+    public void Tick(
+        PlayerCollisionMove2D mover,
+        Transform playerTransform,
+        Vector2 movementInput,
+        Vector2 aimInput,
+        float deltaTime,
+        float speedMultiplier = 1f)
     {
         if (mover != null)
         {
             var mag = movementInput.magnitude;
-            mover.SetMoveInput(mag < deadZone ? Vector2.zero : movementInput);
+            Vector2 resolvedMovement = mag < deadZone
+                ? Vector2.zero
+                : movementInput * Mathf.Max(0f, speedMultiplier);
+            mover.SetMoveInput(resolvedMovement);
         }
 
         if (movementInput.magnitude > 0f)
             LastMoveDirection = movementInput;
 
         Vector2 facingSource = aimInput.magnitude > deadZone ? aimInput : LastMoveDirection;
+        if (facingSource.sqrMagnitude > 0f)
+            LastFacingDirection = facingSource.normalized;
         Vector2 angleDirection = flipDirection ? -facingSource : facingSource;
         float targetAngle = Mathf.Atan2(angleDirection.y, angleDirection.x) * Mathf.Rad2Deg + facingDirectionOffset;
         var targetRotation = Quaternion.Euler(0f, 0f, targetAngle);

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Input/MobileInputDriver.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Input/MobileInputDriver.cs
@@ -21,6 +21,7 @@ namespace Castlebound.Gameplay.Input
     {
         [SerializeField] private TouchMovementZone movementZone;
         [SerializeField] private TouchAimAttackZone aimAttackZone;
+        [SerializeField] private TouchDefenseAimButton defenseAimButton;
         [SerializeField] private TouchRepairButton repairButton;
 
         [Tooltip("The PlayerInput component that drives PlayerController. " +
@@ -110,7 +111,13 @@ namespace Castlebound.Gameplay.Input
             // Right stick drives facing direction.
             // Right trigger remains held while the right zone is firing.
             // Cadence authority lives in PlayerAttackLoop / cooldown gate.
-            if (aimAttackZone != null)
+            if (defenseAimButton != null && defenseAimButton.IsDefending)
+            {
+                state.rightStick = defenseAimButton.FacingDirection;
+                state.leftTrigger = 1f;
+                state.rightTrigger = 0f;
+            }
+            else if (aimAttackZone != null)
             {
                 state.rightStick = aimAttackZone.FacingDirection;
                 state.rightTrigger = aimAttackZone.IsFiring ? 1f : 0f;

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Input/PlayerControls.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Input/PlayerControls.cs
@@ -111,6 +111,15 @@ public partial class @PlayerControls: IInputActionCollection2, IDisposable
                     ""initialStateCheck"": false
                 },
                 {
+                    ""name"": ""Defend"",
+                    ""type"": ""Button"",
+                    ""id"": ""9257d560-5243-4fc0-9f40-c65996309ad3"",
+                    ""expectedControlType"": """",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
                     ""name"": ""Repair"",
                     ""type"": ""Button"",
                     ""id"": ""aeb04078-27ae-4783-ba22-34d94795bc81"",
@@ -346,6 +355,28 @@ public partial class @PlayerControls: IInputActionCollection2, IDisposable
                 },
                 {
                     ""name"": """",
+                    ""id"": ""f60cb787-f214-4242-afce-1d3dcaecbbee"",
+                    ""path"": ""<Mouse>/rightButton"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""Defend"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""a6f39d7d-c831-45d6-aac3-2e273f2ce4d1"",
+                    ""path"": ""<Gamepad>/leftTrigger"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""Defend"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
                     ""id"": ""4e9a8d2b-0a7f-47de-90cc-13d5e8f25732"",
                     ""path"": ""<Mouse>/position"",
                     ""interactions"": """",
@@ -364,6 +395,7 @@ public partial class @PlayerControls: IInputActionCollection2, IDisposable
         m_Player = asset.FindActionMap("Player", throwIfNotFound: true);
         m_Player_Move = m_Player.FindAction("Move", throwIfNotFound: true);
         m_Player_Fire = m_Player.FindAction("Fire", throwIfNotFound: true);
+        m_Player_Defend = m_Player.FindAction("Defend", throwIfNotFound: true);
         m_Player_Repair = m_Player.FindAction("Repair", throwIfNotFound: true);
         m_Player_UsePotion = m_Player.FindAction("UsePotion", throwIfNotFound: true);
         m_Player_SwapWeaponSlot = m_Player.FindAction("SwapWeaponSlot", throwIfNotFound: true);
@@ -451,6 +483,7 @@ public partial class @PlayerControls: IInputActionCollection2, IDisposable
     private List<IPlayerActions> m_PlayerActionsCallbackInterfaces = new List<IPlayerActions>();
     private readonly InputAction m_Player_Move;
     private readonly InputAction m_Player_Fire;
+    private readonly InputAction m_Player_Defend;
     private readonly InputAction m_Player_Repair;
     private readonly InputAction m_Player_UsePotion;
     private readonly InputAction m_Player_SwapWeaponSlot;
@@ -475,6 +508,10 @@ public partial class @PlayerControls: IInputActionCollection2, IDisposable
         /// Provides access to the underlying input action "Player/Fire".
         /// </summary>
         public InputAction @Fire => m_Wrapper.m_Player_Fire;
+        /// <summary>
+        /// Provides access to the underlying input action "Player/Defend".
+        /// </summary>
+        public InputAction @Defend => m_Wrapper.m_Player_Defend;
         /// <summary>
         /// Provides access to the underlying input action "Player/Repair".
         /// </summary>
@@ -527,6 +564,9 @@ public partial class @PlayerControls: IInputActionCollection2, IDisposable
             @Fire.started += instance.OnFire;
             @Fire.performed += instance.OnFire;
             @Fire.canceled += instance.OnFire;
+            @Defend.started += instance.OnDefend;
+            @Defend.performed += instance.OnDefend;
+            @Defend.canceled += instance.OnDefend;
             @Repair.started += instance.OnRepair;
             @Repair.performed += instance.OnRepair;
             @Repair.canceled += instance.OnRepair;
@@ -559,6 +599,9 @@ public partial class @PlayerControls: IInputActionCollection2, IDisposable
             @Fire.started -= instance.OnFire;
             @Fire.performed -= instance.OnFire;
             @Fire.canceled -= instance.OnFire;
+            @Defend.started -= instance.OnDefend;
+            @Defend.performed -= instance.OnDefend;
+            @Defend.canceled -= instance.OnDefend;
             @Repair.started -= instance.OnRepair;
             @Repair.performed -= instance.OnRepair;
             @Repair.canceled -= instance.OnRepair;
@@ -628,6 +671,13 @@ public partial class @PlayerControls: IInputActionCollection2, IDisposable
         /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
         /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
         void OnFire(InputAction.CallbackContext context);
+        /// <summary>
+        /// Method invoked when associated input action "Defend" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+        /// </summary>
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+        void OnDefend(InputAction.CallbackContext context);
         /// <summary>
         /// Method invoked when associated input action "Repair" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
         /// </summary>

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Input/TouchDefenseAimButton.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Input/TouchDefenseAimButton.cs
@@ -1,0 +1,271 @@
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.InputSystem;
+using UnityEngine.InputSystem.UI;
+
+namespace Castlebound.Gameplay.Input
+{
+    public class TouchDefenseAimButton : MonoBehaviour, IPointerDownHandler, IDragHandler, IPointerUpHandler
+    {
+        private const int NoPointer = int.MinValue;
+
+        [Tooltip("Distance in screen pixels the pointer can move from the button center before the button begins following.")]
+        [SerializeField, Min(0f)] private float softAnchorRadius = 160f;
+
+        [Tooltip("Maximum distance in screen pixels the button can drift from its authored position.")]
+        [SerializeField, Min(0f)] private float maxAnchorDrift = 170f;
+
+        private enum CaptureValidationMode
+        {
+            None,
+            Touchscreen,
+            GenericPointer
+        }
+
+        private int activePointerId = NoPointer;
+        private RectTransform buttonRect;
+        private Vector2 visualHomeAnchoredPosition;
+        private Vector2 gestureHomeScreenPosition;
+        private Vector2 currentAnchorScreenPosition;
+        private Camera pointerCamera;
+        private bool hasVisualHome;
+        private CaptureValidationMode validationMode;
+
+        public bool IsDefending => activePointerId != NoPointer;
+        public Vector2 FacingDirection { get; private set; }
+        public Vector2 CurrentAnchorScreenPosition => currentAnchorScreenPosition;
+
+        public float SoftAnchorRadius
+        {
+            get => softAnchorRadius;
+            set => softAnchorRadius = Mathf.Max(0f, value);
+        }
+
+        public float MaxAnchorDrift
+        {
+            get => maxAnchorDrift;
+            set => maxAnchorDrift = Mathf.Max(0f, value);
+        }
+
+        public void OnPointerDown(PointerEventData eventData)
+        {
+            if (TryGetPointerIdentity(eventData, out int pointerId, out CaptureValidationMode mode))
+                TryBeginDefense(pointerId, eventData.position, mode, eventData.pressEventCamera);
+        }
+
+        public void OnDrag(PointerEventData eventData)
+        {
+            if (TryGetPointerIdentity(eventData, out int pointerId, out _))
+                SimulateDrag(pointerId, eventData.position);
+        }
+
+        public void OnPointerUp(PointerEventData eventData)
+        {
+            if (TryGetPointerIdentity(eventData, out int pointerId, out _))
+                SimulatePointerUp(pointerId);
+        }
+
+        private void LateUpdate()
+        {
+            if (IsDefending && validationMode != CaptureValidationMode.None && !IsCapturedPointerActive())
+                ResetCapture();
+        }
+
+        private void OnDisable()
+        {
+            ResetCapture();
+        }
+
+        private void OnApplicationFocus(bool hasFocus)
+        {
+            if (!hasFocus)
+                ResetCapture();
+        }
+
+        private void OnApplicationPause(bool isPaused)
+        {
+            if (isPaused)
+                ResetCapture();
+        }
+
+        public bool SimulatePointerDown(int pointerId, Vector2 screenPosition)
+        {
+            return TryBeginDefense(pointerId, screenPosition, CaptureValidationMode.None, null);
+        }
+
+        private bool TryBeginDefense(
+            int pointerId,
+            Vector2 screenPosition,
+            CaptureValidationMode mode,
+            Camera eventCamera)
+        {
+            if (IsDefending)
+                return false;
+
+            CacheAnchorHomes(screenPosition);
+            activePointerId = pointerId;
+            pointerCamera = eventCamera;
+            validationMode = mode;
+            FacingDirection = Vector2.zero;
+            return true;
+        }
+
+        public bool SimulateDrag(int pointerId, Vector2 screenPosition)
+        {
+            if (pointerId != activePointerId)
+                return false;
+
+            Vector2 anchorDelta = screenPosition - currentAnchorScreenPosition;
+            float distanceFromAnchor = anchorDelta.magnitude;
+            if (distanceFromAnchor > softAnchorRadius)
+            {
+                Vector2 direction = anchorDelta / distanceFromAnchor;
+                Vector2 proposedAnchor = currentAnchorScreenPosition +
+                                         direction * (distanceFromAnchor - softAnchorRadius);
+                Vector2 driftFromHome = Vector2.ClampMagnitude(
+                    proposedAnchor - gestureHomeScreenPosition,
+                    maxAnchorDrift);
+                currentAnchorScreenPosition = gestureHomeScreenPosition + driftFromHome;
+            }
+
+            ApplyAnchorVisual();
+
+            Vector2 delta = screenPosition - currentAnchorScreenPosition;
+            if (delta.sqrMagnitude > 0f)
+                FacingDirection = delta.normalized;
+            return true;
+        }
+
+        public bool SimulatePointerUp(int pointerId)
+        {
+            if (pointerId != activePointerId)
+                return false;
+
+            ResetCapture();
+            return true;
+        }
+
+        private void ResetCapture()
+        {
+            activePointerId = NoPointer;
+            validationMode = CaptureValidationMode.None;
+            FacingDirection = Vector2.zero;
+            pointerCamera = null;
+
+            if (hasVisualHome && buttonRect != null)
+                buttonRect.anchoredPosition = visualHomeAnchoredPosition;
+
+            currentAnchorScreenPosition = hasVisualHome ? gestureHomeScreenPosition : Vector2.zero;
+        }
+
+        private void CacheAnchorHomes(Vector2 screenPosition)
+        {
+            buttonRect = transform as RectTransform;
+            if (buttonRect == null)
+            {
+                gestureHomeScreenPosition = screenPosition;
+                currentAnchorScreenPosition = screenPosition;
+                hasVisualHome = false;
+                return;
+            }
+
+            visualHomeAnchoredPosition = buttonRect.anchoredPosition;
+            gestureHomeScreenPosition = screenPosition;
+            currentAnchorScreenPosition = gestureHomeScreenPosition;
+            hasVisualHome = true;
+        }
+
+        private void ApplyAnchorVisual()
+        {
+            if (!hasVisualHome || buttonRect == null)
+                return;
+
+            if (buttonRect.parent is RectTransform parentRect &&
+                RectTransformUtility.ScreenPointToLocalPointInRectangle(
+                    parentRect,
+                    gestureHomeScreenPosition,
+                    pointerCamera,
+                    out Vector2 homeLocal) &&
+                RectTransformUtility.ScreenPointToLocalPointInRectangle(
+                    parentRect,
+                    currentAnchorScreenPosition,
+                    pointerCamera,
+                    out Vector2 currentLocal))
+            {
+                buttonRect.anchoredPosition = visualHomeAnchoredPosition + currentLocal - homeLocal;
+                return;
+            }
+
+            buttonRect.anchoredPosition = visualHomeAnchoredPosition +
+                                          currentAnchorScreenPosition -
+                                          gestureHomeScreenPosition;
+        }
+
+        private static bool TryGetPointerIdentity(
+            PointerEventData eventData,
+            out int pointerId,
+            out CaptureValidationMode mode)
+        {
+            pointerId = NoPointer;
+            mode = CaptureValidationMode.None;
+            if (eventData == null)
+                return false;
+
+            if (eventData is ExtendedPointerEventData extended)
+            {
+                if (extended.pointerType != UIPointerType.Touch || extended.touchId == 0)
+                    return false;
+
+                pointerId = extended.touchId;
+                mode = CaptureValidationMode.Touchscreen;
+                return true;
+            }
+
+            if (eventData.pointerId < 0)
+                return false;
+
+            pointerId = eventData.pointerId;
+            mode = CaptureValidationMode.GenericPointer;
+            return true;
+        }
+
+        private bool IsCapturedPointerActive()
+        {
+            if (validationMode == CaptureValidationMode.Touchscreen)
+                return IsTouchActive(activePointerId);
+
+            return IsAnyTouchActive() ||
+                   (Mouse.current != null && Mouse.current.leftButton.isPressed);
+        }
+
+        private static bool IsTouchActive(int touchId)
+        {
+            Touchscreen touchscreen = Touchscreen.current;
+            if (touchscreen == null)
+                return false;
+
+            foreach (var touch in touchscreen.touches)
+            {
+                if (touch.touchId.ReadValue() == touchId && touch.press.isPressed)
+                    return true;
+            }
+
+            return false;
+        }
+
+        private static bool IsAnyTouchActive()
+        {
+            Touchscreen touchscreen = Touchscreen.current;
+            if (touchscreen == null)
+                return false;
+
+            foreach (var touch in touchscreen.touches)
+            {
+                if (touch.press.isPressed)
+                    return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Input/TouchDefenseAimButton.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Input/TouchDefenseAimButton.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c1bd09cfd2464bd89a759fac2ba047df

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/PlayerController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/PlayerController.cs
@@ -26,6 +26,7 @@ public class PlayerController : MonoBehaviour
     [SerializeField] private PlayerFacingPolicyResolver facingPolicyResolver;
     [SerializeField] private PlayerAttackAnimationDriver attackAnimationDriver;
     [SerializeField] private PlayerAttackLoop attackLoop;
+    [SerializeField] private PlayerDefenseController defenseController;
     [SerializeField, Min(0)] private int baseAttackDamage = 1;
     [SerializeField] private float baseAttackRate = 1.5f;
     
@@ -73,6 +74,9 @@ public class PlayerController : MonoBehaviour
 
     public float RepairCooldownRemaining => repairCooldownRemaining;
     public bool IsRepairOnCooldown => repairCooldownRemaining > 0f;
+    public Vector2 CurrentFacingDirection => movementOrchestrator != null
+        ? movementOrchestrator.LastFacingDirection
+        : -(Vector2)transform.up;
     public int BaseAttackDamage
     {
         get => baseAttackDamage;
@@ -93,6 +97,7 @@ public class PlayerController : MonoBehaviour
         if (facingPolicyResolver == null) facingPolicyResolver = GetComponent<PlayerFacingPolicyResolver>();
         if (attackAnimationDriver == null) attackAnimationDriver = GetComponent<PlayerAttackAnimationDriver>();
         if (attackLoop == null) attackLoop = GetComponent<PlayerAttackLoop>();
+        if (defenseController == null) defenseController = GetComponent<PlayerDefenseController>();
         inventoryState = inventorySource != null ? inventorySource.State : null;
         if (weaponSlotSwapHandler == null) weaponSlotSwapHandler = new WeaponSlotSwapHandler();
         if (movementOrchestrator == null) movementOrchestrator = new PlayerMovementOrchestrator();
@@ -121,7 +126,7 @@ public class PlayerController : MonoBehaviour
 
     public void OnFire(InputValue value)
     {
-        if (inputLocked)
+        if (inputLocked || (defenseController != null && !defenseController.CanAttack))
         {
             fireInputController?.ClearHeldFire();
             return;
@@ -142,7 +147,8 @@ public class PlayerController : MonoBehaviour
         if (attackLoop == null)
             attackLoop = GetComponent<PlayerAttackLoop>();
 
-        var isFireHeld = fireInputController != null && fireInputController.IsFireHeld;
+        bool canAttack = defenseController == null || defenseController.CanAttack;
+        var isFireHeld = canAttack && fireInputController != null && fireInputController.IsFireHeld;
         attackRuntime.Tick(
             Time.fixedDeltaTime,
             baseAttackDamage,
@@ -154,7 +160,16 @@ public class PlayerController : MonoBehaviour
             animator,
             hitboxObject);
 
-        movementOrchestrator.Tick(mover, transform, movementInput, ResolveFacingInput(), Time.fixedDeltaTime);
+        float movementSpeedMultiplier = defenseController != null
+            ? defenseController.MovementSpeedMultiplier
+            : 1f;
+        movementOrchestrator.Tick(
+            mover,
+            transform,
+            movementInput,
+            ResolveFacingInput(),
+            Time.fixedDeltaTime,
+            movementSpeedMultiplier);
     }
 
     /// <summary>
@@ -317,7 +332,8 @@ public class PlayerController : MonoBehaviour
         if (facingPolicyResolver == null)
             return resolvedAimInput;
 
-        var aimIntentActive = fireInputController != null && fireInputController.IsFireHeld;
+        var aimIntentActive = (fireInputController != null && fireInputController.IsFireHeld)
+            || (defenseController != null && defenseController.IsGuarding);
         var currentFacing = movementOrchestrator != null ? movementOrchestrator.LastMoveDirection : (Vector2)transform.up;
         return facingPolicyResolver.ResolveFacing(
             currentFacing,

--- a/Assets/_Project/Settings/Input/PlayerControls.inputactions
+++ b/Assets/_Project/Settings/Input/PlayerControls.inputactions
@@ -25,6 +25,15 @@
                     "initialStateCheck": false
                 },
                 {
+                    "name": "Defend",
+                    "type": "Button",
+                    "id": "9257d560-5243-4fc0-9f40-c65996309ad3",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
                     "name": "Repair",
                     "type": "Button",
                     "id": "aeb04078-27ae-4783-ba22-34d94795bc81",
@@ -255,6 +264,28 @@
                     "processors": "",
                     "groups": "",
                     "action": "Look",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "f60cb787-f214-4242-afce-1d3dcaecbbee",
+                    "path": "<Mouse>/rightButton",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Defend",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "a6f39d7d-c831-45d6-aac3-2e273f2ce4d1",
+                    "path": "<Gamepad>/leftTrigger",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Defend",
                     "isComposite": false,
                     "isPartOfComposite": false
                 },

--- a/Assets/_Project/_Tests/EditMode/Combat/PlayerDefenseControllerTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Combat/PlayerDefenseControllerTests.cs
@@ -1,0 +1,188 @@
+using Castlebound.Gameplay.Combat;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Castlebound.Tests.Combat
+{
+    public class PlayerDefenseControllerTests
+    {
+        private GameObject player;
+        private GameObject attacker;
+        private Health health;
+        private PlayerDefenseController defense;
+
+        [SetUp]
+        public void SetUp()
+        {
+            player = new GameObject("Player");
+            player.tag = "Player";
+            player.transform.rotation = Quaternion.Euler(0f, 0f, 90f);
+            health = player.AddComponent<Health>();
+            health.ConfigureMaxHealth(10, refill: true);
+            defense = player.AddComponent<PlayerDefenseController>();
+            defense.Configure(0.15f, 0.15f, 120f, 0.6f);
+
+            attacker = new GameObject("Attacker");
+            attacker.transform.position = Vector2.right;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (attacker != null)
+                Object.DestroyImmediate(attacker);
+            if (player != null)
+                Object.DestroyImmediate(player);
+        }
+
+        [Test]
+        public void ReceiveHit_DuringFrontalParry_PreservesHealthAndPublishesResult()
+        {
+            PlayerHitResult observed = default;
+            defense.HitResolved += result => observed = result;
+            defense.SetDefensePressed(true);
+
+            PlayerHitResult result = defense.ReceiveHit(new PlayerHitRequest(
+                4,
+                attacker,
+                attacker.transform.position,
+                CombatDamageType.Melee));
+
+            Assert.That(result.Outcome, Is.EqualTo(PlayerHitOutcome.Parried));
+            Assert.That(result.Attacker, Is.SameAs(attacker));
+            Assert.That(observed.Outcome, Is.EqualTo(PlayerHitOutcome.Parried));
+            Assert.That(health.Current, Is.EqualTo(10));
+        }
+
+        [Test]
+        public void ReceiveHit_FromRear_AppliesResolvedDamageThroughHealth()
+        {
+            attacker.transform.position = Vector2.left;
+            defense.SetDefensePressed(true);
+
+            PlayerHitResult result = defense.ReceiveHit(new PlayerHitRequest(
+                4,
+                attacker,
+                attacker.transform.position,
+                CombatDamageType.Melee));
+
+            Assert.That(result.Outcome, Is.EqualTo(PlayerHitOutcome.Damaged));
+            Assert.That(result.AppliedDamage, Is.EqualTo(4));
+            Assert.That(health.Current, Is.EqualTo(6));
+        }
+
+        [Test]
+        public void ReceiveHit_ReportsDamageActuallyAppliedByHealth()
+        {
+            health.ConfigureMaxHealth(2, refill: true);
+            attacker.transform.position = Vector2.left;
+
+            PlayerHitResult result = defense.ReceiveHit(new PlayerHitRequest(
+                4,
+                attacker,
+                attacker.transform.position,
+                CombatDamageType.Melee));
+
+            Assert.That(result.RequestedDamage, Is.EqualTo(4));
+            Assert.That(result.AppliedDamage, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void Guarding_UsesConfiguredMovementMultiplierOnlyWhileActive()
+        {
+            Assert.That(defense.MovementSpeedMultiplier, Is.EqualTo(1f));
+
+            defense.SetDefensePressed(true);
+            Assert.That(defense.MovementSpeedMultiplier, Is.EqualTo(0.6f).Within(0.0001f));
+
+            defense.SetDefensePressed(false);
+            Assert.That(defense.MovementSpeedMultiplier, Is.EqualTo(1f));
+        }
+
+        [Test]
+        public void MissingCanceledInput_ReleasesDefenseWhenNoBoundControlRemainsPressed()
+        {
+            defense.Configure(0.15f, 0.15f, 120f, 0.6f, () => false);
+            defense.OnDefensePressedStateChanged(true);
+            Assert.That(defense.State, Is.EqualTo(PlayerDefenseState.ParryWindow));
+
+            defense.Tick(0f);
+
+            Assert.That(defense.State, Is.EqualTo(PlayerDefenseState.Recovery));
+            Assert.IsFalse(defense.IsGuarding);
+        }
+
+        [Test]
+        public void StartingDefense_CancelsHeldFireAndActiveSwing()
+        {
+            var attackPlayer = new GameObject("AttackPlayer");
+            try
+            {
+                var fireInput = attackPlayer.AddComponent<PlayerFireInputController>();
+                var attackLoop = attackPlayer.AddComponent<PlayerAttackLoop>();
+                attackPlayer.AddComponent<PlayerController>();
+                var attackDefense = attackPlayer.AddComponent<PlayerDefenseController>();
+                attackDefense.Configure(0.15f, 0.15f, 120f, 0.6f);
+
+                fireInput.Configure(null, () => true);
+                fireInput.OnFirePressedStateChanged(true);
+                attackLoop.Tick(0.01f, 1f, true);
+                Assert.IsTrue(attackLoop.IsSwingActive);
+
+                attackDefense.SetDefensePressed(true);
+
+                Assert.IsFalse(fireInput.IsFireHeld);
+                Assert.IsFalse(attackLoop.IsSwingActive);
+            }
+            finally
+            {
+                Object.DestroyImmediate(attackPlayer);
+            }
+        }
+
+        [Test]
+        public void EnemyMeleeDelivery_FrontalParry_UsesContextualReceiver()
+        {
+            var delivery = attacker.AddComponent<EnemyMeleeAttackDelivery>();
+            PlayerHitResult observed = default;
+            defense.HitResolved += result => observed = result;
+            defense.SetDefensePressed(true);
+
+            bool delivered = delivery.TryDeliver(player.transform, null, CreateDamageSnapshot(4));
+
+            Assert.IsTrue(delivered);
+            Assert.That(health.Current, Is.EqualTo(10));
+            Assert.That(observed.Outcome, Is.EqualTo(PlayerHitOutcome.Parried));
+            Assert.That(observed.Attacker, Is.SameAs(attacker));
+        }
+
+        [Test]
+        public void EnemyMeleeDelivery_RearAttack_AppliesCapturedDamage()
+        {
+            attacker.transform.position = Vector2.left;
+            var delivery = attacker.AddComponent<EnemyMeleeAttackDelivery>();
+            defense.SetDefensePressed(true);
+
+            bool delivered = delivery.TryDeliver(player.transform, null, CreateDamageSnapshot(4));
+
+            Assert.IsTrue(delivered);
+            Assert.That(health.Current, Is.EqualTo(6));
+        }
+
+        private static CombatEquipmentSnapshot CreateDamageSnapshot(int damage)
+        {
+            return new CombatEquipmentSnapshot(
+                "test-melee",
+                damage,
+                1f,
+                0f,
+                0f,
+                CombatEquipmentCapability.MeleeDelivery,
+                null,
+                null,
+                0f,
+                0f,
+                0f);
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Combat/PlayerDefenseControllerTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Combat/PlayerDefenseControllerTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f68bc2bb550d4774a845f2365438a41b

--- a/Assets/_Project/_Tests/EditMode/Combat/PlayerDefenseHitResolverTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Combat/PlayerDefenseHitResolverTests.cs
@@ -1,0 +1,140 @@
+using Castlebound.Gameplay.Combat;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Castlebound.Tests.Combat
+{
+    public class PlayerDefenseHitResolverTests
+    {
+        private const float BlockArcDegrees = 120f;
+        private GameObject attacker;
+
+        [SetUp]
+        public void SetUp()
+        {
+            attacker = new GameObject("Attacker");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(attacker);
+        }
+
+        [Test]
+        public void Resolve_FrontMeleeDuringParry_NegatesDamageAndPreservesAttacker()
+        {
+            var request = new PlayerHitRequest(4, attacker, Vector2.right, CombatDamageType.Melee);
+
+            PlayerHitResult result = PlayerDefenseHitResolver.Resolve(
+                request,
+                PlayerDefenseState.ParryWindow,
+                Vector2.zero,
+                Vector2.right,
+                BlockArcDegrees);
+
+            Assert.That(result.Outcome, Is.EqualTo(PlayerHitOutcome.Parried));
+            Assert.That(result.AppliedDamage, Is.Zero);
+            Assert.That(result.Attacker, Is.SameAs(attacker));
+            Assert.That(result.RequestedDamage, Is.EqualTo(4));
+            Assert.That(result.DamageType, Is.EqualTo(CombatDamageType.Melee));
+        }
+
+        [Test]
+        public void Resolve_FrontMeleeDuringBlock_NegatesDamage()
+        {
+            var request = new PlayerHitRequest(4, attacker, Vector2.right, CombatDamageType.Melee);
+
+            PlayerHitResult result = PlayerDefenseHitResolver.Resolve(
+                request,
+                PlayerDefenseState.Blocking,
+                Vector2.zero,
+                Vector2.right,
+                BlockArcDegrees);
+
+            Assert.That(result.Outcome, Is.EqualTo(PlayerHitOutcome.Blocked));
+            Assert.That(result.AppliedDamage, Is.Zero);
+        }
+
+        [TestCase(60f, PlayerHitOutcome.Blocked)]
+        [TestCase(-60f, PlayerHitOutcome.Blocked)]
+        [TestCase(60.01f, PlayerHitOutcome.Damaged)]
+        [TestCase(-60.01f, PlayerHitOutcome.Damaged)]
+        [TestCase(180f, PlayerHitOutcome.Damaged)]
+        public void Resolve_UsesInclusiveArcEdges(float attackAngle, PlayerHitOutcome expectedOutcome)
+        {
+            Vector2 attackOrigin = Quaternion.Euler(0f, 0f, attackAngle) * Vector2.right;
+            var request = new PlayerHitRequest(3, attacker, attackOrigin, CombatDamageType.Melee);
+
+            PlayerHitResult result = PlayerDefenseHitResolver.Resolve(
+                request,
+                PlayerDefenseState.Blocking,
+                Vector2.zero,
+                Vector2.right,
+                BlockArcDegrees);
+
+            Assert.That(result.Outcome, Is.EqualTo(expectedOutcome));
+            Assert.That(result.AppliedDamage, Is.EqualTo(expectedOutcome == PlayerHitOutcome.Damaged ? 3 : 0));
+        }
+
+        [TestCase(PlayerDefenseState.Idle)]
+        [TestCase(PlayerDefenseState.Recovery)]
+        public void Resolve_WhenNotActivelyGuarding_AppliesFullDamage(PlayerDefenseState state)
+        {
+            var request = new PlayerHitRequest(3, attacker, Vector2.right, CombatDamageType.Melee);
+
+            PlayerHitResult result = PlayerDefenseHitResolver.Resolve(
+                request,
+                state,
+                Vector2.zero,
+                Vector2.right,
+                BlockArcDegrees);
+
+            Assert.That(result.Outcome, Is.EqualTo(PlayerHitOutcome.Damaged));
+            Assert.That(result.AppliedDamage, Is.EqualTo(3));
+        }
+
+        [Test]
+        public void Resolve_ProjectileDuringParry_BypassesDefense()
+        {
+            var request = new PlayerHitRequest(5, attacker, Vector2.right, CombatDamageType.Projectile);
+
+            PlayerHitResult result = PlayerDefenseHitResolver.Resolve(
+                request,
+                PlayerDefenseState.ParryWindow,
+                Vector2.zero,
+                Vector2.right,
+                BlockArcDegrees);
+
+            Assert.That(result.Outcome, Is.EqualTo(PlayerHitOutcome.Damaged));
+            Assert.That(result.AppliedDamage, Is.EqualTo(5));
+        }
+
+        [TestCase(0f, 1f)]
+        [TestCase(1f, 0f)]
+        public void Resolve_WithoutUsableDirection_AppliesFullDamage(float facingX, float originX)
+        {
+            var request = new PlayerHitRequest(2, attacker, new Vector2(originX, 0f), CombatDamageType.Melee);
+
+            PlayerHitResult result = PlayerDefenseHitResolver.Resolve(
+                request,
+                PlayerDefenseState.Blocking,
+                new Vector2(originX, 0f),
+                new Vector2(facingX, 0f),
+                BlockArcDegrees);
+
+            Assert.That(result.Outcome, Is.EqualTo(PlayerHitOutcome.Damaged));
+            Assert.That(result.AppliedDamage, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void Request_NormalizesNegativeDamageWithoutDiscardingContext()
+        {
+            var request = new PlayerHitRequest(-3, attacker, Vector2.left, CombatDamageType.Melee);
+
+            Assert.That(request.Damage, Is.Zero);
+            Assert.That(request.Attacker, Is.SameAs(attacker));
+            Assert.That(request.AttackOrigin, Is.EqualTo(Vector2.left));
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Combat/PlayerDefenseHitResolverTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Combat/PlayerDefenseHitResolverTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 886917ce257146c3ba8a01b01877234a

--- a/Assets/_Project/_Tests/EditMode/Combat/PlayerDefensePrefabContractTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Combat/PlayerDefensePrefabContractTests.cs
@@ -1,0 +1,42 @@
+using System.Reflection;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+
+namespace Castlebound.Tests.Combat
+{
+    public class PlayerDefensePrefabContractTests
+    {
+        private const string PlayerPrefabPath = "Assets/_Project/Prefabs/Player.prefab";
+
+        [Test]
+        public void PlayerPrefab_OwnsDefenseStateAndGuardPresentation()
+        {
+            GameObject root = PrefabUtility.LoadPrefabContents(PlayerPrefabPath);
+            try
+            {
+                var playerController = root.GetComponent<PlayerController>();
+                var defenseController = root.GetComponent<PlayerDefenseController>();
+                var presenter = root.GetComponent<PlayerGuardArcPresenter>();
+
+                Assert.NotNull(playerController);
+                Assert.NotNull(defenseController);
+                Assert.NotNull(presenter);
+                Assert.NotNull(root.GetComponent<Health>());
+                Assert.That(root.tag, Is.EqualTo("Player"));
+                Assert.That(root.layer, Is.EqualTo(LayerMask.NameToLayer("Player")));
+                Assert.That(defenseController.BlockArcDegrees, Is.EqualTo(120f));
+
+                var field = typeof(PlayerController).GetField(
+                    "defenseController",
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+                Assert.NotNull(field);
+                Assert.That(field.GetValue(playerController), Is.SameAs(defenseController));
+            }
+            finally
+            {
+                PrefabUtility.UnloadPrefabContents(root);
+            }
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Combat/PlayerDefensePrefabContractTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Combat/PlayerDefensePrefabContractTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a2f56c669dd24441aa92c4f7c9df2bd8

--- a/Assets/_Project/_Tests/EditMode/Combat/PlayerDefenseStateMachineTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Combat/PlayerDefenseStateMachineTests.cs
@@ -1,0 +1,109 @@
+using Castlebound.Gameplay.Combat;
+using NUnit.Framework;
+
+namespace Castlebound.Tests.Combat
+{
+    public class PlayerDefenseStateMachineTests
+    {
+        private const float ParryWindow = 0.15f;
+        private const float RecoveryDuration = 0.15f;
+
+        [Test]
+        public void BeginDefense_FromIdle_EntersParryWindow()
+        {
+            var stateMachine = new PlayerDefenseStateMachine(ParryWindow, RecoveryDuration);
+
+            bool started = stateMachine.BeginDefense();
+
+            Assert.IsTrue(started);
+            Assert.That(stateMachine.State, Is.EqualTo(PlayerDefenseState.ParryWindow));
+            Assert.IsTrue(stateMachine.IsGuarding);
+            Assert.IsFalse(stateMachine.CanAttack);
+        }
+
+        [Test]
+        public void Advance_AtInclusiveParryBoundary_RemainsParryWindow()
+        {
+            var stateMachine = new PlayerDefenseStateMachine(ParryWindow, RecoveryDuration);
+            stateMachine.BeginDefense();
+
+            stateMachine.Advance(ParryWindow);
+
+            Assert.That(stateMachine.State, Is.EqualTo(PlayerDefenseState.ParryWindow));
+        }
+
+        [Test]
+        public void Advance_BeyondParryBoundaryWhileHeld_EntersBlocking()
+        {
+            var stateMachine = new PlayerDefenseStateMachine(ParryWindow, RecoveryDuration);
+            stateMachine.BeginDefense();
+
+            stateMachine.Advance(ParryWindow + 0.001f);
+
+            Assert.That(stateMachine.State, Is.EqualTo(PlayerDefenseState.Blocking));
+            Assert.IsTrue(stateMachine.IsGuarding);
+        }
+
+        [TestCase(PlayerDefenseState.ParryWindow)]
+        [TestCase(PlayerDefenseState.Blocking)]
+        public void ReleaseDefense_FromGuarding_EntersRecovery(PlayerDefenseState releaseState)
+        {
+            var stateMachine = new PlayerDefenseStateMachine(ParryWindow, RecoveryDuration);
+            stateMachine.BeginDefense();
+            if (releaseState == PlayerDefenseState.Blocking)
+                stateMachine.Advance(ParryWindow + 0.001f);
+
+            bool released = stateMachine.ReleaseDefense();
+
+            Assert.IsTrue(released);
+            Assert.That(stateMachine.State, Is.EqualTo(PlayerDefenseState.Recovery));
+            Assert.IsFalse(stateMachine.IsGuarding);
+            Assert.IsFalse(stateMachine.CanAttack);
+        }
+
+        [Test]
+        public void Recovery_BlocksRestartUntilDurationCompletes()
+        {
+            var stateMachine = new PlayerDefenseStateMachine(ParryWindow, RecoveryDuration);
+            stateMachine.BeginDefense();
+            stateMachine.ReleaseDefense();
+
+            Assert.IsFalse(stateMachine.BeginDefense());
+            stateMachine.Advance(RecoveryDuration - 0.001f);
+            Assert.That(stateMachine.State, Is.EqualTo(PlayerDefenseState.Recovery));
+
+            stateMachine.Advance(0.001f);
+
+            Assert.That(stateMachine.State, Is.EqualTo(PlayerDefenseState.Idle));
+            Assert.IsTrue(stateMachine.CanAttack);
+            Assert.IsTrue(stateMachine.BeginDefense());
+        }
+
+        [Test]
+        public void Advance_LargeDelta_CarriesFromParryThroughHeldBlockingOnly()
+        {
+            var stateMachine = new PlayerDefenseStateMachine(ParryWindow, RecoveryDuration);
+            stateMachine.BeginDefense();
+
+            stateMachine.Advance(10f);
+
+            Assert.That(stateMachine.State, Is.EqualTo(PlayerDefenseState.Blocking));
+        }
+
+        [Test]
+        public void InvalidDurationsAndDelta_AreNormalized()
+        {
+            var stateMachine = new PlayerDefenseStateMachine(float.NaN, -1f);
+
+            stateMachine.BeginDefense();
+            stateMachine.Advance(float.NaN);
+            Assert.That(stateMachine.State, Is.EqualTo(PlayerDefenseState.ParryWindow));
+
+            stateMachine.Advance(0.001f);
+            Assert.That(stateMachine.State, Is.EqualTo(PlayerDefenseState.Blocking));
+            stateMachine.ReleaseDefense();
+            stateMachine.Advance(0f);
+            Assert.That(stateMachine.State, Is.EqualTo(PlayerDefenseState.Idle));
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Combat/PlayerDefenseStateMachineTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Combat/PlayerDefenseStateMachineTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1c0676f5ad9c4d3c9e6b5c84f673118e

--- a/Assets/_Project/_Tests/EditMode/Combat/PlayerGuardArcPresenterTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Combat/PlayerGuardArcPresenterTests.cs
@@ -1,0 +1,77 @@
+using Castlebound.Gameplay.Combat;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Castlebound.Tests.Combat
+{
+    public class PlayerGuardArcPresenterTests
+    {
+        private GameObject player;
+        private PlayerDefenseController defense;
+        private LineRenderer lineRenderer;
+        private PlayerGuardArcPresenter presenter;
+
+        [SetUp]
+        public void SetUp()
+        {
+            player = new GameObject("PlayerGuardArc");
+            player.AddComponent<Health>();
+            defense = player.AddComponent<PlayerDefenseController>();
+            defense.Configure(0.15f, 0.15f, 120f, 0.6f);
+            lineRenderer = player.AddComponent<LineRenderer>();
+            presenter = player.AddComponent<PlayerGuardArcPresenter>();
+            presenter.RefreshPresentation();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(player);
+        }
+
+        [Test]
+        public void StateChanges_ShowGuardAndHideImmediatelyDuringRecovery()
+        {
+            Assert.IsFalse(lineRenderer.enabled);
+
+            defense.SetDefensePressed(true);
+            Assert.IsTrue(lineRenderer.enabled);
+            Assert.That(lineRenderer.positionCount, Is.GreaterThan(2));
+            defense.SetDefensePressed(false);
+            Assert.IsFalse(lineRenderer.enabled);
+
+            defense.Tick(0.15f);
+            Assert.IsFalse(lineRenderer.enabled);
+        }
+
+        [Test]
+        public void SuccessfulParry_UsesDistinctFlashColor()
+        {
+            var attacker = new GameObject("Attacker");
+            try
+            {
+                player.transform.rotation = Quaternion.Euler(0f, 0f, 90f);
+                attacker.transform.position = Vector2.right;
+                defense.SetDefensePressed(true);
+
+                defense.ReceiveHit(new PlayerHitRequest(
+                    1,
+                    attacker,
+                    attacker.transform.position,
+                    CombatDamageType.Melee));
+
+                Color renderedColor = lineRenderer.startColor;
+                Color expectedColor = presenter.ParrySuccessColor;
+                const float colorChannelTolerance = (1f / 255f) + 0.0001f;
+                Assert.That(renderedColor.r, Is.EqualTo(expectedColor.r).Within(colorChannelTolerance));
+                Assert.That(renderedColor.g, Is.EqualTo(expectedColor.g).Within(colorChannelTolerance));
+                Assert.That(renderedColor.b, Is.EqualTo(expectedColor.b).Within(colorChannelTolerance));
+                Assert.That(renderedColor.a, Is.EqualTo(expectedColor.a).Within(colorChannelTolerance));
+            }
+            finally
+            {
+                Object.DestroyImmediate(attacker);
+            }
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Combat/PlayerGuardArcPresenterTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Combat/PlayerGuardArcPresenterTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: efdce7f5233648d1a74616b66fd9d313

--- a/Assets/_Project/_Tests/EditMode/Input/DefenseInputContractsTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Input/DefenseInputContractsTests.cs
@@ -1,0 +1,51 @@
+using System.IO;
+using NUnit.Framework;
+
+namespace Castlebound.Tests.Input
+{
+    public class DefenseInputContractsTests
+    {
+        private const string InputActionsPath =
+            "Assets/_Project/Settings/Input/PlayerControls.inputactions";
+        private const string GeneratedControlsPath =
+            "Assets/_Project/Scripts/_Project.Gameplay/Player/Input/PlayerControls.cs";
+        private const string MobileDriverPath =
+            "Assets/_Project/Scripts/_Project.Gameplay/Player/Input/MobileInputDriver.cs";
+        private const string MainPrototypePath = "Assets/_Project/Scenes/MainPrototype.unity";
+
+        [Test]
+        public void PlayerControls_DefendUsesRequiredDesktopAndGamepadBindings()
+        {
+            string actions = File.ReadAllText(InputActionsPath);
+            string generated = File.ReadAllText(GeneratedControlsPath);
+
+            StringAssert.Contains("\"name\": \"Defend\"", actions);
+            StringAssert.Contains("<Mouse>/rightButton", actions);
+            StringAssert.Contains("<Gamepad>/leftTrigger", actions);
+            StringAssert.Contains("m_Player_Defend", generated);
+        }
+
+        [Test]
+        public void MobileDefense_SuppressesAttackAndUsesIndependentLeftStick()
+        {
+            string source = File.ReadAllText(MobileDriverPath);
+
+            StringAssert.Contains("state.leftStick = movementZone.MoveVector", source);
+            StringAssert.Contains("defenseAimButton.IsDefending", source);
+            StringAssert.Contains("state.leftTrigger = 1f", source);
+            StringAssert.Contains("state.rightTrigger = 0f", source);
+        }
+
+        [Test]
+        public void MainPrototype_WiresSmallTouchDefenseAimButton()
+        {
+            string scene = File.ReadAllText(MainPrototypePath);
+
+            StringAssert.Contains("m_Name: TouchDefenseAimButton", scene);
+            StringAssert.Contains("defenseAimButton: {fileID: 3004000004}", scene);
+            StringAssert.Contains("m_SizeDelta: {x: 120, y: 120}", scene);
+            StringAssert.Contains("softAnchorRadius: 160", scene);
+            StringAssert.Contains("maxAnchorDrift: 170", scene);
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Input/DefenseInputContractsTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Input/DefenseInputContractsTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 72948cd12ecf469f8a787494191890c4

--- a/Assets/_Project/_Tests/EditMode/Input/TouchDefenseAimButtonTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Input/TouchDefenseAimButtonTests.cs
@@ -1,0 +1,319 @@
+using System.Reflection;
+using Castlebound.Gameplay.Input;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.InputSystem.UI;
+
+namespace Castlebound.Tests.Input
+{
+    public class TouchDefenseAimButtonTests
+    {
+        private GameObject buttonObject;
+        private TouchDefenseAimButton button;
+
+        [SetUp]
+        public void SetUp()
+        {
+            buttonObject = new GameObject("TouchDefenseAimButton", typeof(RectTransform));
+            button = buttonObject.AddComponent<TouchDefenseAimButton>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(buttonObject);
+        }
+
+        [Test]
+        public void PointerBeginningOnButton_CapturesDefenseUntilMatchingRelease()
+        {
+            Assert.IsTrue(button.SimulatePointerDown(7, new Vector2(100f, 100f)));
+            button.SimulateDrag(7, new Vector2(140f, 100f));
+
+            Assert.IsTrue(button.IsDefending);
+            Assert.That(button.FacingDirection, Is.EqualTo(Vector2.right));
+            Assert.IsFalse(button.SimulatePointerUp(8));
+            Assert.IsTrue(button.IsDefending);
+
+            Assert.IsTrue(button.SimulatePointerUp(7));
+            Assert.IsFalse(button.IsDefending);
+            Assert.That(button.FacingDirection, Is.EqualTo(Vector2.zero));
+        }
+
+        [Test]
+        public void SecondPointer_CannotTakeOverCapturedDefenseGesture()
+        {
+            Assert.IsTrue(button.SimulatePointerDown(3, Vector2.zero));
+
+            Assert.IsFalse(button.SimulatePointerDown(4, new Vector2(20f, 20f)));
+            Assert.IsFalse(button.SimulateDrag(4, Vector2.up * 50f));
+            Assert.That(button.FacingDirection, Is.EqualTo(Vector2.zero));
+
+            Assert.IsTrue(button.SimulateDrag(3, Vector2.up * 50f));
+            Assert.That(button.FacingDirection, Is.EqualTo(Vector2.up));
+        }
+
+        [Test]
+        public void InputSystemTouch_UsesStableTouchIdForRelease()
+        {
+            var eventSystemObject = new GameObject("EventSystem");
+            var eventSystem = eventSystemObject.AddComponent<EventSystem>();
+            try
+            {
+                var pointerDown = CreateExtendedPointer(
+                    eventSystem,
+                    UIPointerType.Touch,
+                    touchId: 17,
+                    pointerId: 100,
+                    position: Vector2.zero);
+                var pointerUp = CreateExtendedPointer(
+                    eventSystem,
+                    UIPointerType.Touch,
+                    touchId: 17,
+                    pointerId: 200,
+                    position: Vector2.zero);
+
+                button.OnPointerDown(pointerDown);
+                Assert.IsTrue(button.IsDefending);
+
+                button.OnPointerUp(pointerUp);
+                Assert.IsFalse(button.IsDefending);
+            }
+            finally
+            {
+                Object.DestroyImmediate(eventSystemObject);
+            }
+        }
+
+        [Test]
+        public void InputSystemMouse_IsNotCapturedAsTouch()
+        {
+            var eventSystemObject = new GameObject("EventSystem");
+            var eventSystem = eventSystemObject.AddComponent<EventSystem>();
+            try
+            {
+                var pointerDown = CreateExtendedPointer(
+                    eventSystem,
+                    UIPointerType.MouseOrPen,
+                    touchId: 0,
+                    pointerId: 5,
+                    position: Vector2.zero);
+
+                button.OnPointerDown(pointerDown);
+
+                Assert.IsFalse(button.IsDefending);
+            }
+            finally
+            {
+                Object.DestroyImmediate(eventSystemObject);
+            }
+        }
+
+        [Test]
+        public void MissingPointerUp_ResetsWhenCapturedTouchIsNoLongerActive()
+        {
+            var eventSystemObject = new GameObject("EventSystem");
+            var eventSystem = eventSystemObject.AddComponent<EventSystem>();
+            try
+            {
+                button.OnPointerDown(CreateExtendedPointer(
+                    eventSystem,
+                    UIPointerType.Touch,
+                    touchId: 23,
+                    pointerId: 123,
+                    position: Vector2.zero));
+                Assert.IsTrue(button.IsDefending);
+                button.SimulateDrag(23, Vector2.right * 200f);
+
+                InvokeLifecycle(button, "LateUpdate");
+
+                Assert.IsFalse(button.IsDefending);
+                Assert.That(button.FacingDirection, Is.EqualTo(Vector2.zero));
+                Assert.That(buttonObject.GetComponent<RectTransform>().anchoredPosition,
+                    Is.EqualTo(Vector2.zero));
+            }
+            finally
+            {
+                Object.DestroyImmediate(eventSystemObject);
+            }
+        }
+
+        [Test]
+        public void GenericPointer_MissingPointerUpResetsWhenNoPointerIsPressed()
+        {
+            var eventSystemObject = new GameObject("EventSystem");
+            var eventSystem = eventSystemObject.AddComponent<EventSystem>();
+            try
+            {
+                button.OnPointerDown(new PointerEventData(eventSystem)
+                {
+                    pointerId = 12,
+                    position = Vector2.zero
+                });
+                Assert.IsTrue(button.IsDefending);
+                button.SimulateDrag(12, Vector2.up * 200f);
+
+                InvokeLifecycle(button, "LateUpdate");
+
+                Assert.IsFalse(button.IsDefending);
+                Assert.That(button.FacingDirection, Is.EqualTo(Vector2.zero));
+                Assert.That(buttonObject.GetComponent<RectTransform>().anchoredPosition,
+                    Is.EqualTo(Vector2.zero));
+            }
+            finally
+            {
+                Object.DestroyImmediate(eventSystemObject);
+            }
+        }
+
+        [Test]
+        public void DisableAndFocusLoss_ClearCapturedDefense()
+        {
+            var buttonRect = buttonObject.GetComponent<RectTransform>();
+            button.SimulatePointerDown(4, Vector2.zero);
+            button.SimulateDrag(4, Vector2.right * 200f);
+            InvokeLifecycle(button, "OnDisable");
+            Assert.IsFalse(button.IsDefending);
+            Assert.That(buttonRect.anchoredPosition, Is.EqualTo(Vector2.zero));
+
+            button.SimulatePointerDown(5, Vector2.zero);
+            button.SimulateDrag(5, Vector2.up * 200f);
+            InvokeLifecycle(button, "OnApplicationFocus", false);
+            Assert.IsFalse(button.IsDefending);
+            Assert.That(buttonRect.anchoredPosition, Is.EqualTo(Vector2.zero));
+        }
+
+        [Test]
+        public void ApplicationPause_ClearsCaptureAndSnapsButtonHome()
+        {
+            var buttonRect = buttonObject.GetComponent<RectTransform>();
+            button.SoftAnchorRadius = 75f;
+            button.SimulatePointerDown(4, Vector2.zero);
+            button.SimulateDrag(4, Vector2.right * 200f);
+            Assert.That(buttonRect.anchoredPosition, Is.Not.EqualTo(Vector2.zero));
+
+            InvokeLifecycle(button, "OnApplicationPause", true);
+
+            Assert.IsFalse(button.IsDefending);
+            Assert.That(button.FacingDirection, Is.EqualTo(Vector2.zero));
+            Assert.That(buttonRect.anchoredPosition, Is.EqualTo(Vector2.zero));
+        }
+
+        [Test]
+        public void DragWithinSoftRadius_AimsWithoutMovingButton()
+        {
+            var buttonRect = buttonObject.GetComponent<RectTransform>();
+            button.SoftAnchorRadius = 75f;
+            button.MaxAnchorDrift = 100f;
+            button.SimulatePointerDown(4, Vector2.zero);
+
+            button.SimulateDrag(4, Vector2.right * 50f);
+
+            Assert.That(button.FacingDirection, Is.EqualTo(Vector2.right));
+            Assert.That(button.CurrentAnchorScreenPosition, Is.EqualTo(Vector2.zero));
+            Assert.That(buttonRect.anchoredPosition, Is.EqualTo(Vector2.zero));
+        }
+
+        [Test]
+        public void PointerDownAwayFromVisualCenter_BecomesLogicalAimAnchor()
+        {
+            var buttonRect = buttonObject.GetComponent<RectTransform>();
+            Vector2 pointerDownPosition = new Vector2(100f, 100f);
+            button.SimulatePointerDown(4, pointerDownPosition);
+
+            button.SimulateDrag(4, pointerDownPosition + Vector2.right * 50f);
+
+            Assert.That(button.FacingDirection, Is.EqualTo(Vector2.right));
+            Assert.That(button.CurrentAnchorScreenPosition, Is.EqualTo(pointerDownPosition));
+            Assert.That(buttonRect.anchoredPosition, Is.EqualTo(Vector2.zero));
+        }
+
+        [Test]
+        public void DragBeyondSoftRadius_MovesButtonByOnlyExcessDistance()
+        {
+            button.SoftAnchorRadius = 75f;
+            button.MaxAnchorDrift = 100f;
+            button.SimulatePointerDown(4, Vector2.zero);
+
+            button.SimulateDrag(4, Vector2.right * 125f);
+
+            Assert.That(button.CurrentAnchorScreenPosition, Is.EqualTo(Vector2.right * 50f));
+            Assert.That(buttonObject.GetComponent<RectTransform>().anchoredPosition,
+                Is.EqualTo(Vector2.right * 50f));
+        }
+
+        [Test]
+        public void PointerReturningInsideRadius_KeepsAnchorAtItsNewPosition()
+        {
+            button.SoftAnchorRadius = 75f;
+            button.MaxAnchorDrift = 100f;
+            button.SimulatePointerDown(4, Vector2.zero);
+            button.SimulateDrag(4, Vector2.right * 125f);
+            Assert.That(button.CurrentAnchorScreenPosition, Is.EqualTo(Vector2.right * 50f));
+
+            button.SimulateDrag(4, Vector2.right * 80f);
+
+            Assert.That(button.CurrentAnchorScreenPosition, Is.EqualTo(Vector2.right * 50f));
+            Assert.That(buttonObject.GetComponent<RectTransform>().anchoredPosition,
+                Is.EqualTo(Vector2.right * 50f));
+            Assert.That(button.FacingDirection, Is.EqualTo(Vector2.right));
+        }
+
+        [Test]
+        public void ExtendedDrag_ClampsButtonDriftFromOriginalPosition()
+        {
+            button.SoftAnchorRadius = 75f;
+            button.MaxAnchorDrift = 100f;
+            button.SimulatePointerDown(4, Vector2.zero);
+
+            Vector2 farDiagonalPointer = new Vector2(-400f, 400f);
+            button.SimulateDrag(4, farDiagonalPointer);
+
+            Assert.That(button.CurrentAnchorScreenPosition.magnitude, Is.EqualTo(100f).Within(0.0001f));
+            Assert.That(button.FacingDirection, Is.EqualTo(farDiagonalPointer.normalized));
+        }
+
+        [Test]
+        public void ReleaseAfterSoftAnchorDrift_SnapsButtonBackHome()
+        {
+            var buttonRect = buttonObject.GetComponent<RectTransform>();
+            button.SoftAnchorRadius = 75f;
+            button.MaxAnchorDrift = 100f;
+            button.SimulatePointerDown(4, Vector2.zero);
+            button.SimulateDrag(4, Vector2.up * 200f);
+            Assert.That(buttonRect.anchoredPosition, Is.Not.EqualTo(Vector2.zero));
+
+            button.SimulatePointerUp(4);
+
+            Assert.That(buttonRect.anchoredPosition, Is.EqualTo(Vector2.zero));
+            Assert.That(button.CurrentAnchorScreenPosition, Is.EqualTo(Vector2.zero));
+        }
+
+        private static void InvokeLifecycle(
+            TouchDefenseAimButton target,
+            string methodName,
+            params object[] arguments)
+        {
+            target.GetType()
+                .GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic)
+                ?.Invoke(target, arguments);
+        }
+
+        private static ExtendedPointerEventData CreateExtendedPointer(
+            EventSystem eventSystem,
+            UIPointerType pointerType,
+            int touchId,
+            int pointerId,
+            Vector2 position)
+        {
+            return new ExtendedPointerEventData(eventSystem)
+            {
+                pointerType = pointerType,
+                touchId = touchId,
+                pointerId = pointerId,
+                position = position
+            };
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Input/TouchDefenseAimButtonTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Input/TouchDefenseAimButtonTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ca607576626f457c82c66249214e1e23

--- a/Assets/_Project/_Tests/EditMode/_Project.Tests.EditMode.asmdef
+++ b/Assets/_Project/_Tests/EditMode/_Project.Tests.EditMode.asmdef
@@ -1,7 +1,7 @@
 {
   "name": "_Project.Tests.EditMode",
   "rootNamespace": "",
-  "references": ["_Project.Core", "_Project.Gameplay", "Unity.TextMeshPro", "GUID:476f7c6c6dfeed041b063446a926e656"],
+  "references": ["_Project.Core", "_Project.Gameplay", "Unity.TextMeshPro", "Unity.InputSystem", "GUID:476f7c6c6dfeed041b063446a926e656"],
   "includePlatforms": ["Editor"],
   "excludePlatforms": [],
   "allowUnsafeCode": false,

--- a/Assets/_Project/_Tests/PlayMode/Combat/PlayerDefenseEnemyAttackPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/Combat/PlayerDefenseEnemyAttackPlayTests.cs
@@ -1,0 +1,77 @@
+using System.Collections;
+using System.Reflection;
+using Castlebound.Gameplay.Combat;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Castlebound.Tests.PlayMode.Combat
+{
+    public class PlayerDefenseEnemyAttackPlayTests
+    {
+        [UnityTest]
+        public IEnumerator EnemyClockImpact_DuringFrontalParry_NegatesPlayerDamage()
+        {
+            var player = CreatePlayer();
+            var enemy = CreateEnemy(player.transform);
+            var defense = player.GetComponent<PlayerDefenseController>();
+            PlayerHitResult observed = default;
+            defense.HitResolved += result => observed = result;
+
+            try
+            {
+                defense.SetDefensePressed(true);
+                yield return new WaitForSeconds(0.08f);
+
+                Assert.That(player.GetComponent<Health>().Current, Is.EqualTo(10));
+                Assert.That(observed.Outcome, Is.EqualTo(PlayerHitOutcome.Parried));
+                Assert.That(observed.Attacker, Is.SameAs(enemy));
+            }
+            finally
+            {
+                Object.Destroy(enemy);
+                Object.Destroy(player);
+            }
+        }
+
+        private static GameObject CreatePlayer()
+        {
+            var player = new GameObject("Player");
+            player.tag = "Player";
+            player.layer = LayerMask.NameToLayer("Player");
+            player.transform.position = new Vector2(0.5f, 0f);
+            player.transform.rotation = Quaternion.Euler(0f, 0f, -90f);
+            player.AddComponent<BoxCollider2D>();
+            player.AddComponent<Health>().ConfigureMaxHealth(10, refill: true);
+            var defense = player.AddComponent<PlayerDefenseController>();
+            defense.Configure(0.15f, 0.15f, 120f, 0.6f);
+            return player;
+        }
+
+        private static GameObject CreateEnemy(Transform target)
+        {
+            var enemy = new GameObject("Enemy");
+            var body = enemy.AddComponent<Rigidbody2D>();
+            body.gravityScale = 0f;
+            enemy.AddComponent<BoxCollider2D>();
+            var controller = enemy.AddComponent<EnemyController2D>();
+            controller.Debug_SetupRefs(target);
+
+            var facing = enemy.GetComponent<EnemyFacing>();
+            SetField(facing, "attackAlignmentThreshold", 180f);
+
+            var attack = enemy.AddComponent<EnemyAttack>();
+            SetField(attack, "windupSeconds", 0.02f);
+            attack.CooldownSeconds = 1f;
+            attack.Damage = 4;
+            return enemy;
+        }
+
+        private static void SetField(object instance, string fieldName, object value)
+        {
+            instance.GetType()
+                .GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)
+                ?.SetValue(instance, value);
+        }
+    }
+}

--- a/Assets/_Project/_Tests/PlayMode/Combat/PlayerDefenseEnemyAttackPlayTests.cs.meta
+++ b/Assets/_Project/_Tests/PlayMode/Combat/PlayerDefenseEnemyAttackPlayTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f621b81fe8574cfeb33de555a754d21c

--- a/TEST_LOG.md
+++ b/TEST_LOG.md
@@ -1,3 +1,39 @@
+## 2026-08-05 - feat-player-defense-soft-anchor
+
+### Summary
+- Made the physical mobile defense button advance only when aim exceeds its current soft-anchor radius, retaining each new position until exceeded again or released.
+- Clamped button drift to a maximum radius around its authored right-side screen position.
+- Restored the button to its authored position on release, missing release, disable, pause, or focus loss.
+- Tuned the authored soft-anchor radius to 160 pixels and maximum drift to 170 pixels.
+
+### New or Updated Tests
+**EditMode**
+- TouchDefenseAimButtonTests — soft-follow threshold, radial maximum drift, continued aim direction, and snap-back lifecycle coverage.
+
+**PlayMode**
+- N/A — N/A
+
+### Notes
+- Full EditMode and PlayMode suites pass in the Unity Test Runner; simulator validation confirms block/parry feedback, reliable release, and bounded stateful soft-anchor behavior.
+
+## 2026-08-04 - feat-player-frontal-block-parry
+
+### Summary
+- Added deterministic Idle, Parry Window, Blocking, and Recovery defense states with a 120-degree frontal melee resolver and Health-owned applied damage.
+- Integrated attack cancellation, continuous guard aiming, 60% guarding movement, contextual enemy melee delivery, and projectile bypass behavior.
+- Added right-mouse, left-trigger, and captured mobile defense/aim input plus a world-space guard arc for parry, block, success, and recovery feedback.
+- Hardened mobile defense release with stable Input System touch identity and cleanup for missing release, cancellation, disable, pause, and focus loss.
+
+### New or Updated Tests
+**EditMode**
+- PlayerDefenseStateMachineTests, PlayerDefenseHitResolverTests, PlayerDefenseControllerTests, PlayerGuardArcPresenterTests, PlayerDefensePrefabContractTests, TouchDefenseAimButtonTests, and DefenseInputContractsTests — state timing, inclusive arc boundaries, applied damage, attack cancellation, presentation, prefab wiring, stable touch release, stale-capture cleanup, and desktop/gamepad/mobile input contracts.
+
+**PlayMode**
+- PlayerDefenseEnemyAttackPlayTests — deterministic enemy-clock impact is negated by a frontal parry while preserving attacker identity.
+
+### Notes
+- Gameplay and test assemblies pass Roslyn compile validation; Unity EditMode and PlayMode execution remains pending manual Test Runner validation because the project is open in Unity.
+
 ## 2026-08-03 - refactor-269-normalized-attack-timing
 
 ### Summary


### PR DESCRIPTION
## Why
Player combat needs an active directional defense option that rewards timing while preserving free movement and distinct desktop, gamepad, and mobile controls.

## What changed
- Added deterministic parry-window, blocking, recovery, and hit-resolution contracts for 120-degree frontal melee defense
- Integrated immediate attack cancellation, reduced guarding movement, full frontal damage negation, and projectile/out-of-arc bypass behavior
- Added cyan block/parry presentation with gold successful-parry feedback
- Added right-mouse, left-trigger, and captured mobile defense aim with a bounded stateful soft anchor
- Added EditMode contract/regression coverage and a PlayMode enemy-impact defense path

## How to test
1. Open MainPrototype and enter Play Mode
2. Hold defense with right mouse, left trigger, or the mobile defense button; verify aiming, release, guard arc feedback, frontal block, and gold successful-parry flash
3. Run tests:
   - EditMode: full suite passes
   - PlayMode: full suite passes; manual simulator behavior validated

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched (N/A - behavior and validation are recorded in TEST_LOG.md)

## Related
- Closes #265