### PR TITLE
feat(combat): stagger enemies after successful parries

### DIFF
--- a/Assets/_Project/Prefabs/Enemy_Goblin_Melee.prefab
+++ b/Assets/_Project/Prefabs/Enemy_Goblin_Melee.prefab
@@ -132,6 +132,7 @@ GameObject:
   - component: {fileID: 1937058686654329911}
   - component: {fileID: 3821050183671550168}
   - component: {fileID: 9000000000000000001}
+  - component: {fileID: 9200000000000000001}
   - component: {fileID: 4031526577869015660}
   - component: {fileID: 4347245256977356794}
   - component: {fileID: 2387932495633829988}
@@ -249,6 +250,7 @@ MonoBehaviour:
   facing: {fileID: 8041287619235472015}
   engagement: {fileID: 8041287619235472016}
   animationPresenter: {fileID: 0}
+  staggerReceiver: {fileID: 9200000000000000001}
   speed: 8
   orbitBase: 2.8
   maxTangent: 2
@@ -295,6 +297,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   attackDeliverySource: {fileID: 9000000000000000001}
+  staggerReceiver: {fileID: 9200000000000000001}
   windupSeconds: 0.3
   cooldownSeconds: 0.8
   targetMask:
@@ -315,6 +318,22 @@ MonoBehaviour:
   m_EditorClassIdentifier:
   damage: 1
   enemyHitBarrierFeedbackChannel: {fileID: 11400000, guid: 70c41c2488baae148bc4ec73d60b720f, type: 2}
+  staggerReceiver: {fileID: 9200000000000000001}
+--- !u!114 &9200000000000000001
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6394411849047796180}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 067c998b09e54aa5bb8cd66a3e2f743d, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  staggerEligible: 1
+  staggerDurationSeconds: 1
+  enemyAttack: {fileID: 3821050183671550168}
 --- !u!114 &4031526577869015660
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -345,6 +364,8 @@ MonoBehaviour:
   targetRenderer: {fileID: 7926314504726225482}
   flashColor: {r: 1, g: 0.2, b: 0.2, a: 0.4392157}
   flashDurationSeconds: 0.1
+  staggerReceiver: {fileID: 9200000000000000001}
+  staggerColor: {r: 1, g: 0.85, b: 0, a: 1}
 --- !u!114 &2387932495633829988
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyController2D.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyController2D.cs
@@ -24,6 +24,7 @@ public class EnemyController2D : MonoBehaviour
     [SerializeField] private EnemyFacing facing;
     [SerializeField] private EnemyEngagement engagement;
     [SerializeField] private EnemyAnimationPresenter animationPresenter;
+    [SerializeField] private EnemyStaggerReceiver staggerReceiver;
 
     [SerializeField] private float speed = 3.5f;
     [SerializeField] private float orbitBase = 0.8f;
@@ -195,6 +196,20 @@ public class EnemyController2D : MonoBehaviour
             if (_rb == null) return;
         }
 
