### PR TITLE
feat(player): add post-aim facing grace before movement override

### DIFF
--- a/Assets/_Project/Prefabs/Player.prefab
+++ b/Assets/_Project/Prefabs/Player.prefab
@@ -267,6 +267,7 @@ MonoBehaviour:
   baseAttackRate: 1.5
   movementOrchestrator:
     deadZone: 0.1
+  facingOrchestrator:
     rotationSpeed: 720
     facingDirectionOffset: 90
     flipDirection: 0
@@ -617,7 +618,7 @@ MonoBehaviour:
   aimEnterThreshold: 0.25
   aimExitThreshold: 0.2
   movementMeaningfulThreshold: 0.1
-  returnToMovementFacingSpeed: 720
+  postAimFacingGraceDuration: 0.6
   stickMagnitudeMax: 1.1
 --- !u!114 &9150000000000000204
 MonoBehaviour:

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerFacingOrchestrator.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerFacingOrchestrator.cs
@@ -1,0 +1,28 @@
+using System;
+using UnityEngine;
+
+[Serializable]
+public class PlayerFacingOrchestrator
+{
+    [SerializeField] private float rotationSpeed = 720f;
+    [SerializeField] private float facingDirectionOffset = -90f;
+    [SerializeField] private bool flipDirection;
+
+    public Vector2 LastFacingDirection { get; private set; } = Vector2.up;
+
+    public void Tick(Transform playerTransform, Vector2 facingDirection, float deltaTime)
+    {
+        if (playerTransform == null || facingDirection.sqrMagnitude <= 0.0001f)
+            return;
+
+        LastFacingDirection = facingDirection.normalized;
+        Vector2 angleDirection = flipDirection ? -LastFacingDirection : LastFacingDirection;
+        float targetAngle = Mathf.Atan2(angleDirection.y, angleDirection.x) * Mathf.Rad2Deg
+            + facingDirectionOffset;
+        var targetRotation = Quaternion.Euler(0f, 0f, targetAngle);
+        playerTransform.rotation = Quaternion.RotateTowards(
+            playerTransform.rotation,
+            targetRotation,
+            rotationSpeed * Mathf.Max(0f, deltaTime));
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerFacingOrchestrator.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerFacingOrchestrator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 14b034a9b012453a9dfc1d9ba62c7d01

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerFacingPolicyResolver.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerFacingPolicyResolver.cs
@@ -5,30 +5,85 @@ public class PlayerFacingPolicyResolver : MonoBehaviour
     [SerializeField] private float aimEnterThreshold = 0.25f;
     [SerializeField] private float aimExitThreshold = 0.20f;
     [SerializeField] private float movementMeaningfulThreshold = 0.10f;
-    [SerializeField] private float returnToMovementFacingSpeed = 720f;
+    [SerializeField, Min(0f)] private float postAimFacingGraceDuration = 0.6f;
     [SerializeField] private float stickMagnitudeMax = 1.1f;
 
     private bool rightStickAimActive;
+    private bool attackAimWasActive;
+    private bool defenseWasActive;
+    private float postAimFacingGraceRemaining;
+    private Vector2 lastAttackAimDirection;
+    private Vector2 retainedPostAimDirection;
+    private Vector2 activeDefenseDirection;
 
     public Vector2 ResolveFacing(
         Vector2 currentFacing,
         Vector2 movementInput,
         Vector2 resolvedAimInput,
         Vector2 rawLookInput,
-        bool aimIntentActive,
+        bool attackAimIntentActive,
+        bool defenseActive,
         float deltaTime)
     {
         bool stickAimIntentActive = UpdateRightStickAimIntent(rawLookInput);
-        bool shouldUseAim = aimIntentActive || stickAimIntentActive;
+        bool attackAimActive = attackAimIntentActive || stickAimIntentActive;
+        bool hasResolvedAim = resolvedAimInput.sqrMagnitude > 0.0001f;
 
-        if (shouldUseAim && resolvedAimInput.sqrMagnitude > 0.0001f)
+        if (attackAimActive && hasResolvedAim)
+            lastAttackAimDirection = resolvedAimInput.normalized;
+
+        if (!attackAimActive && attackAimWasActive && lastAttackAimDirection.sqrMagnitude > 0.0001f)
+        {
+            retainedPostAimDirection = lastAttackAimDirection;
+            postAimFacingGraceRemaining = postAimFacingGraceDuration;
+        }
+
+        postAimFacingGraceRemaining = Mathf.Max(
+            0f,
+            postAimFacingGraceRemaining - Mathf.Max(0f, deltaTime));
+
+        if (!defenseActive && defenseWasActive)
+            postAimFacingGraceRemaining = 0f;
+
+        if (defenseActive && hasResolvedAim)
+        {
+            activeDefenseDirection = resolvedAimInput.normalized;
+        }
+        else if (defenseActive && !defenseWasActive)
+            activeDefenseDirection = ResolveDefenseStartDirection(currentFacing);
+
+        attackAimWasActive = attackAimActive;
+        defenseWasActive = defenseActive;
+
+        if (defenseActive && activeDefenseDirection.sqrMagnitude > 0.0001f)
+            return activeDefenseDirection;
+
+        if (attackAimActive && hasResolvedAim)
             return resolvedAimInput.normalized;
+
+        if (postAimFacingGraceRemaining > 0f && retainedPostAimDirection.sqrMagnitude > 0.0001f)
+            return retainedPostAimDirection;
 
         float movementThresholdSquared = movementMeaningfulThreshold * movementMeaningfulThreshold;
         if (movementInput.sqrMagnitude >= movementThresholdSquared)
             return movementInput.normalized;
 
         return currentFacing;
+    }
+
+    private void OnValidate()
+    {
+        postAimFacingGraceDuration = Mathf.Max(0f, postAimFacingGraceDuration);
+    }
+
+    private Vector2 ResolveDefenseStartDirection(Vector2 currentFacing)
+    {
+        if (postAimFacingGraceRemaining > 0f && retainedPostAimDirection.sqrMagnitude > 0.0001f)
+            return retainedPostAimDirection;
+
+        return currentFacing.sqrMagnitude > 0.0001f
+            ? currentFacing.normalized
+            : Vector2.up;
     }
 
     private bool UpdateRightStickAimIntent(Vector2 rawLookInput)

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerMovementOrchestrator.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerMovementOrchestrator.cs
@@ -5,19 +5,10 @@ using UnityEngine;
 public class PlayerMovementOrchestrator
 {
     [SerializeField] private float deadZone = 0.1f;
-    [SerializeField] private float rotationSpeed = 720f;
-    [SerializeField] private float facingDirectionOffset = -90f;
-    [SerializeField] private bool flipDirection = false;
-
-    public Vector2 LastMoveDirection { get; private set; } = new Vector2(0f, 1f);
-    public Vector2 LastFacingDirection { get; private set; } = new Vector2(0f, 1f);
 
     public void Tick(
         PlayerCollisionMove2D mover,
-        Transform playerTransform,
         Vector2 movementInput,
-        Vector2 aimInput,
-        float deltaTime,
         float speedMultiplier = 1f)
     {
         if (mover != null)
@@ -28,16 +19,5 @@ public class PlayerMovementOrchestrator
                 : movementInput * Mathf.Max(0f, speedMultiplier);
             mover.SetMoveInput(resolvedMovement);
         }
-
-        if (movementInput.magnitude > 0f)
-            LastMoveDirection = movementInput;
-
-        Vector2 facingSource = aimInput.magnitude > deadZone ? aimInput : LastMoveDirection;
-        if (facingSource.sqrMagnitude > 0f)
-            LastFacingDirection = facingSource.normalized;
-        Vector2 angleDirection = flipDirection ? -facingSource : facingSource;
-        float targetAngle = Mathf.Atan2(angleDirection.y, angleDirection.x) * Mathf.Rad2Deg + facingDirectionOffset;
-        var targetRotation = Quaternion.Euler(0f, 0f, targetAngle);
-        playerTransform.rotation = Quaternion.RotateTowards(playerTransform.rotation, targetRotation, rotationSpeed * deltaTime);
     }
 }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/PlayerController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/PlayerController.cs
@@ -33,6 +33,9 @@ public class PlayerController : MonoBehaviour
     [Header("Movement")]
     [SerializeField] private PlayerMovementOrchestrator movementOrchestrator = new PlayerMovementOrchestrator();
 
+    [Header("Facing")]
+    [SerializeField] private PlayerFacingOrchestrator facingOrchestrator = new PlayerFacingOrchestrator();
+
     private Rigidbody2D rb;
     private Vector2 movementInput;
     private Vector2 aimInput;
@@ -74,8 +77,8 @@ public class PlayerController : MonoBehaviour
 
     public float RepairCooldownRemaining => repairCooldownRemaining;
     public bool IsRepairOnCooldown => repairCooldownRemaining > 0f;
-    public Vector2 CurrentFacingDirection => movementOrchestrator != null
-        ? movementOrchestrator.LastFacingDirection
+    public Vector2 CurrentFacingDirection => facingOrchestrator != null
+        ? facingOrchestrator.LastFacingDirection
         : -(Vector2)transform.up;
     public int BaseAttackDamage
     {
@@ -101,6 +104,7 @@ public class PlayerController : MonoBehaviour
         inventoryState = inventorySource != null ? inventorySource.State : null;
         if (weaponSlotSwapHandler == null) weaponSlotSwapHandler = new WeaponSlotSwapHandler();
         if (movementOrchestrator == null) movementOrchestrator = new PlayerMovementOrchestrator();
+        if (facingOrchestrator == null) facingOrchestrator = new PlayerFacingOrchestrator();
         if (fireInputController != null)
             fireInputController.Configure(null);
     }
@@ -163,13 +167,9 @@ public class PlayerController : MonoBehaviour
         float movementSpeedMultiplier = defenseController != null
             ? defenseController.MovementSpeedMultiplier
             : 1f;
-        movementOrchestrator.Tick(
-            mover,
-            transform,
-            movementInput,
-            ResolveFacingInput(),
-            Time.fixedDeltaTime,
-            movementSpeedMultiplier);
+        Vector2 facingDirection = ResolveFacingInput();
+        movementOrchestrator.Tick(mover, movementInput, movementSpeedMultiplier);
+        facingOrchestrator.Tick(transform, facingDirection, Time.fixedDeltaTime);
     }
 
     /// <summary>
@@ -332,15 +332,18 @@ public class PlayerController : MonoBehaviour
         if (facingPolicyResolver == null)
             return resolvedAimInput;
 
-        var aimIntentActive = (fireInputController != null && fireInputController.IsFireHeld)
-            || (defenseController != null && defenseController.IsGuarding);
-        var currentFacing = movementOrchestrator != null ? movementOrchestrator.LastMoveDirection : (Vector2)transform.up;
+        bool attackAimIntentActive = fireInputController != null && fireInputController.IsFireHeld;
+        bool defenseActive = defenseController != null && defenseController.IsGuarding;
+        var currentFacing = facingOrchestrator != null
+            ? facingOrchestrator.LastFacingDirection
+            : -(Vector2)transform.up;
         return facingPolicyResolver.ResolveFacing(
             currentFacing,
             movementInput,
             resolvedAimInput,
             aimInput,
-            aimIntentActive,
+            attackAimIntentActive,
+            defenseActive,
             Time.fixedDeltaTime);
     }
 }

--- a/Assets/_Project/_Tests/EditMode/Input/PlayerFacingOrchestratorTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Input/PlayerFacingOrchestratorTests.cs
@@ -1,0 +1,30 @@
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Castlebound.Tests.Input
+{
+    public class PlayerFacingOrchestratorTests
+    {
+        [Test]
+        public void Tick_AppliesResolvedDirectionWithoutOwningSourceSelection()
+        {
+            var player = new GameObject("Player");
+
+            try
+            {
+                var orchestrator = new PlayerFacingOrchestrator();
+
+                orchestrator.Tick(player.transform, new Vector2(2f, 0f), 1f);
+
+                Assert.Less(Vector2.Distance(orchestrator.LastFacingDirection, Vector2.right), 0.001f);
+                Assert.That(
+                    Quaternion.Angle(player.transform.rotation, Quaternion.Euler(0f, 0f, -90f)),
+                    Is.LessThan(0.001f));
+            }
+            finally
+            {
+                Object.DestroyImmediate(player);
+            }
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Input/PlayerFacingOrchestratorTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Input/PlayerFacingOrchestratorTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1bf6d95e085f4fab8a72ddd122051229

--- a/Assets/_Project/_Tests/EditMode/Input/PlayerFacingPolicyContractsTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Input/PlayerFacingPolicyContractsTests.cs
@@ -1,5 +1,7 @@
 using System.IO;
 using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
 
 namespace Castlebound.Tests.Input
 {
@@ -9,6 +11,11 @@ namespace Castlebound.Tests.Input
             "Assets/_Project/Scripts/_Project.Gameplay/Player/PlayerController.cs";
         private const string FacingPolicyResolverPath =
             "Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerFacingPolicyResolver.cs";
+        private const string FacingOrchestratorPath =
+            "Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerFacingOrchestrator.cs";
+        private const string MovementOrchestratorPath =
+            "Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerMovementOrchestrator.cs";
+        private const string PlayerPrefabPath = "Assets/_Project/Prefabs/Player.prefab";
 
         [Test]
         public void PlayerController_DelegatesFacingSourceSelection_ToFacingPolicyResolver()
@@ -22,7 +29,7 @@ namespace Castlebound.Tests.Input
         }
 
         [Test]
-        public void FacingPolicyResolver_Exists_WithThresholdAndSmoothingTunables()
+        public void FacingPolicyResolver_Exists_WithThresholdAndGraceTunables()
         {
             Assert.That(File.Exists(FacingPolicyResolverPath), Is.True,
                 "Facing policy component should exist as a dedicated resolver.");
@@ -35,12 +42,12 @@ namespace Castlebound.Tests.Input
                 "Aim-exit threshold should be tunable for hysteresis.");
             StringAssert.Contains("[SerializeField] private float movementMeaningfulThreshold", source,
                 "Movement threshold should gate movement-facing behavior.");
-            StringAssert.Contains("[SerializeField] private float returnToMovementFacingSpeed", source,
-                "Return speed should be tunable for smooth transition back to movement-facing.");
+            StringAssert.Contains("[SerializeField, Min(0f)] private float postAimFacingGraceDuration", source,
+                "Post-aim facing grace should have a single inspector-safe policy owner.");
         }
 
         [Test]
-        public void FacingPolicyResolver_ExposesExplicitAimIntent_AndSmoothReturnContract()
+        public void FacingPolicyResolver_ExposesSeparateAttackAndDefenseIntentContracts()
         {
             Assert.That(File.Exists(FacingPolicyResolverPath), Is.True,
                 "Facing policy component should exist before evaluating contract details.");
@@ -49,12 +56,14 @@ namespace Castlebound.Tests.Input
 
             StringAssert.Contains("ResolveFacing(", source,
                 "Facing policy resolver should expose a single facing resolution entrypoint.");
-            StringAssert.Contains("aimIntentActive", source,
+            StringAssert.Contains("attackAimIntentActive", source,
                 "Facing policy should only apply aim override when explicit aim intent is active.");
+            StringAssert.Contains("defenseActive", source,
+                "Defense must be a distinct higher-priority facing source.");
             StringAssert.Contains("return resolvedAimInput.normalized", source,
                 "When aim intent is active, policy should select aim as the facing source.");
-            StringAssert.DoesNotContain("Mathf.MoveTowardsAngle", source,
-                "Facing policy should not own angle interpolation; rotation smoothing belongs to movement orchestration.");
+            StringAssert.DoesNotContain("transform.rotation", source,
+                "Facing policy should select directions without executing presentation rotation.");
         }
 
         [Test]
@@ -69,6 +78,46 @@ namespace Castlebound.Tests.Input
                 "Movement-facing should only apply when movement input is meaningful.");
             StringAssert.Contains("return currentFacing", source,
                 "When movement is not meaningful, facing should be preserved.");
+        }
+
+        [Test]
+        public void MovementOrchestrator_OwnsVelocityOnly_AndFacingOrchestratorOwnsRotation()
+        {
+            var movementSource = File.ReadAllText(MovementOrchestratorPath);
+            var facingSource = File.ReadAllText(FacingOrchestratorPath);
+
+            StringAssert.Contains("mover.SetMoveInput", movementSource);
+            StringAssert.DoesNotContain("playerTransform", movementSource);
+            StringAssert.DoesNotContain("LastFacingDirection", movementSource);
+            StringAssert.Contains("LastFacingDirection", facingSource);
+            StringAssert.Contains("playerTransform.rotation", facingSource);
+        }
+
+        [Test]
+        public void PlayerPrefab_AuthorsPointSixSecondGraceOnFacingPolicyResolver()
+        {
+            var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(PlayerPrefabPath);
+            Assert.NotNull(prefab);
+
+            var resolver = prefab.GetComponent<PlayerFacingPolicyResolver>();
+            var playerController = prefab.GetComponent<PlayerController>();
+            Assert.NotNull(resolver);
+            Assert.NotNull(playerController);
+
+            var serializedResolver = new SerializedObject(resolver);
+            Assert.That(
+                serializedResolver.FindProperty("postAimFacingGraceDuration").floatValue,
+                Is.EqualTo(0.6f).Within(0.0001f));
+
+            var serializedController = new SerializedObject(playerController);
+            Assert.NotNull(serializedController.FindProperty("facingOrchestrator"));
+
+            string controllerSource = File.ReadAllText(PlayerControllerPath);
+            string movementSource = File.ReadAllText(MovementOrchestratorPath);
+            string facingSource = File.ReadAllText(FacingOrchestratorPath);
+            StringAssert.DoesNotContain("postAimFacingGraceDuration", controllerSource);
+            StringAssert.DoesNotContain("postAimFacingGraceDuration", movementSource);
+            StringAssert.DoesNotContain("postAimFacingGraceDuration", facingSource);
         }
     }
 }