+        if (staggerReceiver != null &&
+            staggerReceiver.State == EnemyStaggerState.Staggered)
+        {
+            _rb.velocity = Vector2.zero;
+            _rb.angularVelocity = 0f;
+            _rb.position = staggerReceiver.LockPosition;
+            transform.position = new Vector3(
+                staggerReceiver.LockPosition.x,
+                staggerReceiver.LockPosition.y,
+                transform.position.z);
+            animationPresenter?.SetMovementRequested(false);
+            return;
+        }
+
         if (regionState == null)
         {
             regionState = GetComponent<EnemyRegionState>();
@@ -203,7 +218,16 @@ public class EnemyController2D : MonoBehaviour
         bool enemyInsideCastle = regionState != null && regionState.EnemyInside;
         bool playerInsideCastle = regionState != null && regionState.PlayerInside;
 
+        bool awaitingStaggerRefresh = staggerReceiver != null &&
+            staggerReceiver.State == EnemyStaggerState.AwaitingTargetRefresh;
+        if (awaitingStaggerRefresh)
+            Targeting.RequestRetarget();
+
         Targeting.Refresh(_rb.position, playerInsideCastle, enemyInsideCastle);
+        if (awaitingStaggerRefresh)
+        {
+            staggerReceiver.AcknowledgeTargetRefresh();
+        }
         Transform steerTarget = Targeting.SteerTarget;
         Transform target = Targeting.AttackTarget;
         Transform player = Targeting.Player;

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyStaggerReceiver.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyStaggerReceiver.cs
@@ -1,0 +1,92 @@
+using UnityEngine;
+
+namespace Castlebound.Gameplay.AI
+{
+    public class EnemyStaggerReceiver : MonoBehaviour, IEnemyStaggerReceiver
+    {
+        [SerializeField] private bool staggerEligible = true;
+        [SerializeField, Min(0f)] private float staggerDurationSeconds = 1f;
+        [SerializeField] private EnemyAttack enemyAttack;
+
+        public EnemyStaggerState State { get; private set; }
+        public float RemainingSeconds { get; private set; }
+        public bool IsActionLocked => State != EnemyStaggerState.Inactive;
+        public bool StaggerEligible => staggerEligible;
+        public float StaggerDurationSeconds => NormalizeDuration(staggerDurationSeconds);
+
+        private void Update()
+        {
+            Tick(Time.deltaTime);
+        }
+
+        private void OnDisable()
+        {
+            ClearState();
+        }
+
+        private void OnValidate()
+        {
+            staggerDurationSeconds = NormalizeDuration(staggerDurationSeconds);
+        }
+
+        public bool TryStagger()
+        {
+            float duration = StaggerDurationSeconds;
+            if (!staggerEligible || duration <= 0f || enemyAttack == null || IsActionLocked)
+                return false;
+
+            RemainingSeconds = duration;
+            State = EnemyStaggerState.Staggered;
+            enemyAttack.CancelForStagger();
+            return true;
+        }
+
+        public void Tick(float deltaTime)
+        {
+            if (State != EnemyStaggerState.Staggered)
+                return;
+
+            RemainingSeconds = Mathf.Max(0f, RemainingSeconds - NormalizeDelta(deltaTime));
+            if (RemainingSeconds <= 0f)
+                State = EnemyStaggerState.AwaitingTargetRefresh;
+        }
+
+        public bool AcknowledgeTargetRefresh()
+        {
+            if (State != EnemyStaggerState.AwaitingTargetRefresh)
+                return false;
+
+            ClearState();
+            return true;
+        }
+
+        public void Configure(bool eligible, float durationSeconds, EnemyAttack attack)
+        {
+            staggerEligible = eligible;
+            staggerDurationSeconds = NormalizeDuration(durationSeconds);
+            enemyAttack = attack;
+        }
+
+        private void ClearState()
+        {
+            State = EnemyStaggerState.Inactive;
+            RemainingSeconds = 0f;
+        }
+
+        private static float NormalizeDuration(float duration)
+        {
+            if (float.IsNaN(duration) || float.IsInfinity(duration) || duration <= 0f)
+                return 0f;
+            return duration;
+        }
+
+        private static float NormalizeDelta(float deltaTime)
+        {
+            if (float.IsNaN(deltaTime) || float.IsNegativeInfinity(deltaTime) || deltaTime <= 0f)
+                return 0f;
+            if (float.IsPositiveInfinity(deltaTime))
+                return float.MaxValue;
+            return deltaTime;
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyStaggerReceiver.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyStaggerReceiver.cs
@@ -10,6 +10,7 @@ namespace Castlebound.Gameplay.AI
 
         public EnemyStaggerState State { get; private set; }
         public float RemainingSeconds { get; private set; }
+        public Vector2 LockPosition { get; private set; }
         public bool IsActionLocked => State != EnemyStaggerState.Inactive;
         public bool StaggerEligible => staggerEligible;
         public float StaggerDurationSeconds => NormalizeDuration(staggerDurationSeconds);
@@ -36,6 +37,7 @@ namespace Castlebound.Gameplay.AI
                 return false;
 
             RemainingSeconds = duration;
+            LockPosition = transform.position;
             State = EnemyStaggerState.Staggered;
             enemyAttack.CancelForStagger();
             return true;
@@ -71,6 +73,7 @@ namespace Castlebound.Gameplay.AI
         {
             State = EnemyStaggerState.Inactive;
             RemainingSeconds = 0f;
+            LockPosition = transform.position;
         }
 
         private static float NormalizeDuration(float duration)

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyStaggerReceiver.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyStaggerReceiver.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 067c998b09e54aa5bb8cd66a3e2f743d

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyStaggerState.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyStaggerState.cs
@@ -1,0 +1,9 @@
+namespace Castlebound.Gameplay.AI
+{
+    public enum EnemyStaggerState
+    {
+        Inactive,
+        Staggered,
+        AwaitingTargetRefresh
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyStaggerState.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyStaggerState.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 95c7053167fc4377af593e67700af2bc

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/IEnemyStaggerReceiver.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/IEnemyStaggerReceiver.cs
@@ -1,0 +1,8 @@
+namespace Castlebound.Gameplay.AI
+{
+    public interface IEnemyStaggerReceiver
+    {
+        bool IsActionLocked { get; }
+        bool TryStagger();
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/IEnemyStaggerReceiver.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/IEnemyStaggerReceiver.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 78f54d35a6c947c7b409e397165fffe3

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/EnemyAttack.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/EnemyAttack.cs
@@ -22,6 +22,7 @@ public class EnemyAttack : MonoBehaviour
     private EnemyRootReceiver rootReceiver;
     private EnemyAnimationPresenter animationPresenter;
     private EnemyEquipment equipment;
+    [SerializeField] private EnemyStaggerReceiver staggerReceiver;
     private IEnemyAttackDelivery attackDelivery;
     private Transform lockedTarget;
     private EnemyEquipmentDefinition equipmentDefinitionSnapshot;
@@ -73,6 +74,12 @@ public class EnemyAttack : MonoBehaviour
 
     private void Update()
     {
+        if (staggerReceiver != null && staggerReceiver.IsActionLocked)
+        {
+            CancelForStagger();
+            return;
+        }
+
         if (attackClock.IsRunning)
         {
             AdvanceAttack(Time.deltaTime);
@@ -162,6 +169,9 @@ public class EnemyAttack : MonoBehaviour
                     CancelCurrentAttack(requestChase: true);
                     return;
                 }
+
+                if (!attackClock.IsRunning)
+                    return;
 
                 impactDelivered = true;
             }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/EnemyAttack.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/EnemyAttack.cs
@@ -205,6 +205,11 @@ public class EnemyAttack : MonoBehaviour
             controller?.RequestChase();
     }
 
+    public void CancelForStagger()
+    {
+        CancelCurrentAttack(requestChase: false);
+    }
+
     private void ClearAttackSnapshot()
     {
         lockedTarget = null;

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/EnemyMeleeAttackDelivery.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/EnemyMeleeAttackDelivery.cs
@@ -6,6 +6,7 @@ public class EnemyMeleeAttackDelivery : MonoBehaviour, IEnemyAttackDelivery
 {
     [SerializeField, Min(0)] private int damage = 1;
     [SerializeField] private FeedbackEventChannel enemyHitBarrierFeedbackChannel;
+    [SerializeField] private EnemyStaggerReceiver staggerReceiver;
 
     private EnemyRegionState regionState;
     private EnemyRootReceiver rootReceiver;
@@ -19,6 +20,7 @@ public class EnemyMeleeAttackDelivery : MonoBehaviour, IEnemyAttackDelivery
         CombatEquipmentSnapshot combatEquipmentSnapshot)
     {
         return lockedTarget != null &&
+               !IsActionLocked() &&
                (equipmentDefinitionSnapshot == null || equipmentDefinitionSnapshot.IsCompatibleWith(AttackRole)) &&
                ResolveDamageable(lockedTarget) != null;
     }
@@ -55,7 +57,7 @@ public class EnemyMeleeAttackDelivery : MonoBehaviour, IEnemyAttackDelivery
 
     private bool TryDealDamage(IDamageable target, int resolvedDamage)
     {
-        if (target == null || resolvedDamage <= 0 || IsRooted())
+        if (target == null || resolvedDamage <= 0 || IsRooted() || IsActionLocked())
         {
             return false;
         }
@@ -78,11 +80,13 @@ public class EnemyMeleeAttackDelivery : MonoBehaviour, IEnemyAttackDelivery
 
         if (TryResolvePlayerHitReceiver(target, out var playerHitReceiver))
         {
-            playerHitReceiver.ReceiveHit(new PlayerHitRequest(
+            PlayerHitResult result = playerHitReceiver.ReceiveHit(new PlayerHitRequest(
                 resolvedDamage,
                 gameObject,
                 transform.position,
                 CombatDamageType.Melee));
+            if (result.Outcome == PlayerHitOutcome.Parried)
+                ((IEnemyStaggerReceiver)staggerReceiver)?.TryStagger();
             return true;
         }
 
@@ -146,5 +150,10 @@ public class EnemyMeleeAttackDelivery : MonoBehaviour, IEnemyAttackDelivery
         }
 
         return rootReceiver != null && rootReceiver.IsRooted;
+    }
+
+    private bool IsActionLocked()
+    {
+        return staggerReceiver != null && staggerReceiver.IsActionLocked;
     }
 }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/Feedback/HitFlashListener.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/Feedback/HitFlashListener.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using Castlebound.Gameplay.AI;
 using UnityEngine;
 
 public class HitFlashListener : MonoBehaviour
@@ -7,9 +8,12 @@ public class HitFlashListener : MonoBehaviour
     [SerializeField] SpriteRenderer targetRenderer;
     [SerializeField] Color flashColor = new Color(1f, 0.2f, 0.2f, 1f);
     [SerializeField] float flashDurationSeconds = 0.1f;
+    [SerializeField] EnemyStaggerReceiver staggerReceiver;
+    [SerializeField] Color staggerColor = new Color(1f, 0.85f, 0f, 1f);
 
     Color originalColor;
     Coroutine flashRoutine;
+    bool isDamageFlashActive;
 
     void Awake()
     {
@@ -34,6 +38,11 @@ public class HitFlashListener : MonoBehaviour
         ResetFlash();
     }
 
+    void LateUpdate()
+    {
+        ApplyCurrentColor();
+    }
+
     void OnFeedbackRaised(FeedbackCue cue)
     {
         if (cue.Type != FeedbackCueType.PlayerHitEnemy)
@@ -45,20 +54,18 @@ public class HitFlashListener : MonoBehaviour
         if (flashRoutine != null)
             StopCoroutine(flashRoutine);
 
+        isDamageFlashActive = true;
+        ApplyCurrentColor();
         flashRoutine = StartCoroutine(FlashRoutine());
     }
 
     IEnumerator FlashRoutine()
     {
-        if (targetRenderer != null)
-            targetRenderer.color = flashColor;
-
         yield return new WaitForSeconds(flashDurationSeconds);
 
-        if (targetRenderer != null)
-            targetRenderer.color = originalColor;
-
+        isDamageFlashActive = false;
         flashRoutine = null;
+        ApplyCurrentColor();
     }
 
     void ResetFlash()
@@ -69,7 +76,24 @@ public class HitFlashListener : MonoBehaviour
             flashRoutine = null;
         }
 
+        isDamageFlashActive = false;
         if (targetRenderer != null)
             targetRenderer.color = originalColor;
+    }
+
+    private void ApplyCurrentColor()
+    {
+        if (targetRenderer == null)
+            return;
+
+        if (isDamageFlashActive)
+        {
+            targetRenderer.color = flashColor;
+            return;
+        }
+
+        targetRenderer.color = staggerReceiver != null && staggerReceiver.IsActionLocked
+            ? staggerColor
+            : originalColor;
     }
 }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/PlayerDefenseStateMachine.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/PlayerDefenseStateMachine.cs
@@ -6,38 +6,50 @@ namespace Castlebound.Gameplay.Combat
     {
         private const float BoundaryTolerance = 0.000001f;
 
-        private readonly float parryWindowDuration;
-        private readonly float recoveryDuration;
+        private float activeParryWindowDuration;
+        private float activeRecoveryDuration;
         private float elapsed;
 
-        public PlayerDefenseStateMachine(float parryWindowDuration, float recoveryDuration)
-        {
-            this.parryWindowDuration = NormalizeDuration(parryWindowDuration);
-            this.recoveryDuration = NormalizeDuration(recoveryDuration);
-        }
-
         public PlayerDefenseState State { get; private set; } = PlayerDefenseState.Idle;
+        public int RemainingParryCapacity { get; private set; }
         public bool IsGuarding => State == PlayerDefenseState.ParryWindow
             || State == PlayerDefenseState.Blocking;
         public bool CanAttack => State == PlayerDefenseState.Idle;
 
-        public bool BeginDefense()
+        public bool BeginDefense(float parryWindowDuration, int parryCapacity)
         {
             if (State != PlayerDefenseState.Idle)
                 return false;
 
             elapsed = 0f;
-            State = PlayerDefenseState.ParryWindow;
+            activeParryWindowDuration = NormalizeDuration(parryWindowDuration);
+            RemainingParryCapacity = Mathf.Max(0, parryCapacity);
+            State = RemainingParryCapacity > 0
+                ? PlayerDefenseState.ParryWindow
+                : PlayerDefenseState.Blocking;
             return true;
         }
 
-        public bool ReleaseDefense()
+        public bool ReleaseDefense(float recoveryDuration)
         {
             if (!IsGuarding)
                 return false;
 
             elapsed = 0f;
+            activeRecoveryDuration = NormalizeDuration(recoveryDuration);
+            RemainingParryCapacity = 0;
             State = PlayerDefenseState.Recovery;
+            return true;
+        }
+
+        public bool TryConsumeParry()
+        {
+            if (State != PlayerDefenseState.ParryWindow || RemainingParryCapacity <= 0)
+                return false;
+
+            RemainingParryCapacity--;
+            if (RemainingParryCapacity == 0)
+                State = PlayerDefenseState.Blocking;
             return true;
         }
 
@@ -48,7 +60,7 @@ namespace Castlebound.Gameplay.Combat
             if (State == PlayerDefenseState.ParryWindow)
             {
                 elapsed += safeDelta;
-                if (elapsed > parryWindowDuration + BoundaryTolerance)
+                if (elapsed > activeParryWindowDuration + BoundaryTolerance)
                     State = PlayerDefenseState.Blocking;
                 return;
             }
@@ -57,7 +69,7 @@ namespace Castlebound.Gameplay.Combat
                 return;
 
             elapsed += safeDelta;
-            if (elapsed + BoundaryTolerance < recoveryDuration)
+            if (elapsed + BoundaryTolerance < activeRecoveryDuration)
                 return;
 
             elapsed = 0f;

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerDefenseController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerDefenseController.cs
@@ -8,6 +8,7 @@ public class PlayerDefenseController : MonoBehaviour, IPlayerHitReceiver
 {
     [Header("Timing")]
     [SerializeField, Min(0f)] private float parryWindowDuration = 0.15f;
+    [SerializeField, Min(0)] private int parryCapacity = 1;
     [SerializeField, Min(0f)] private float recoveryDuration = 0.15f;
 
     [Header("Guard")]
@@ -26,6 +27,7 @@ public class PlayerDefenseController : MonoBehaviour, IPlayerHitReceiver
     public PlayerDefenseState State => EnsureStateMachine().State;
     public bool IsGuarding => EnsureStateMachine().IsGuarding;
     public bool CanAttack => EnsureStateMachine().CanAttack;
+    public int RemainingParryCapacity => EnsureStateMachine().RemainingParryCapacity;
     public float MovementSpeedMultiplier => IsGuarding ? guardingMovementMultiplier : 1f;
     public float BlockArcDegrees => blockArcDegrees;
 
@@ -46,6 +48,7 @@ public class PlayerDefenseController : MonoBehaviour, IPlayerHitReceiver
     private void OnValidate()
     {
         parryWindowDuration = Mathf.Max(0f, parryWindowDuration);
+        parryCapacity = Mathf.Max(0, parryCapacity);
         recoveryDuration = Mathf.Max(0f, recoveryDuration);
         blockArcDegrees = Mathf.Clamp(blockArcDegrees, 0f, 360f);
         guardingMovementMultiplier = Mathf.Clamp01(guardingMovementMultiplier);
@@ -66,8 +69,8 @@ public class PlayerDefenseController : MonoBehaviour, IPlayerHitReceiver
     {
         PlayerDefenseState previous = State;
         bool changed = isPressed
-            ? stateMachine.BeginDefense()
-            : stateMachine.ReleaseDefense();
+            ? stateMachine.BeginDefense(parryWindowDuration, parryCapacity)
+            : stateMachine.ReleaseDefense(recoveryDuration);
 
         if (!changed)
             return;
@@ -104,6 +107,11 @@ public class PlayerDefenseController : MonoBehaviour, IPlayerHitReceiver
             ResolveFacingDirection(),
             blockArcDegrees);
 
+        PlayerDefenseState previous = State;
+        if (result.Outcome == PlayerHitOutcome.Parried)
+            stateMachine.TryConsumeParry();
+        PublishStateChange(previous);
+
         if (result.AppliedDamage > 0)
         {
             int appliedDamage = health != null ? health.ApplyDamage(result.AppliedDamage) : 0;
@@ -129,6 +137,22 @@ public class PlayerDefenseController : MonoBehaviour, IPlayerHitReceiver
         RebuildStateMachine();
     }
 
+    public void Configure(
+        float parryWindowSeconds,
+        float recoverySeconds,
+        float arcDegrees,
+        float movementMultiplier,
+        int capacity,
+        Func<bool> pressedEvaluator = null)
+    {
+        parryWindowDuration = Mathf.Max(0f, parryWindowSeconds);
+        parryCapacity = Mathf.Max(0, capacity);
+        recoveryDuration = Mathf.Max(0f, recoverySeconds);
+        blockArcDegrees = Mathf.Clamp(arcDegrees, 0f, 360f);
+        guardingMovementMultiplier = Mathf.Clamp01(movementMultiplier);
+        isDefenseStillPressedEvaluator = pressedEvaluator;
+    }
+
     private PlayerDefenseStateMachine EnsureStateMachine()
     {
         if (stateMachine == null)
@@ -138,7 +162,8 @@ public class PlayerDefenseController : MonoBehaviour, IPlayerHitReceiver
 
     private void RebuildStateMachine()
     {
-        stateMachine = new PlayerDefenseStateMachine(parryWindowDuration, recoveryDuration);
+        if (stateMachine == null)
+            stateMachine = new PlayerDefenseStateMachine();
     }
 
     private void EnsureReferences()

--- a/Assets/_Project/_Tests/EditMode/AI/EnemyStaggerPrefabContractTests.cs
+++ b/Assets/_Project/_Tests/EditMode/AI/EnemyStaggerPrefabContractTests.cs
@@ -1,0 +1,54 @@
+using System.Reflection;
+using Castlebound.Gameplay.AI;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+
+namespace Castlebound.Tests.AI
+{
+    public class EnemyStaggerPrefabContractTests
+    {
+        private const string MeleePrefabPath = "Assets/_Project/Prefabs/Enemy_Goblin_Melee.prefab";
+        private const string RangedPrefabPath = "Assets/_Project/Prefabs/Enemy_Goblin_Ranged.prefab";
+        private const string LurkerPrefabPath = "Assets/_Project/Prefabs/Enemy_Lurker.prefab";
+
+        [Test]
+        public void MeleeGoblin_AuthorsEligibleOneSecondStaggerWithExplicitReferences()
+        {
+            GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>(MeleePrefabPath);
+            var receiver = prefab.GetComponent<EnemyStaggerReceiver>();
+
+            Assert.NotNull(receiver);
+            Assert.IsTrue(receiver.StaggerEligible);
+            Assert.That(receiver.StaggerDurationSeconds, Is.EqualTo(1f));
+            Assert.That(GetField<EnemyAttack>(receiver, "enemyAttack"), Is.SameAs(prefab.GetComponent<EnemyAttack>()));
+            Assert.That(GetField<EnemyStaggerReceiver>(prefab.GetComponent<EnemyAttack>(), "staggerReceiver"),
+                Is.SameAs(receiver));
+            Assert.That(GetField<EnemyStaggerReceiver>(prefab.GetComponent<EnemyController2D>(), "staggerReceiver"),
+                Is.SameAs(receiver));
+            Assert.That(GetField<EnemyStaggerReceiver>(prefab.GetComponent<EnemyMeleeAttackDelivery>(), "staggerReceiver"),
+                Is.SameAs(receiver));
+            Assert.That(GetField<EnemyStaggerReceiver>(prefab.GetComponent<HitFlashListener>(), "staggerReceiver"),
+                Is.SameAs(receiver));
+        }
+
+        [TestCase(RangedPrefabPath)]
+        [TestCase(LurkerPrefabPath)]
+        public void OtherEnemyPrefabs_DoNotOptIntoStagger(string prefabPath)
+        {
+            GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>(prefabPath);
+
+            Assert.NotNull(prefab);
+            Assert.IsNull(prefab.GetComponent<EnemyStaggerReceiver>());
+        }
+
+        private static T GetField<T>(object instance, string fieldName)
+        {
+            FieldInfo field = instance.GetType().GetField(
+                fieldName,
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(field, $"Missing field {fieldName}.");
+            return (T)field.GetValue(instance);
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/AI/EnemyStaggerPrefabContractTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/AI/EnemyStaggerPrefabContractTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bb7ad834c67f4ac6bea57a846eb0dc37

--- a/Assets/_Project/_Tests/EditMode/AI/EnemyStaggerReceiverTests.cs
+++ b/Assets/_Project/_Tests/EditMode/AI/EnemyStaggerReceiverTests.cs
@@ -1,0 +1,128 @@
+using Castlebound.Gameplay.AI;
+using NUnit.Framework;
+using System.Reflection;
+using UnityEngine;
+
+namespace Castlebound.Tests.AI
+{
+    public class EnemyStaggerReceiverTests
+    {
+        private GameObject enemy;
+        private EnemyAttack attack;
+        private EnemyStaggerReceiver receiver;
+
+        [SetUp]
+        public void SetUp()
+        {
+            enemy = new GameObject("Enemy");
+            enemy.AddComponent<Rigidbody2D>();
+            enemy.AddComponent<EnemyController2D>();
+            attack = enemy.AddComponent<EnemyAttack>();
+            receiver = enemy.AddComponent<EnemyStaggerReceiver>();
+            receiver.Configure(true, 1f, attack);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (enemy != null)
+                Object.DestroyImmediate(enemy);
+        }
+
+        [Test]
+        public void TryStagger_EligibleEnemy_EntersStaggeredForAuthoredDuration()
+        {
+            bool started = receiver.TryStagger();
+
+            Assert.IsTrue(started);
+            Assert.That(receiver.State, Is.EqualTo(EnemyStaggerState.Staggered));
+            Assert.That(receiver.RemainingSeconds, Is.EqualTo(1f));
+            Assert.IsTrue(receiver.IsActionLocked);
+        }
+
+        [Test]
+        public void Tick_WhenDurationCompletes_AwaitsTargetRefreshWhileRemainingLocked()
+        {
+            receiver.TryStagger();
+
+            receiver.Tick(0.999f);
+            Assert.That(receiver.State, Is.EqualTo(EnemyStaggerState.Staggered));
+
+            receiver.Tick(0.001f);
+
+            Assert.That(receiver.State, Is.EqualTo(EnemyStaggerState.AwaitingTargetRefresh));
+            Assert.That(receiver.RemainingSeconds, Is.Zero);
+            Assert.IsTrue(receiver.IsActionLocked);
+        }
+
+        [Test]
+        public void AcknowledgeTargetRefresh_AfterTimer_ReleasesActionLock()
+        {
+            receiver.TryStagger();
+            receiver.Tick(1f);
+
+            bool acknowledged = receiver.AcknowledgeTargetRefresh();
+
+            Assert.IsTrue(acknowledged);
+            Assert.That(receiver.State, Is.EqualTo(EnemyStaggerState.Inactive));
+            Assert.IsFalse(receiver.IsActionLocked);
+        }
+
+        [Test]
+        public void TryStagger_WhileAlreadyLocked_IsIgnoredWithoutRefreshingDuration()
+        {
+            receiver.TryStagger();
+            receiver.Tick(0.4f);
+
+            bool repeated = receiver.TryStagger();
+
+            Assert.IsFalse(repeated);
+            Assert.That(receiver.RemainingSeconds, Is.EqualTo(0.6f).Within(0.0001f));
+        }
+
+        [Test]
+        public void TryStagger_WhenIneligible_IsRejected()
+        {
+            receiver.Configure(false, 1f, attack);
+
+            Assert.IsFalse(receiver.TryStagger());
+            Assert.That(receiver.State, Is.EqualTo(EnemyStaggerState.Inactive));
+        }
+
+        [TestCase(0f)]
+        [TestCase(-1f)]
+        [TestCase(float.NaN)]
+        [TestCase(float.PositiveInfinity)]
+        public void TryStagger_WithInvalidDuration_IsRejected(float duration)
+        {
+            receiver.Configure(true, duration, attack);
+
+            Assert.IsFalse(receiver.TryStagger());
+            Assert.That(receiver.RemainingSeconds, Is.Zero);
+        }
+
+        [Test]
+        public void TryStagger_WithoutExplicitAttackReference_IsRejected()
+        {
+            receiver.Configure(true, 1f, null);
+
+            Assert.IsFalse(receiver.TryStagger());
+            Assert.That(receiver.State, Is.EqualTo(EnemyStaggerState.Inactive));
+        }
+
+        [Test]
+        public void OnDisable_ClearsStaggerStateAndRemainingTime()
+        {
+            receiver.TryStagger();
+
+            MethodInfo onDisable = typeof(EnemyStaggerReceiver)
+                .GetMethod("OnDisable", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(onDisable);
+            onDisable.Invoke(receiver, null);
+
+            Assert.That(receiver.State, Is.EqualTo(EnemyStaggerState.Inactive));
+            Assert.That(receiver.RemainingSeconds, Is.Zero);
+            Assert.IsFalse(receiver.IsActionLocked);
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/AI/EnemyStaggerReceiverTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/AI/EnemyStaggerReceiverTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 68d0f74c09d84e138f0e3273eb76a9da

--- a/Assets/_Project/_Tests/EditMode/Combat/EnemyAttackTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Combat/EnemyAttackTests.cs
@@ -1,6 +1,8 @@
 using NUnit.Framework;
+using System.Reflection;
 using UnityEngine;
 using Castlebound.Gameplay.AI;
+using Castlebound.Gameplay.Combat;
 
 namespace Castlebound.Tests.Combat
 {
@@ -130,6 +132,110 @@ namespace Castlebound.Tests.Combat
             {
                 Object.DestroyImmediate(enemy);
             }
+        }
+
+        [Test]
+        public void AdvanceAttack_WhenParryCancelsReentrantly_ClearsClockAndSwingSnapshot()
+        {
+            var player = new GameObject("Player");
+            var enemy = new GameObject("Enemy");
+            try
+            {
+                player.tag = "Player";
+                player.transform.position = new Vector2(0f, 0.25f);
+                player.AddComponent<Health>().ConfigureMaxHealth(10, refill: true);
+                var defense = player.AddComponent<PlayerDefenseController>();
+                defense.Configure(0.15f, 0.15f, 120f, 0.6f);
+                bool hitResolved = false;
+                PlayerHitResult observed = default;
+                defense.HitResolved += result =>
+                {
+                    hitResolved = true;
+                    observed = result;
+                };
+                defense.SetDefensePressed(true);
+
+                enemy.AddComponent<Rigidbody2D>().gravityScale = 0f;
+                var controller = enemy.AddComponent<EnemyController2D>();
+                controller.Debug_SetupRefs(player.transform);
+                enemy.GetComponent<EnemyFacing>().InitializeAimDirection(Vector2.up);
+                enemy.GetComponent<EnemyEngagement>().Debug_SetTuning(1f, 0f);
+                enemy.GetComponent<EnemyLocomotion>()
+                    .SetMovementState(EnemyController2D.State.HOLD);
+
+                var attack = enemy.AddComponent<EnemyAttack>();
+                var delivery = attack.AttackDeliverySource as EnemyMeleeAttackDelivery;
+                delivery.Damage = 4;
+                var stagger = enemy.AddComponent<EnemyStaggerReceiver>();
+                stagger.Configure(true, 1f, attack);
+                SetField(attack, "staggerReceiver", stagger);
+                SetField(delivery, "staggerReceiver", stagger);
+                attack.AttackDeliverySource = delivery;
+                SetField(attack, "windupSeconds", 0.01f);
+                attack.CooldownSeconds = 1f;
+                InvokePrivate(attack, "Awake");
+
+                Assert.That(controller.Target, Is.SameAs(player.transform));
+                Assert.IsTrue(enemy.GetComponent<EnemyEngagement>()
+                    .IsWithinEngagementDistance(player.transform));
+                Assert.IsTrue(enemy.GetComponent<EnemyFacing>()
+                    .IsAlignedWith(enemy.transform.position, player.transform));
+                Assert.That(stagger.State, Is.EqualTo(EnemyStaggerState.Inactive));
+                Assert.That(GetField<IEnemyAttackDelivery>(attack, "attackDelivery"), Is.SameAs(delivery));
+                Assert.IsTrue(InvokePrivate<bool>(attack, "TryBeginAttack"));
+                Assert.IsTrue(attack.IsAttackActive);
+
+                InvokePrivate(attack, "AdvanceAttack", 0.5f);
+
+                Assert.IsTrue(hitResolved, "The active clock should reach contextual melee delivery.");
+                Assert.That(observed.Outcome, Is.EqualTo(PlayerHitOutcome.Parried));
+                Assert.IsFalse(attack.IsAttackActive);
+                Assert.IsNull(GetField<Transform>(attack, "lockedTarget"));
+                Assert.IsFalse(GetField<bool>(attack, "impactDelivered"));
+                Assert.That(stagger.State, Is.EqualTo(EnemyStaggerState.Staggered));
+                Assert.That(player.GetComponent<Health>().Current, Is.EqualTo(10));
+            }
+            finally
+            {
+                Object.DestroyImmediate(enemy);
+                Object.DestroyImmediate(player);
+            }
+        }
+
+        private static T GetField<T>(object instance, string fieldName)
+        {
+            FieldInfo field = instance.GetType().GetField(
+                fieldName,
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(field, $"Missing field {fieldName}.");
+            return (T)field.GetValue(instance);
+        }
+
+        private static void SetField(object instance, string fieldName, object value)
+        {
+            FieldInfo field = instance.GetType().GetField(
+                fieldName,
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(field, $"Missing field {fieldName}.");
+            field.SetValue(instance, value);
+        }
+
+        private static void InvokePrivate(object instance, string methodName, params object[] arguments)
+        {
+            MethodInfo method = instance.GetType().GetMethod(
+                methodName,
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(method, $"Missing method {methodName}.");
+            method.Invoke(instance, arguments);
+        }
+
+        private static T InvokePrivate<T>(object instance, string methodName, params object[] arguments)
+        {
+            MethodInfo method = instance.GetType().GetMethod(
+                methodName,
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(method, $"Missing method {methodName}.");
+            return (T)method.Invoke(instance, arguments);
         }
     }
 }

--- a/Assets/_Project/_Tests/EditMode/Combat/PlayerDefenseControllerTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Combat/PlayerDefenseControllerTests.cs
@@ -52,6 +52,44 @@ namespace Castlebound.Tests.Combat
             Assert.That(result.Attacker, Is.SameAs(attacker));
             Assert.That(observed.Outcome, Is.EqualTo(PlayerHitOutcome.Parried));
             Assert.That(health.Current, Is.EqualTo(10));
+            Assert.That(defense.State, Is.EqualTo(PlayerDefenseState.Blocking));
+        }
+
+        [Test]
+        public void ReceiveHit_FirstReceivedParryConsumesDefaultCapacity_SecondHitBlocks()
+        {
+            defense.SetDefensePressed(true);
+
+            PlayerHitResult first = defense.ReceiveHit(CreateMeleeHit(attacker));
+            PlayerHitResult second = defense.ReceiveHit(CreateMeleeHit(attacker));
+
+            Assert.That(first.Outcome, Is.EqualTo(PlayerHitOutcome.Parried));
+            Assert.That(second.Outcome, Is.EqualTo(PlayerHitOutcome.Blocked));
+            Assert.That(defense.RemainingParryCapacity, Is.Zero);
+            Assert.That(health.Current, Is.EqualTo(10));
+        }
+
+        [Test]
+        public void Configure_DuringDefense_AffectsNextActivationOnly()
+        {
+            defense.Configure(0.3f, 0f, 120f, 0.6f, 2);
+            defense.SetDefensePressed(true);
+
+            defense.Configure(0.01f, 0f, 120f, 0.6f, 1);
+            defense.Tick(0.02f);
+            PlayerHitResult first = defense.ReceiveHit(CreateMeleeHit(attacker));
+            PlayerHitResult second = defense.ReceiveHit(CreateMeleeHit(attacker));
+
+            Assert.That(first.Outcome, Is.EqualTo(PlayerHitOutcome.Parried));
+            Assert.That(second.Outcome, Is.EqualTo(PlayerHitOutcome.Parried));
+            Assert.That(defense.State, Is.EqualTo(PlayerDefenseState.Blocking));
+
+            defense.SetDefensePressed(false);
+            defense.Tick(0f);
+            defense.SetDefensePressed(true);
+            Assert.That(defense.RemainingParryCapacity, Is.EqualTo(1));
+            defense.Tick(0.02f);
+            Assert.That(defense.State, Is.EqualTo(PlayerDefenseState.Blocking));
         }
 
         [Test]
@@ -183,6 +221,15 @@ namespace Castlebound.Tests.Combat
                 0f,
                 0f,
                 0f);
+        }
+
+        private static PlayerHitRequest CreateMeleeHit(GameObject source)
+        {
+            return new PlayerHitRequest(
+                4,
+                source,
+                source.transform.position,
+                CombatDamageType.Melee);
         }
     }
 }

--- a/Assets/_Project/_Tests/EditMode/Combat/PlayerDefenseStateMachineTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Combat/PlayerDefenseStateMachineTests.cs
@@ -9,23 +9,75 @@ namespace Castlebound.Tests.Combat
         private const float RecoveryDuration = 0.15f;
 
         [Test]
-        public void BeginDefense_FromIdle_EntersParryWindow()
+        public void BeginDefense_FromIdle_EntersParryWindowWithCapturedCapacity()
         {
-            var stateMachine = new PlayerDefenseStateMachine(ParryWindow, RecoveryDuration);
+            var stateMachine = new PlayerDefenseStateMachine();
 
-            bool started = stateMachine.BeginDefense();
+            bool started = stateMachine.BeginDefense(ParryWindow, 2);
 
             Assert.IsTrue(started);
             Assert.That(stateMachine.State, Is.EqualTo(PlayerDefenseState.ParryWindow));
+            Assert.That(stateMachine.RemainingParryCapacity, Is.EqualTo(2));
             Assert.IsTrue(stateMachine.IsGuarding);
             Assert.IsFalse(stateMachine.CanAttack);
         }
 
         [Test]
+        public void BeginDefense_WithZeroCapacity_EntersBlocking()
+        {
+            var stateMachine = new PlayerDefenseStateMachine();
+
+            bool started = stateMachine.BeginDefense(ParryWindow, 0);
+
+            Assert.IsTrue(started);
+            Assert.That(stateMachine.State, Is.EqualTo(PlayerDefenseState.Blocking));
+            Assert.That(stateMachine.RemainingParryCapacity, Is.Zero);
+        }
+
+        [Test]
+        public void ConsumeParry_WhenCapacityReachesZero_ImmediatelyEntersBlocking()
+        {
+            var stateMachine = new PlayerDefenseStateMachine();
+            stateMachine.BeginDefense(ParryWindow, 1);
+
+            bool consumed = stateMachine.TryConsumeParry();
+
+            Assert.IsTrue(consumed);
+            Assert.That(stateMachine.RemainingParryCapacity, Is.Zero);
+            Assert.That(stateMachine.State, Is.EqualTo(PlayerDefenseState.Blocking));
+        }
+
+        [Test]
+        public void ConsumeParry_WithRemainingCapacity_KeepsParryWindowActive()
+        {
+            var stateMachine = new PlayerDefenseStateMachine();
+            stateMachine.BeginDefense(ParryWindow, 2);
+
+            bool consumed = stateMachine.TryConsumeParry();
+
+            Assert.IsTrue(consumed);
+            Assert.That(stateMachine.RemainingParryCapacity, Is.EqualTo(1));
+            Assert.That(stateMachine.State, Is.EqualTo(PlayerDefenseState.ParryWindow));
+        }
+
+        [Test]
+        public void ConsumeParry_OutsideParryWindow_IsRejected()
+        {
+            var stateMachine = new PlayerDefenseStateMachine();
+            stateMachine.BeginDefense(ParryWindow, 1);
+            stateMachine.Advance(ParryWindow + 0.001f);
+
+            bool consumed = stateMachine.TryConsumeParry();
+
+            Assert.IsFalse(consumed);
+            Assert.That(stateMachine.RemainingParryCapacity, Is.EqualTo(1));
+        }
+
+        [Test]
         public void Advance_AtInclusiveParryBoundary_RemainsParryWindow()
         {
-            var stateMachine = new PlayerDefenseStateMachine(ParryWindow, RecoveryDuration);
-            stateMachine.BeginDefense();
+            var stateMachine = new PlayerDefenseStateMachine();
+            stateMachine.BeginDefense(ParryWindow, 1);
 
             stateMachine.Advance(ParryWindow);
 
@@ -33,10 +85,10 @@ namespace Castlebound.Tests.Combat
         }
 
         [Test]
-        public void Advance_BeyondParryBoundaryWhileHeld_EntersBlocking()
+        public void Advance_BeyondCapturedParryBoundaryWhileHeld_EntersBlocking()
         {
-            var stateMachine = new PlayerDefenseStateMachine(ParryWindow, RecoveryDuration);
-            stateMachine.BeginDefense();
+            var stateMachine = new PlayerDefenseStateMachine();
+            stateMachine.BeginDefense(ParryWindow, 1);
 
             stateMachine.Advance(ParryWindow + 0.001f);
 
@@ -48,12 +100,12 @@ namespace Castlebound.Tests.Combat
         [TestCase(PlayerDefenseState.Blocking)]
         public void ReleaseDefense_FromGuarding_EntersRecovery(PlayerDefenseState releaseState)
         {
-            var stateMachine = new PlayerDefenseStateMachine(ParryWindow, RecoveryDuration);
-            stateMachine.BeginDefense();
+            var stateMachine = new PlayerDefenseStateMachine();
+            stateMachine.BeginDefense(ParryWindow, 1);
             if (releaseState == PlayerDefenseState.Blocking)
                 stateMachine.Advance(ParryWindow + 0.001f);
 
-            bool released = stateMachine.ReleaseDefense();
+            bool released = stateMachine.ReleaseDefense(RecoveryDuration);
 
             Assert.IsTrue(released);
             Assert.That(stateMachine.State, Is.EqualTo(PlayerDefenseState.Recovery));
@@ -62,13 +114,13 @@ namespace Castlebound.Tests.Combat
         }
 
         [Test]
-        public void Recovery_BlocksRestartUntilDurationCompletes()
+        public void Recovery_BlocksRestartUntilCapturedDurationCompletes()
         {
-            var stateMachine = new PlayerDefenseStateMachine(ParryWindow, RecoveryDuration);
-            stateMachine.BeginDefense();
-            stateMachine.ReleaseDefense();
+            var stateMachine = new PlayerDefenseStateMachine();
+            stateMachine.BeginDefense(ParryWindow, 1);
+            stateMachine.ReleaseDefense(RecoveryDuration);
 
-            Assert.IsFalse(stateMachine.BeginDefense());
+            Assert.IsFalse(stateMachine.BeginDefense(ParryWindow, 1));
             stateMachine.Advance(RecoveryDuration - 0.001f);
             Assert.That(stateMachine.State, Is.EqualTo(PlayerDefenseState.Recovery));
 
@@ -76,14 +128,14 @@ namespace Castlebound.Tests.Combat
 
             Assert.That(stateMachine.State, Is.EqualTo(PlayerDefenseState.Idle));
             Assert.IsTrue(stateMachine.CanAttack);
-            Assert.IsTrue(stateMachine.BeginDefense());
+            Assert.IsTrue(stateMachine.BeginDefense(ParryWindow, 1));
         }
 
         [Test]
         public void Advance_LargeDelta_CarriesFromParryThroughHeldBlockingOnly()
         {
-            var stateMachine = new PlayerDefenseStateMachine(ParryWindow, RecoveryDuration);
-            stateMachine.BeginDefense();
+            var stateMachine = new PlayerDefenseStateMachine();
+            stateMachine.BeginDefense(ParryWindow, 1);
 
             stateMachine.Advance(10f);
 
@@ -91,17 +143,16 @@ namespace Castlebound.Tests.Combat
         }
 
         [Test]
-        public void InvalidDurationsAndDelta_AreNormalized()
+        public void InvalidActivationValuesAndDelta_AreNormalized()
         {
-            var stateMachine = new PlayerDefenseStateMachine(float.NaN, -1f);
+            var stateMachine = new PlayerDefenseStateMachine();
 
-            stateMachine.BeginDefense();
+            stateMachine.BeginDefense(float.NaN, -1);
             stateMachine.Advance(float.NaN);
-            Assert.That(stateMachine.State, Is.EqualTo(PlayerDefenseState.ParryWindow));
-
-            stateMachine.Advance(0.001f);
             Assert.That(stateMachine.State, Is.EqualTo(PlayerDefenseState.Blocking));
-            stateMachine.ReleaseDefense();
+            Assert.That(stateMachine.RemainingParryCapacity, Is.Zero);
+
+            stateMachine.ReleaseDefense(-1f);
             stateMachine.Advance(0f);
             Assert.That(stateMachine.State, Is.EqualTo(PlayerDefenseState.Idle));
         }

--- a/Assets/_Project/_Tests/PlayMode/Combat/FeedbackRoutingPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/Combat/FeedbackRoutingPlayTests.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Reflection;
+using Castlebound.Gameplay.AI;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
@@ -54,6 +55,50 @@ namespace Castlebound.Tests.Combat
             Assert.That(image.color.a, Is.Zero);
 
             Object.Destroy(overlay);
+            Object.Destroy(channel);
+        }
+
+        [UnityTest]
+        public IEnumerator StaggerOverlay_RemainsYellowUntilTargetRefreshIsAcknowledged()
+        {
+            var channel = ScriptableObject.CreateInstance<FeedbackEventChannel>();
+            var enemy = new GameObject("StaggeredEnemy");
+            var renderer = enemy.AddComponent<SpriteRenderer>();
+            var attack = enemy.AddComponent<EnemyAttack>();
+            var receiver = enemy.AddComponent<EnemyStaggerReceiver>();
+            receiver.Configure(true, 1f, attack);
+            var listener = enemy.AddComponent<HitFlashListener>();
+            SetField(listener, "feedbackChannel", channel);
+            SetField(listener, "targetRenderer", renderer);
+            SetField(listener, "staggerReceiver", receiver);
+            listener.enabled = false;
+            listener.enabled = true;
+
+            receiver.TryStagger();
+            yield return null;
+            Assert.That(renderer.color, Is.EqualTo(new Color(1f, 0.85f, 0f, 1f)));
+
+            channel.Raise(new FeedbackCue(
+                FeedbackCueType.PlayerHitEnemy,
+                enemy.transform.position,
+                enemy.GetInstanceID()));
+            yield return null;
+            Assert.That(renderer.color, Is.EqualTo(new Color(1f, 0.2f, 0.2f, 1f)),
+                "Damage feedback should remain readable while the enemy is staggered.");
+
+            yield return new WaitForSeconds(0.11f);
+            Assert.That(renderer.color, Is.EqualTo(new Color(1f, 0.85f, 0f, 1f)),
+                "The stagger overlay should resume after the damage flash completes.");
+
+            receiver.Tick(1f);
+            yield return null;
+            Assert.That(renderer.color, Is.EqualTo(new Color(1f, 0.85f, 0f, 1f)));
+
+            receiver.AcknowledgeTargetRefresh();
+            yield return null;
+            Assert.That(renderer.color, Is.EqualTo(Color.white));
+
+            Object.Destroy(enemy);
             Object.Destroy(channel);
         }
 

--- a/Assets/_Project/_Tests/PlayMode/Combat/PlayerDefenseEnemyAttackPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/Combat/PlayerDefenseEnemyAttackPlayTests.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Reflection;
+using Castlebound.Gameplay.AI;
 using Castlebound.Gameplay.Combat;
 using NUnit.Framework;
 using UnityEngine;
@@ -10,7 +11,7 @@ namespace Castlebound.Tests.PlayMode.Combat
     public class PlayerDefenseEnemyAttackPlayTests
     {
         [UnityTest]
-        public IEnumerator EnemyClockImpact_DuringFrontalParry_NegatesPlayerDamage()
+        public IEnumerator EnemyClockImpact_DuringFrontalParry_StaggersThenRecoversFresh()
         {
             var player = CreatePlayer();
             var enemy = CreateEnemy(player.transform);
@@ -26,6 +27,23 @@ namespace Castlebound.Tests.PlayMode.Combat
                 Assert.That(player.GetComponent<Health>().Current, Is.EqualTo(10));
                 Assert.That(observed.Outcome, Is.EqualTo(PlayerHitOutcome.Parried));
                 Assert.That(observed.Attacker, Is.SameAs(enemy));
+                var stagger = enemy.GetComponent<EnemyStaggerReceiver>();
+                Assert.That(stagger.State, Is.EqualTo(EnemyStaggerState.Staggered));
+                Assert.IsFalse(enemy.GetComponent<EnemyAttack>().IsAttackActive);
+
+                Vector2 lockedPosition = enemy.transform.position;
+                Vector2 lockedFacing = enemy.GetComponent<EnemyFacing>().AimDirection;
+                int targetRevision = enemy.GetComponent<EnemyTargeting>().TargetRevision;
+                yield return new WaitForSeconds(0.2f);
+                Assert.That(Vector2.Distance(enemy.transform.position, lockedPosition),
+                    Is.LessThan(0.001f));
+                Assert.That(enemy.GetComponent<EnemyFacing>().AimDirection, Is.EqualTo(lockedFacing));
+
+                yield return new WaitForSeconds(0.85f);
+                yield return new WaitForFixedUpdate();
+                Assert.That(stagger.State, Is.EqualTo(EnemyStaggerState.Inactive));
+                Assert.That(enemy.GetComponent<EnemyTargeting>().TargetRevision,
+                    Is.GreaterThan(targetRevision));
             }
             finally
             {
@@ -61,6 +79,12 @@ namespace Castlebound.Tests.PlayMode.Combat
             SetField(facing, "attackAlignmentThreshold", 180f);
 
             var attack = enemy.AddComponent<EnemyAttack>();
+            var delivery = attack.AttackDeliverySource as EnemyMeleeAttackDelivery;
+            var stagger = enemy.AddComponent<EnemyStaggerReceiver>();
+            stagger.Configure(true, 1f, attack);
+            SetField(attack, "staggerReceiver", stagger);
+            SetField(delivery, "staggerReceiver", stagger);
+            SetField(controller, "staggerReceiver", stagger);
             SetField(attack, "windupSeconds", 0.02f);
             attack.CooldownSeconds = 1f;
             attack.Damage = 4;

--- a/TEST_LOG.md
+++ b/TEST_LOG.md
@@ -1,3 +1,20 @@
+## 2026-08-06 - feat-enemy-parry-stagger
+
+### Summary
+- Added activation-snapshotted parry window and capacity with deterministic successful-parry consumption.
+- Added an enemy-owned stagger authority for eligibility, duration, repeated-request rejection, recovery locking, and lifecycle cleanup.
+- Added the explicit idempotent enemy attack cancellation boundary required for later melee integration.
+
+### New or Updated Tests
+**EditMode**
+- PlayerDefenseStateMachineTests, PlayerDefenseControllerTests, and EnemyStaggerReceiverTests — activation snapshots, first-received capacity consumption, stagger timing, ignored repeats, recovery locking, normalization, and cleanup.
+
+**PlayMode**
+- N/A — N/A
+
+### Notes
+- PlayerDefenseStateMachineTests and PlayerDefenseControllerTests pass manually; EnemyStaggerReceiverTests awaits rerun after correcting its EditMode lifecycle invocation.
+
 ## 2026-08-05 - feat-player-defense-soft-anchor
 
 ### Summary

--- a/TEST_LOG.md
+++ b/TEST_LOG.md
@@ -2,18 +2,18 @@
 
 ### Summary
 - Added activation-snapshotted parry window and capacity with deterministic successful-parry consumption.
-- Added an enemy-owned stagger authority for eligibility, duration, repeated-request rejection, recovery locking, and lifecycle cleanup.
-- Added the explicit idempotent enemy attack cancellation boundary required for later melee integration.
+- Added exact-attacker melee stagger with immediate swing cancellation, movement/turn/action locking, target-refresh recovery, and melee-goblin prefab ownership.
+- Added continuous yellow stagger feedback that briefly yields to red damage flashes before resuming.
 
 ### New or Updated Tests
 **EditMode**
-- PlayerDefenseStateMachineTests, PlayerDefenseControllerTests, and EnemyStaggerReceiverTests — activation snapshots, first-received capacity consumption, stagger timing, ignored repeats, recovery locking, normalization, and cleanup.
+- PlayerDefenseStateMachineTests, PlayerDefenseControllerTests, EnemyStaggerReceiverTests, EnemyAttackTests, and EnemyStaggerPrefabContractTests — activation snapshots, capacity ordering, stagger timing, ignored repeats, re-entrant cancellation, recovery locking, normalization, cleanup, and explicit prefab wiring.
 
 **PlayMode**
-- N/A — N/A
+- PlayerDefenseEnemyAttackPlayTests and FeedbackRoutingPlayTests — parry-to-stagger integration, frozen movement/facing, target-refresh recovery, and red-over-yellow tint priority.
 
 ### Notes
-- PlayerDefenseStateMachineTests and PlayerDefenseControllerTests pass manually; EnemyStaggerReceiverTests awaits rerun after correcting its EditMode lifecycle invocation.
+- Full EditMode and PlayMode suites pass manually; only the melee goblin opts into stagger in this issue.
 
 ## 2026-08-05 - feat-player-defense-soft-anchor
 


### PR DESCRIPTION
## Why
Successful parries need a deterministic tactical reward on the exact attacker, while parry capacity must remain tunable without changing an active defense activation.

## What changed
- Added activation-snapshotted parry capacity and window timing with first-received consumption ordering
- Added enemy-owned stagger eligibility, timing, ignored-repeat, cleanup, and target-refresh recovery state
- Routed successful melee parry results back to the exact attacker and cancelled active swings safely, including re-entrant impact delivery
- Locked staggered melee goblins against movement, turning, attack decisions, attack-clock progress, and damage delivery
- Added continuous yellow stagger feedback with brief red damage flashes layered above it
- Authored the melee goblin with an eligible one-second stagger while leaving ranged goblins and Lurkers unchanged

## How to test
1. Open the main prototype scene and approach a melee goblin
2. Press and hold defense immediately before its frontal melee impact; verify gold parry confirmation, one-second yellow enemy stagger, no movement/turning/damage, then clean recovery
3. Verify the first parry changes held defense to normal blocking, and verify damage during stagger briefly flashes red before yellow resumes
4. Run tests:
   - EditMode
   - PlayMode

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated (N/A - existing prototype scene consumes the updated melee goblin prefab)
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched (TEST_LOG.md updated)

## Related
- Closes #268