--- a/Assets/_Project/_Tests/EditMode/Input/PlayerFacingPolicyResolverTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Input/PlayerFacingPolicyResolverTests.cs
@@ -17,6 +17,7 @@ namespace Castlebound.Tests.Input
             SetPrivateFloat("aimEnterThreshold", 0.25f);
             SetPrivateFloat("aimExitThreshold", 0.20f);
             SetPrivateFloat("movementMeaningfulThreshold", 0.10f);
+            SetPrivateFloat("postAimFacingGraceDuration", 0.6f);
             SetPrivateFloat("stickMagnitudeMax", 1.1f);
         }
 
@@ -34,7 +35,8 @@ namespace Castlebound.Tests.Input
                 movementInput: Vector2.right,
                 resolvedAimInput: Vector2.left,
                 rawLookInput: Vector2.zero,
-                aimIntentActive: false,
+                attackAimIntentActive: false,
+                defenseActive: false,
                 deltaTime: 0.02f);
 
             Assert.Less(Vector2.Distance(result, Vector2.right), 0.001f);
@@ -48,7 +50,8 @@ namespace Castlebound.Tests.Input
                 movementInput: Vector2.right,
                 resolvedAimInput: Vector2.left,
                 rawLookInput: Vector2.zero,
-                aimIntentActive: true,
+                attackAimIntentActive: true,
+                defenseActive: false,
                 deltaTime: 0.02f);
 
             Assert.Less(Vector2.Distance(result, Vector2.left), 0.001f);
@@ -62,7 +65,8 @@ namespace Castlebound.Tests.Input
                 movementInput: Vector2.right,
                 resolvedAimInput: Vector2.down,
                 rawLookInput: new Vector2(0.30f, 0f),
-                aimIntentActive: false,
+                attackAimIntentActive: false,
+                defenseActive: false,
                 deltaTime: 0.02f);
 
             Assert.Less(Vector2.Distance(result, Vector2.down), 0.001f);
@@ -76,7 +80,8 @@ namespace Castlebound.Tests.Input
                 movementInput: Vector2.right,
                 resolvedAimInput: Vector2.left,
                 rawLookInput: new Vector2(0.30f, 0f),
-                aimIntentActive: false,
+                attackAimIntentActive: false,
+                defenseActive: false,
                 deltaTime: 0.02f);
 
             var result = resolver.ResolveFacing(
@@ -84,21 +89,23 @@ namespace Castlebound.Tests.Input
                 movementInput: Vector2.right,
                 resolvedAimInput: Vector2.left,
                 rawLookInput: new Vector2(0.22f, 0f),
-                aimIntentActive: false,
+                attackAimIntentActive: false,
+                defenseActive: false,
                 deltaTime: 0.02f);
 
             Assert.Less(Vector2.Distance(result, Vector2.left), 0.001f);
         }
 
         [Test]
-        public void ResolveFacing_AndroidRightStickBelowExit_ReturnsToMovementDirection()
+        public void ResolveFacing_AndroidRightStickBelowExit_RetainsFinalAimDirection()
         {
             resolver.ResolveFacing(
                 currentFacing: Vector2.up,
                 movementInput: Vector2.left,
                 resolvedAimInput: Vector2.down,
                 rawLookInput: new Vector2(0.30f, 0f),
-                aimIntentActive: false,
+                attackAimIntentActive: false,
+                defenseActive: false,
                 deltaTime: 0.02f);
 
             var result = resolver.ResolveFacing(
@@ -106,10 +113,11 @@ namespace Castlebound.Tests.Input
                 movementInput: Vector2.left,
                 resolvedAimInput: Vector2.down,
                 rawLookInput: new Vector2(0.19f, 0f),
-                aimIntentActive: false,
+                attackAimIntentActive: false,
+                defenseActive: false,
                 deltaTime: 0.02f);
 
-            Assert.Less(Vector2.Distance(result, Vector2.left), 0.001f);
+            Assert.Less(Vector2.Distance(result, Vector2.down), 0.001f);
         }
 
         [Test]
@@ -121,21 +129,23 @@ namespace Castlebound.Tests.Input
                 movementInput: new Vector2(0.05f, 0f),
                 resolvedAimInput: Vector2.left,
                 rawLookInput: Vector2.zero,
-                aimIntentActive: false,
+                attackAimIntentActive: false,
+                defenseActive: false,
                 deltaTime: 0.02f);
 
             Assert.Less(Vector2.Distance(result, currentFacing), 0.001f);
         }
 
         [Test]
-        public void ResolveFacing_InvalidLookMagnitudeAboveMax_DisablesStickAimIntent()
+        public void ResolveFacing_InvalidLookMagnitudeAboveMax_ReleasesIntoGracePeriod()
         {
             resolver.ResolveFacing(
                 currentFacing: Vector2.up,
                 movementInput: Vector2.right,
                 resolvedAimInput: Vector2.left,
                 rawLookInput: new Vector2(0.30f, 0f),
-                aimIntentActive: false,
+                attackAimIntentActive: false,
+                defenseActive: false,
                 deltaTime: 0.02f);
 
             var result = resolver.ResolveFacing(
@@ -143,10 +153,73 @@ namespace Castlebound.Tests.Input
                 movementInput: Vector2.right,
                 resolvedAimInput: Vector2.left,
                 rawLookInput: new Vector2(1.2f, 0f),
-                aimIntentActive: false,
+                attackAimIntentActive: false,
+                defenseActive: false,
                 deltaTime: 0.02f);
 
-            Assert.Less(Vector2.Distance(result, Vector2.right), 0.001f);
+            Assert.Less(Vector2.Distance(result, Vector2.left), 0.001f);
+        }
+
+        [Test]
+        public void ResolveFacing_AimReleaseWhileWalking_RetainsFinalAimForGraceDuration()
+        {
+            resolver.ResolveFacing(Vector2.up, Vector2.right, Vector2.left, Vector2.zero, true, false, 0.02f);
+
+            var duringGrace = resolver.ResolveFacing(
+                Vector2.left, Vector2.right, Vector2.left, Vector2.zero, false, false, 0.3f);
+
+            Assert.Less(Vector2.Distance(duringGrace, Vector2.left), 0.001f);
+        }
+
+        [Test]
+        public void ResolveFacing_GraceExpires_AllowsActiveWalkingToReclaimFacing()
+        {
+            resolver.ResolveFacing(Vector2.up, Vector2.right, Vector2.left, Vector2.zero, true, false, 0.02f);
+            resolver.ResolveFacing(Vector2.left, Vector2.right, Vector2.left, Vector2.zero, false, false, 0.3f);
+
+            var afterGrace = resolver.ResolveFacing(
+                Vector2.left, Vector2.right, Vector2.left, Vector2.zero, false, false, 0.3f);
+
+            Assert.Less(Vector2.Distance(afterGrace, Vector2.right), 0.001f);
+        }
+
+        [Test]
+        public void ResolveFacing_DefenseBeginsDuringGrace_UsesRetainedFallbackThenLiveDefenseAim()
+        {
+            resolver.ResolveFacing(Vector2.up, Vector2.right, Vector2.left, Vector2.zero, true, false, 0.02f);
+
+            var defenseStarted = resolver.ResolveFacing(
+                Vector2.left, Vector2.right, Vector2.zero, Vector2.zero, false, true, 0.1f);
+            var defenseAimedAfterGrace = resolver.ResolveFacing(
+                defenseStarted, Vector2.down, Vector2.down, Vector2.zero, false, true, 2f);
+
+            Assert.Less(Vector2.Distance(defenseStarted, Vector2.left), 0.001f);
+            Assert.Less(Vector2.Distance(defenseAimedAfterGrace, Vector2.down), 0.001f);
+        }
+
+        [Test]
+        public void ResolveFacing_DefenseEnds_AllowsWalkingToReclaimFacingImmediately()
+        {
+            resolver.ResolveFacing(Vector2.up, Vector2.right, Vector2.left, Vector2.zero, true, false, 0.02f);
+            resolver.ResolveFacing(Vector2.left, Vector2.right, Vector2.left, Vector2.zero, false, true, 0.1f);
+
+            var defenseReleased = resolver.ResolveFacing(
+                Vector2.left, Vector2.down, Vector2.left, Vector2.zero, false, false, 0.02f);
+
+            Assert.Less(Vector2.Distance(defenseReleased, Vector2.down), 0.001f);
+        }
+
+        [Test]
+        public void ResolveFacing_ActiveDefenseAim_RemainsHigherPriorityThanWalking()
+        {
+            var defenseStarted = resolver.ResolveFacing(
+                Vector2.left, Vector2.right, Vector2.up, Vector2.zero, false, true, 0.02f);
+
+            var defenseHeld = resolver.ResolveFacing(
+                defenseStarted, Vector2.right, Vector2.down, Vector2.zero, false, true, 0.02f);
+
+            Assert.Less(Vector2.Distance(defenseStarted, Vector2.up), 0.001f);
+            Assert.Less(Vector2.Distance(defenseHeld, Vector2.down), 0.001f);
         }
 
         private void SetPrivateFloat(string fieldName, float value)

--- a/Assets/_Project/_Tests/PlayMode/Input/PlayerFacingPolicyPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/Input/PlayerFacingPolicyPlayTests.cs
@@ -20,7 +20,8 @@ namespace Castlebound.Tests.PlayMode.Input
                 movementInput: Vector2.right,
                 resolvedAimInput: Vector2.left,
                 rawLookInput: Vector2.zero,
-                aimIntentActive: false,
+                attackAimIntentActive: false,
+                defenseActive: false,
                 deltaTime: 0.02f);
             yield return null;
 
@@ -29,7 +30,8 @@ namespace Castlebound.Tests.PlayMode.Input
                 movementInput: Vector2.right,
                 resolvedAimInput: Vector2.left,
                 rawLookInput: Vector2.zero,
-                aimIntentActive: true,
+                attackAimIntentActive: true,
+                defenseActive: false,
                 deltaTime: 0.02f);
             yield return null;
 
@@ -38,18 +40,19 @@ namespace Castlebound.Tests.PlayMode.Input
                 movementInput: Vector2.right,
                 resolvedAimInput: Vector2.left,
                 rawLookInput: Vector2.zero,
-                aimIntentActive: false,
+                attackAimIntentActive: false,
+                defenseActive: false,
                 deltaTime: 0.02f);
 
             Assert.Less(Vector2.Distance(movementFacing, Vector2.right), 0.001f);
             Assert.Less(Vector2.Distance(aimFacing, Vector2.left), 0.001f);
-            Assert.Less(Vector2.Distance(releasedFacing, Vector2.right), 0.001f);
+            Assert.Less(Vector2.Distance(releasedFacing, Vector2.left), 0.001f);
 
             Object.Destroy(root);
         }
 
         [UnityTest]
-        public IEnumerator Runtime_AndroidRightStickHysteresis_ActivatesAndReleasesAimOverride()
+        public IEnumerator Runtime_AndroidRightStickHysteresis_ReleasesIntoGracePeriod()
         {
             var root = new GameObject("PlayerFacingPolicyResolver");
             var resolver = root.AddComponent<PlayerFacingPolicyResolver>();
@@ -60,7 +63,8 @@ namespace Castlebound.Tests.PlayMode.Input
                 movementInput: Vector2.down,
                 resolvedAimInput: Vector2.left,
                 rawLookInput: new Vector2(0.30f, 0f),
-                aimIntentActive: false,
+                attackAimIntentActive: false,
+                defenseActive: false,
                 deltaTime: 0.02f);
             yield return null;
 
@@ -69,7 +73,8 @@ namespace Castlebound.Tests.PlayMode.Input
                 movementInput: Vector2.down,
                 resolvedAimInput: Vector2.left,
                 rawLookInput: new Vector2(0.22f, 0f),
-                aimIntentActive: false,
+                attackAimIntentActive: false,
+                defenseActive: false,
                 deltaTime: 0.02f);
             yield return null;
 
@@ -78,12 +83,13 @@ namespace Castlebound.Tests.PlayMode.Input
                 movementInput: Vector2.down,
                 resolvedAimInput: Vector2.left,
                 rawLookInput: new Vector2(0.19f, 0f),
-                aimIntentActive: false,
+                attackAimIntentActive: false,
+                defenseActive: false,
                 deltaTime: 0.02f);
 
             Assert.Less(Vector2.Distance(entered, Vector2.left), 0.001f);
             Assert.Less(Vector2.Distance(between, Vector2.left), 0.001f);
-            Assert.Less(Vector2.Distance(exited, Vector2.down), 0.001f);
+            Assert.Less(Vector2.Distance(exited, Vector2.left), 0.001f);
 
             Object.Destroy(root);
         }
@@ -100,7 +106,8 @@ namespace Castlebound.Tests.PlayMode.Input
                 movementInput: Vector2.zero,
                 resolvedAimInput: Vector2.left,
                 rawLookInput: Vector2.zero,
-                aimIntentActive: true,
+                attackAimIntentActive: true,
+                defenseActive: false,
                 deltaTime: 0.02f);
             yield return null;
 
@@ -109,11 +116,42 @@ namespace Castlebound.Tests.PlayMode.Input
                 movementInput: new Vector2(0.05f, 0f),
                 resolvedAimInput: Vector2.left,
                 rawLookInput: Vector2.zero,
-                aimIntentActive: false,
+                attackAimIntentActive: false,
+                defenseActive: false,
                 deltaTime: 0.02f);
 
             Assert.Less(Vector2.Distance(aimedFacing, Vector2.left), 0.001f);
             Assert.Less(Vector2.Distance(releasedFacing, aimedFacing), 0.001f);
+
+            Object.Destroy(root);
+        }
+
+        [UnityTest]
+        public IEnumerator Runtime_RetreatAimReleaseAndBlock_UsesFallbackThenLiveDefenseAim()
+        {
+            var root = new GameObject("PlayerFacingPolicyResolver");
+            var resolver = root.AddComponent<PlayerFacingPolicyResolver>();
+            ConfigureResolver(resolver);
+
+            var aimedFacing = resolver.ResolveFacing(
+                Vector2.right, Vector2.right, Vector2.left, Vector2.zero, true, false, 0.02f);
+            yield return null;
+
+            var graceFacing = resolver.ResolveFacing(
+                aimedFacing, Vector2.right, Vector2.left, Vector2.zero, false, false, 0.02f);
+            yield return null;
+
+            var defenseFacing = resolver.ResolveFacing(
+                graceFacing, Vector2.right, Vector2.zero, Vector2.zero, false, true, 0.02f);
+            yield return null;
+
+            var heldDefenseFacing = resolver.ResolveFacing(
+                defenseFacing, Vector2.down, Vector2.down, Vector2.zero, false, true, 1.5f);
+
+            Assert.Less(Vector2.Distance(aimedFacing, Vector2.left), 0.001f);
+            Assert.Less(Vector2.Distance(graceFacing, Vector2.left), 0.001f);
+            Assert.Less(Vector2.Distance(defenseFacing, Vector2.left), 0.001f);
+            Assert.Less(Vector2.Distance(heldDefenseFacing, Vector2.down), 0.001f);
 
             Object.Destroy(root);
         }
@@ -123,6 +161,7 @@ namespace Castlebound.Tests.PlayMode.Input
             SetPrivateFloat(resolver, "aimEnterThreshold", 0.25f);
             SetPrivateFloat(resolver, "aimExitThreshold", 0.20f);
             SetPrivateFloat(resolver, "movementMeaningfulThreshold", 0.10f);
+            SetPrivateFloat(resolver, "postAimFacingGraceDuration", 0.6f);
             SetPrivateFloat(resolver, "stickMagnitudeMax", 1.1f);
         }
 

--- a/TEST_LOG.md
+++ b/TEST_LOG.md
@@ -1,3 +1,20 @@
+## 2026-08-08 - feat-player-post-aim-facing-grace
+
+### Summary
+- Added a prefab-tunable 0.6-second post-aim facing grace shared by desktop and mobile aim paths.
+- Made active defense aim the highest-priority facing source, with retained/current fallback when defense aim is temporarily unavailable.
+- Separated facing execution from movement so walking remains the sole velocity source and the facing resolver remains the sole selection authority.
+
+### New or Updated Tests
+**EditMode**
+- PlayerFacingPolicyResolverTests, PlayerFacingPolicyContractsTests, and PlayerFacingOrchestratorTests — facing priority, 0.6-second grace timing, live defense aim, retained fallback, expiry, idle retention, prefab ownership, velocity separation, and facing execution regression coverage.
+
+**PlayMode**
+- PlayerFacingPolicyPlayTests — desktop and mobile grace behavior plus retreat-to-aim-to-defense fallback and live defense aiming.
+
+### Notes
+- Full EditMode and PlayMode suites pass manually; retreat, post-aim grace, block/parry aim priority, and movement independence feel correct in play.
+
 ## 2026-08-06 - feat-enemy-parry-stagger
 
 ### Summary


### PR DESCRIPTION
## Why
Releasing attack aim while moving could immediately return facing to walking, causing a snap during the transition into block or parry. Facing needs a short retained-aim window and deterministic defense priority without coupling movement velocity to facing.

## What changed
- Added a prefab-tunable 0.6-second post-aim facing grace for desktop and mobile input
- Made active defense aim the highest-priority facing source with retained/current fallback
- Separated facing execution from velocity-only movement orchestration
- Added EditMode, PlayMode, prefab-contract, and regression coverage

## How to test
1. Open the main prototype scene and move away from a target while aiming toward it
2. Release attack aim, begin block/parry during the grace period, and verify movement continues while facing stays stable
3. Adjust defense aim while held and verify it overrides walking; release defense and verify walking immediately regains facing
4. Run tests:
   - EditMode
   - PlayMode

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated (N/A - no scene changes required)
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched (N/A - no documentation changes required)

## Related
- Closes #289