### PR TITLE
feat(player): add directional combat dash

### DIFF
--- a/Assets/_Project/Prefabs/Player.prefab
+++ b/Assets/_Project/Prefabs/Player.prefab
@@ -128,6 +128,7 @@ GameObject:
   - component: {fileID: 9150000000000000401}
   - component: {fileID: 9150000000000000701}
   - component: {fileID: 9150000000000000702}
+  - component: {fileID: 9150000000000000801}
   m_Layer: 3
   m_Name: Player
   m_TagString: Player
@@ -263,6 +264,7 @@ MonoBehaviour:
   attackAnimationDriver: {fileID: 9150000000000000204}
   attackLoop: {fileID: 9150000000000000205}
   defenseController: {fileID: 9150000000000000701}
+  dashController: {fileID: 9150000000000000801}
   baseAttackDamage: 1
   baseAttackRate: 1.5
   movementOrchestrator:
@@ -404,6 +406,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   maxHealth: 200
   playerHitFeedbackChannel: {fileID: 11400000, guid: d20a388de840a2442a233efbf88b515b, type: 2}
+  damageImmunitySource: {fileID: 9150000000000000801}
 --- !u!114 &-5784453068084145222
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -815,6 +818,7 @@ MonoBehaviour:
   guardingMovementMultiplier: 0.6
   health: {fileID: 2634735562689669640}
   playerController: {fileID: 4369444282720785943}
+  dashController: {fileID: 9150000000000000801}
 --- !u!114 &9150000000000000702
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -836,3 +840,21 @@ MonoBehaviour:
   parryWindowColor: {r: 0.25, g: 0.95, b: 1, a: 0.7}
   blockingColor: {r: 0.25, g: 0.6, b: 1, a: 0.55}
   parrySuccessColor: {r: 1, g: 0.9, b: 0.2, a: 0.95}
+--- !u!114 &9150000000000000801
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8325390509751579795}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 793a36ca57e94dc8a0052a78ac94c96e, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  dashSpeed: 24
+  fullDashDuration: 0.2
+  rearDurationMultiplier: 0.6
+  cooldown: 0.75
+  invulnerabilityDuration: 0.25
+  mobileOuterReleaseThreshold: 0.9

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/Health.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/Health.cs
@@ -1,6 +1,7 @@
 // Assets/Scripts/Combat/Health.cs
 using System;
 using UnityEngine;
+using Castlebound.Gameplay.Combat;
 using Castlebound.Gameplay.Inventory;
 using Castlebound.Gameplay.Stats;
 
@@ -8,7 +9,10 @@ public class Health : MonoBehaviour, IDamageable, IHealable
 {
     [SerializeField] int maxHealth = 10;
     [SerializeField] FeedbackEventChannel playerHitFeedbackChannel;
+    [SerializeField] MonoBehaviour damageImmunitySource;
     int current;
+    IDamageImmunitySource damageImmunity;
+    bool damageImmunityResolved;
 
     public int Current => current;
     public int Max => maxHealth;
@@ -24,6 +28,7 @@ public class Health : MonoBehaviour, IDamageable, IHealable
 
     void Awake()
     {
+        ResolveDamageImmunity();
         current = maxHealth;
         OnHealthChanged?.Invoke(current, maxHealth);
     }
@@ -35,7 +40,9 @@ public class Health : MonoBehaviour, IDamageable, IHealable
 
     public int ApplyDamage(int amount)
     {
-        if (current <= 0 || amount <= 0) return 0;
+        ResolveDamageImmunity();
+        if (current <= 0 || amount <= 0 || (damageImmunity != null && damageImmunity.IsDamageImmune))
+            return 0;
         int previous = current;
         current = Mathf.Max(0, current - amount);
         int appliedDamage = previous - current;
@@ -78,5 +85,27 @@ public class Health : MonoBehaviour, IDamageable, IHealable
             Destroy(gameObject);
         else
             DestroyImmediate(gameObject);
+    }
+
+    private void ResolveDamageImmunity()
+    {
+        if (damageImmunityResolved)
+            return;
+
+        damageImmunityResolved = true;
+        damageImmunity = damageImmunitySource as IDamageImmunitySource;
+        if (damageImmunity != null)
+            return;
+
+        var sources = GetComponents<MonoBehaviour>();
+        for (int i = 0; i < sources.Length; i++)
+        {
+            if (sources[i] is IDamageImmunitySource immunitySource)
+            {
+                damageImmunitySource = sources[i];
+                damageImmunity = immunitySource;
+                return;
+            }
+        }
     }
 }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/IDamageImmunitySource.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/IDamageImmunitySource.cs
@@ -1,0 +1,7 @@
+namespace Castlebound.Gameplay.Combat
+{
+    public interface IDamageImmunitySource
+    {
+        bool IsDamageImmune { get; }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Combat/IDamageImmunitySource.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Combat/IDamageImmunitySource.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1889bb30b4ee42a8bdad29d4a3e4a270
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/_Project.Gameplay/Inventory/PotionUseController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Inventory/PotionUseController.cs
@@ -11,6 +11,7 @@ namespace Castlebound.Gameplay.Inventory
 
         private PotionConsumeController consumeController;
         private IHealable healTarget;
+        private PlayerDashController dashController;
 
         private void Awake()
         {
@@ -30,6 +31,11 @@ namespace Castlebound.Gameplay.Inventory
         public bool TryConsume()
         {
             EnsureController();
+            if (dashController != null && dashController.IsDashing)
+            {
+                return false;
+            }
+
             if (inventorySource == null || consumeController == null)
             {
                 return false;
@@ -92,6 +98,11 @@ namespace Castlebound.Gameplay.Inventory
             if (consumeController == null)
             {
                 consumeController = new PotionConsumeController(resolverSource, new UnityTimeProvider(), healTarget);
+            }
+
+            if (dashController == null)
+            {
+                dashController = GetComponentInParent<PlayerDashController>();
             }
         }
     }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerDashController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerDashController.cs
@@ -1,0 +1,170 @@
+using Castlebound.Gameplay.Combat;
+using UnityEngine;
+
+public class PlayerDashController : MonoBehaviour, IDamageImmunitySource
+{
+    private const float DirectionEpsilonSquared = 0.01f;
+    private const float TimerTolerance = 0.000001f;
+
+    [Header("Movement")]
+    [SerializeField, Min(0f)] private float dashSpeed = 24f;
+    [SerializeField, Min(0f)] private float fullDashDuration = 0.2f;
+    [SerializeField, Range(0f, 1f)] private float rearDurationMultiplier = 0.6f;
+
+    [Header("Availability")]
+    [SerializeField, Min(0f)] private float cooldown = 0.75f;
+    [SerializeField, Min(0f)] private float invulnerabilityDuration = 0.25f;
+
+    [Header("Mobile")]
+    [SerializeField, Range(0f, 1f)] private float mobileOuterReleaseThreshold = 0.9f;
+
+    private Vector2 direction;
+    private PlayerDashDirection directionClass;
+    private float activeDuration;
+    private float activeRemaining;
+    private float cooldownRemaining;
+    private float invulnerabilityRemaining;
+
+    public float DashSpeed
+    {
+        get => dashSpeed;
+        set => dashSpeed = Mathf.Max(0f, value);
+    }
+
+    public float FullDashDuration => fullDashDuration;
+    public float RearDurationMultiplier => rearDurationMultiplier;
+    public float RearDashDuration => fullDashDuration * rearDurationMultiplier;
+    public float FullDashDistance => dashSpeed * fullDashDuration;
+    public float RearDashDistance => dashSpeed * RearDashDuration;
+    public float MobileOuterReleaseThreshold => mobileOuterReleaseThreshold;
+    public Vector2 Direction => direction;
+    public PlayerDashDirection DirectionClass => directionClass;
+    public float ActiveDuration => activeDuration;
+    public float ActiveRemaining => activeRemaining;
+    public float CooldownRemaining => cooldownRemaining;
+    public float InvulnerabilityRemaining => invulnerabilityRemaining;
+    public bool IsDashing => activeRemaining > 0f;
+    public bool IsInvulnerable => invulnerabilityRemaining > 0f;
+    public bool IsDamageImmune => IsInvulnerable;
+    public bool IsReady => !IsDashing && cooldownRemaining <= 0f;
+    public Vector2 CurrentVelocity => IsDashing ? direction * dashSpeed : Vector2.zero;
+
+    public bool TryStart(Vector2 directionalInput, Vector2 currentFacing, bool actionStateAllowsDash)
+    {
+        if (!actionStateAllowsDash || !IsReady)
+            return false;
+
+        direction = ResolveDirection(directionalInput, currentFacing);
+        directionClass = ClassifyDirection(direction, currentFacing);
+        activeDuration = directionClass == PlayerDashDirection.Rear
+            ? RearDashDuration
+            : fullDashDuration;
+        activeRemaining = activeDuration;
+        cooldownRemaining = cooldown;
+        invulnerabilityRemaining = invulnerabilityDuration;
+        return true;
+    }
+
+    public bool TryResolveMobileRelease(Vector2 releaseSample, out Vector2 releaseDirection)
+    {
+        if (releaseSample.magnitude < mobileOuterReleaseThreshold ||
+            releaseSample.sqrMagnitude <= 0.0001f)
+        {
+            releaseDirection = Vector2.zero;
+            return false;
+        }
+
+        releaseDirection = releaseSample.normalized;
+        return true;
+    }
+
+    public void Tick(float deltaTime)
+    {
+        float safeDelta = NormalizeDelta(deltaTime);
+        activeRemaining = AdvanceTimer(activeRemaining, safeDelta);
+        cooldownRemaining = AdvanceTimer(cooldownRemaining, safeDelta);
+        invulnerabilityRemaining = AdvanceTimer(invulnerabilityRemaining, safeDelta);
+
+        if (!IsDashing)
+            direction = Vector2.zero;
+    }
+
+    public void CancelActiveState()
+    {
+        activeRemaining = 0f;
+        invulnerabilityRemaining = 0f;
+        direction = Vector2.zero;
+    }
+
+    public void ResetState()
+    {
+        direction = Vector2.zero;
+        directionClass = PlayerDashDirection.Full;
+        activeDuration = 0f;
+        activeRemaining = 0f;
+        cooldownRemaining = 0f;
+        invulnerabilityRemaining = 0f;
+    }
+
+    public void Configure(
+        float speed,
+        float fullDuration,
+        float rearMultiplier,
+        float cooldownSeconds,
+        float invulnerabilitySeconds,
+        float mobileReleaseThreshold)
+    {
+        dashSpeed = Mathf.Max(0f, speed);
+        fullDashDuration = Mathf.Max(0f, fullDuration);
+        rearDurationMultiplier = Mathf.Clamp01(rearMultiplier);
+        cooldown = Mathf.Max(0f, cooldownSeconds);
+        invulnerabilityDuration = Mathf.Max(0f, invulnerabilitySeconds);
+        mobileOuterReleaseThreshold = Mathf.Clamp01(mobileReleaseThreshold);
+    }
+
+    public static PlayerDashDirection ClassifyDirection(Vector2 dashDirection, Vector2 currentFacing)
+    {
+        Vector2 normalizedDirection = NormalizeOrFallback(dashDirection, Vector2.down);
+        Vector2 normalizedFacing = NormalizeOrFallback(currentFacing, Vector2.up);
+        return Vector2.Dot(normalizedDirection, normalizedFacing) < 0f
+            ? PlayerDashDirection.Rear
+            : PlayerDashDirection.Full;
+    }
+
+    private static Vector2 ResolveDirection(Vector2 directionalInput, Vector2 currentFacing)
+    {
+        if (directionalInput.sqrMagnitude >= DirectionEpsilonSquared)
+            return directionalInput.normalized;
+
+        return -NormalizeOrFallback(currentFacing, Vector2.up);
+    }
+
+    private static Vector2 NormalizeOrFallback(Vector2 value, Vector2 fallback)
+    {
+        return value.sqrMagnitude > 0.0001f ? value.normalized : fallback;
+    }
+
+    private static float NormalizeDelta(float deltaTime)
+    {
+        if (float.IsNaN(deltaTime) || float.IsNegativeInfinity(deltaTime) || deltaTime <= 0f)
+            return 0f;
+        return float.IsPositiveInfinity(deltaTime) ? float.MaxValue : deltaTime;
+    }
+
+    private static float AdvanceTimer(float remaining, float deltaTime)
+    {
+        return remaining <= deltaTime + TimerTolerance
+            ? 0f
+            : remaining - deltaTime;
+    }
+
+    private void OnValidate()
+    {
+        dashSpeed = Mathf.Max(0f, dashSpeed);
+        fullDashDuration = Mathf.Max(0f, fullDashDuration);
+        rearDurationMultiplier = Mathf.Clamp01(rearDurationMultiplier);
+        cooldown = Mathf.Max(0f, cooldown);
+        invulnerabilityDuration = Mathf.Max(0f, invulnerabilityDuration);
+        mobileOuterReleaseThreshold = Mathf.Clamp01(mobileOuterReleaseThreshold);
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerDashController.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerDashController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 793a36ca57e94dc8a0052a78ac94c96e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerDashDirection.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerDashDirection.cs
@@ -1,0 +1,5 @@
+public enum PlayerDashDirection
+{
+    Full,
+    Rear
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerDashDirection.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerDashDirection.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f4f11ec5d3c74e0aa1b6f51e4f207adb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerDefenseController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerDefenseController.cs
@@ -18,6 +18,7 @@ public class PlayerDefenseController : MonoBehaviour, IPlayerHitReceiver
     [Header("References")]
     [SerializeField] private Health health;
     [SerializeField] private PlayerController playerController;
+    [SerializeField] private PlayerDashController dashController;
     [SerializeField] private bool useReleaseFallbackPolling = true;
 
     private PlayerDefenseStateMachine stateMachine;
@@ -67,6 +68,10 @@ public class PlayerDefenseController : MonoBehaviour, IPlayerHitReceiver
 
     public void SetDefensePressed(bool isPressed)
     {
+        EnsureReferences();
+        if (isPressed && dashController != null && dashController.IsDashing)
+            return;
+
         PlayerDefenseState previous = State;
         bool changed = isPressed
             ? stateMachine.BeginDefense(parryWindowDuration, parryCapacity)
@@ -172,6 +177,8 @@ public class PlayerDefenseController : MonoBehaviour, IPlayerHitReceiver
             health = GetComponent<Health>();
         if (playerController == null)
             playerController = GetComponent<PlayerController>();
+        if (dashController == null)
+            dashController = GetComponent<PlayerDashController>();
     }
 
     private Vector2 ResolveFacingDirection()

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Input/MobileInputDriver.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Input/MobileInputDriver.cs
@@ -23,6 +23,7 @@ namespace Castlebound.Gameplay.Input
         [SerializeField] private TouchAimAttackZone aimAttackZone;
         [SerializeField] private TouchDefenseAimButton defenseAimButton;
         [SerializeField] private TouchRepairButton repairButton;
+        [SerializeField] private PlayerDashController dashController;
 
         [Tooltip("The PlayerInput component that drives PlayerController. " +
                  "Must be assigned so the virtual gamepad is paired to its InputUser.")]
@@ -37,6 +38,8 @@ namespace Castlebound.Gameplay.Input
 
         private Gamepad _virtualGamepad;
         private bool _pendingRepairPress;
+        private bool _pendingDashPress;
+        private Vector2 _pendingDashDirection;
 
         private void OnEnable()
         {
@@ -65,6 +68,13 @@ namespace Castlebound.Gameplay.Input
 
             if (repairButton != null)
                 repairButton.OnRepairRequested += HandleRepairRequested;
+            if (movementZone != null)
+                movementZone.MovementReleased += HandleMovementReleased;
+
+            if (dashController == null && playerInput != null)
+                dashController = playerInput.GetComponent<PlayerDashController>();
+            if (dashController == null)
+                dashController = FindObjectOfType<PlayerDashController>();
 
             ApplyRightStickAttackDeadzone();
         }
@@ -87,6 +97,11 @@ namespace Castlebound.Gameplay.Input
         {
             if (repairButton != null)
                 repairButton.OnRepairRequested -= HandleRepairRequested;
+            if (movementZone != null)
+                movementZone.MovementReleased -= HandleMovementReleased;
+
+            _pendingDashPress = false;
+            _pendingDashDirection = Vector2.zero;
 
             if (_virtualGamepad != null)
             {
@@ -105,8 +120,15 @@ namespace Castlebound.Gameplay.Input
             var state = new GamepadState();
 
             // Left stick drives movement (and facing when aim zone is inactive).
-            if (movementZone != null)
+            if (_pendingDashPress)
+            {
+                state.leftStick = _pendingDashDirection;
+                state.buttons |= (ushort)(1 << (int)GamepadButton.LeftStick);
+            }
+            else if (movementZone != null)
+            {
                 state.leftStick = movementZone.MoveVector;
+            }
 
             // Right stick drives facing direction.
             // Right trigger remains held while the right zone is firing.
@@ -131,11 +153,25 @@ namespace Castlebound.Gameplay.Input
             }
 
             InputSystem.QueueStateEvent(_virtualGamepad, state);
+            _pendingDashPress = false;
+            _pendingDashDirection = Vector2.zero;
         }
 
         private void HandleRepairRequested()
         {
             _pendingRepairPress = true;
+        }
+
+        private void HandleMovementReleased(Vector2 releaseSample)
+        {
+            if (dashController == null ||
+                !dashController.TryResolveMobileRelease(releaseSample, out Vector2 releaseDirection))
+            {
+                return;
+            }
+
+            _pendingDashDirection = releaseDirection;
+            _pendingDashPress = true;
         }
 
         public void SetRightStickAttackDeadzone(float deadzone)

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Input/PlayerControls.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Input/PlayerControls.cs
@@ -120,6 +120,15 @@ public partial class @PlayerControls: IInputActionCollection2, IDisposable
                     ""initialStateCheck"": false
                 },
                 {
+                    ""name"": ""Dash"",
+                    ""type"": ""Button"",
+                    ""id"": ""1b3a86d4-b07d-42e5-a97f-822a55fb5220"",
+                    ""expectedControlType"": """",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
                     ""name"": ""Repair"",
                     ""type"": ""Button"",
                     ""id"": ""aeb04078-27ae-4783-ba22-34d94795bc81"",
@@ -377,6 +386,28 @@ public partial class @PlayerControls: IInputActionCollection2, IDisposable
                 },
                 {
                     ""name"": """",
+                    ""id"": ""f17175c9-140c-4cee-9e14-874388f9f526"",
+                    ""path"": ""<Keyboard>/leftCtrl"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""Dash"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""1da4a31d-30d2-4b97-9926-47242b39d59b"",
+                    ""path"": ""<Gamepad>/leftStickPress"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""Dash"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
                     ""id"": ""4e9a8d2b-0a7f-47de-90cc-13d5e8f25732"",
                     ""path"": ""<Mouse>/position"",
                     ""interactions"": """",
@@ -396,6 +427,7 @@ public partial class @PlayerControls: IInputActionCollection2, IDisposable
         m_Player_Move = m_Player.FindAction("Move", throwIfNotFound: true);
         m_Player_Fire = m_Player.FindAction("Fire", throwIfNotFound: true);
         m_Player_Defend = m_Player.FindAction("Defend", throwIfNotFound: true);
+        m_Player_Dash = m_Player.FindAction("Dash", throwIfNotFound: true);
         m_Player_Repair = m_Player.FindAction("Repair", throwIfNotFound: true);
         m_Player_UsePotion = m_Player.FindAction("UsePotion", throwIfNotFound: true);
         m_Player_SwapWeaponSlot = m_Player.FindAction("SwapWeaponSlot", throwIfNotFound: true);
@@ -484,6 +516,7 @@ public partial class @PlayerControls: IInputActionCollection2, IDisposable
     private readonly InputAction m_Player_Move;
     private readonly InputAction m_Player_Fire;
     private readonly InputAction m_Player_Defend;
+    private readonly InputAction m_Player_Dash;
     private readonly InputAction m_Player_Repair;
     private readonly InputAction m_Player_UsePotion;
     private readonly InputAction m_Player_SwapWeaponSlot;
@@ -512,6 +545,10 @@ public partial class @PlayerControls: IInputActionCollection2, IDisposable
         /// Provides access to the underlying input action "Player/Defend".
         /// </summary>
         public InputAction @Defend => m_Wrapper.m_Player_Defend;
+        /// <summary>
+        /// Provides access to the underlying input action "Player/Dash".
+        /// </summary>
+        public InputAction @Dash => m_Wrapper.m_Player_Dash;
         /// <summary>
         /// Provides access to the underlying input action "Player/Repair".
         /// </summary>
@@ -567,6 +604,9 @@ public partial class @PlayerControls: IInputActionCollection2, IDisposable
             @Defend.started += instance.OnDefend;
             @Defend.performed += instance.OnDefend;
             @Defend.canceled += instance.OnDefend;
+            @Dash.started += instance.OnDash;
+            @Dash.performed += instance.OnDash;
+            @Dash.canceled += instance.OnDash;
             @Repair.started += instance.OnRepair;
             @Repair.performed += instance.OnRepair;
             @Repair.canceled += instance.OnRepair;
@@ -602,6 +642,9 @@ public partial class @PlayerControls: IInputActionCollection2, IDisposable
             @Defend.started -= instance.OnDefend;
             @Defend.performed -= instance.OnDefend;
             @Defend.canceled -= instance.OnDefend;
+            @Dash.started -= instance.OnDash;
+            @Dash.performed -= instance.OnDash;
+            @Dash.canceled -= instance.OnDash;
             @Repair.started -= instance.OnRepair;
             @Repair.performed -= instance.OnRepair;
             @Repair.canceled -= instance.OnRepair;
@@ -678,6 +721,13 @@ public partial class @PlayerControls: IInputActionCollection2, IDisposable
         /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
         /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
         void OnDefend(InputAction.CallbackContext context);
+        /// <summary>
+        /// Method invoked when associated input action "Dash" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+        /// </summary>
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+        void OnDash(InputAction.CallbackContext context);
         /// <summary>
         /// Method invoked when associated input action "Repair" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
         /// </summary>

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Input/TouchMovementZone.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Input/TouchMovementZone.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 using UnityEngine.EventSystems;
 
@@ -11,6 +12,7 @@ namespace Castlebound.Gameplay.Input
 
         public Vector2 MoveVector { get; private set; }
         public Vector2 AnchorPosition { get; private set; }
+        public event Action<Vector2> MovementReleased;
 
         /// <summary>Exposes <see cref="maxRadius"/> so tests can override it without the inspector.</summary>
         public float MaxRadius
@@ -65,8 +67,10 @@ namespace Castlebound.Gameplay.Input
 
         public void SimulatePointerUp()
         {
+            Vector2 releaseSample = MoveVector;
             MoveVector = Vector2.zero;
             AnchorPosition = Vector2.zero;
+            MovementReleased?.Invoke(releaseSample);
         }
 
         private static bool IsTouchPointer(PointerEventData eventData)

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Input/TouchUIBindings.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Input/TouchUIBindings.cs
@@ -106,7 +106,13 @@ namespace Castlebound.Gameplay.Input
         public void Initialize()
         {
             if (_potionButton != null && _potionUseController != null)
-                _potionButton.onClick.AddListener(() => _potionUseController.TryConsume());
+                _potionButton.onClick.AddListener(() =>
+                {
+                    if (_playerController != null)
+                        _playerController.TryUsePotion();
+                    else
+                        _potionUseController.TryConsume();
+                });
 
             if (_weaponButton != null && _playerController != null)
                 _weaponButton.onClick.AddListener(() => _playerController.TrySwapWeaponSlotWithoutCooldown());

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Movement/PlayerCollisionMove2D.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Movement/PlayerCollisionMove2D.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 
 [RequireComponent(typeof(Rigidbody2D))]
 [RequireComponent(typeof(Collider2D))]
+[DefaultExecutionOrder(100)]
 public class PlayerCollisionMove2D : MonoBehaviour
 {
     [SerializeField] private float moveSpeed = 6f;
@@ -11,6 +12,8 @@ public class PlayerCollisionMove2D : MonoBehaviour
     private Rigidbody2D _rb;
     private Collider2D _col;
     private Vector2 _input;
+    private Vector2 _velocityOverride;
+    private bool _useVelocityOverride;
 
     public float MoveSpeed
     {
@@ -26,6 +29,13 @@ public class PlayerCollisionMove2D : MonoBehaviour
         // Clamp per-axis to [-1, 1] without allocating
         _input.x = Mathf.Clamp(input.x, -1f, 1f);
         _input.y = Mathf.Clamp(input.y, -1f, 1f);
+        _useVelocityOverride = false;
+    }
+
+    public void SetMoveVelocity(Vector2 velocity)
+    {
+        _velocityOverride = velocity;
+        _useVelocityOverride = true;
     }
 
     private void Awake()
@@ -48,7 +58,9 @@ public class PlayerCollisionMove2D : MonoBehaviour
         if (_rb == null || _col == null) return;
 
         float dt = Time.fixedDeltaTime;
-        Vector2 delta = _input * moveSpeed * dt;
+        Vector2 delta = _useVelocityOverride
+            ? _velocityOverride * dt
+            : _input * moveSpeed * dt;
 
         // Prepare filter (stack struct, no allocation)
         ContactFilter2D filter = new ContactFilter2D();

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/PlayerController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/PlayerController.cs
@@ -27,6 +27,7 @@ public class PlayerController : MonoBehaviour
     [SerializeField] private PlayerAttackAnimationDriver attackAnimationDriver;
     [SerializeField] private PlayerAttackLoop attackLoop;
     [SerializeField] private PlayerDefenseController defenseController;
+    [SerializeField] private PlayerDashController dashController;
     [SerializeField, Min(0)] private int baseAttackDamage = 1;
     [SerializeField] private float baseAttackRate = 1.5f;
     
@@ -101,6 +102,7 @@ public class PlayerController : MonoBehaviour
         if (attackAnimationDriver == null) attackAnimationDriver = GetComponent<PlayerAttackAnimationDriver>();
         if (attackLoop == null) attackLoop = GetComponent<PlayerAttackLoop>();
         if (defenseController == null) defenseController = GetComponent<PlayerDefenseController>();
+        if (dashController == null) dashController = GetComponent<PlayerDashController>();
         inventoryState = inventorySource != null ? inventorySource.State : null;
         if (weaponSlotSwapHandler == null) weaponSlotSwapHandler = new WeaponSlotSwapHandler();
         if (movementOrchestrator == null) movementOrchestrator = new PlayerMovementOrchestrator();
@@ -130,7 +132,7 @@ public class PlayerController : MonoBehaviour
 
     public void OnFire(InputValue value)
     {
-        if (inputLocked || (defenseController != null && !defenseController.CanAttack))
+        if (inputLocked || IsDashing || (defenseController != null && !defenseController.CanAttack))
         {
             fireInputController?.ClearHeldFire();
             return;
@@ -146,12 +148,16 @@ public class PlayerController : MonoBehaviour
         if (inputLocked)
             return;
 
-        fireInputController?.Tick();
+        bool wasDashing = IsDashing;
+        Vector2 dashVelocity = wasDashing ? dashController.CurrentVelocity : Vector2.zero;
+
+        if (!wasDashing)
+            fireInputController?.Tick();
 
         if (attackLoop == null)
             attackLoop = GetComponent<PlayerAttackLoop>();
 
-        bool canAttack = defenseController == null || defenseController.CanAttack;
+        bool canAttack = !wasDashing && (defenseController == null || defenseController.CanAttack);
         var isFireHeld = canAttack && fireInputController != null && fireInputController.IsFireHeld;
         attackRuntime.Tick(
             Time.fixedDeltaTime,
@@ -164,12 +170,21 @@ public class PlayerController : MonoBehaviour
             animator,
             hitboxObject);
 
-        float movementSpeedMultiplier = defenseController != null
-            ? defenseController.MovementSpeedMultiplier
-            : 1f;
-        Vector2 facingDirection = ResolveFacingInput();
-        movementOrchestrator.Tick(mover, movementInput, movementSpeedMultiplier);
-        facingOrchestrator.Tick(transform, facingDirection, Time.fixedDeltaTime);
+        if (wasDashing)
+        {
+            mover?.SetMoveVelocity(dashVelocity);
+        }
+        else
+        {
+            float movementSpeedMultiplier = defenseController != null
+                ? defenseController.MovementSpeedMultiplier
+                : 1f;
+            Vector2 facingDirection = ResolveFacingInput();
+            movementOrchestrator.Tick(mover, movementInput, movementSpeedMultiplier);
+            facingOrchestrator.Tick(transform, facingDirection, Time.fixedDeltaTime);
+        }
+
+        dashController?.Tick(Time.fixedDeltaTime);
     }
 
     /// <summary>
@@ -193,7 +208,7 @@ public class PlayerController : MonoBehaviour
 
     public bool TryRepair()
     {
-        if (inputLocked || IsRepairOnCooldown || _repairSensor == null)
+        if (inputLocked || IsDashing || IsRepairOnCooldown || _repairSensor == null)
         {
             return false;
         }
@@ -225,7 +240,45 @@ public class PlayerController : MonoBehaviour
         if (!value.isPressed)
             return;
 
-        potionUseController?.TryConsume();
+        TryUsePotion();
+    }
+
+    public bool TryUsePotion()
+    {
+        if (inputLocked || IsDashing)
+            return false;
+
+        return potionUseController != null && potionUseController.TryConsume();
+    }
+
+    public void OnDash(InputValue value)
+    {
+        if (!value.isPressed)
+            return;
+
+        TryStartDash();
+    }
+
+    public bool TryStartDash()
+    {
+        if (inputLocked)
+            return false;
+
+        if (dashController == null)
+            dashController = GetComponent<PlayerDashController>();
+        if (defenseController == null)
+            defenseController = GetComponent<PlayerDefenseController>();
+
+        bool defenseAllowsDash = defenseController == null ||
+            defenseController.State == PlayerDefenseState.Idle;
+        if (dashController == null ||
+            !dashController.TryStart(movementInput, CurrentFacingDirection, defenseAllowsDash))
+        {
+            return false;
+        }
+
+        ClearAttackInputState();
+        return true;
     }
 
     public void OnSwapWeaponSlot(InputValue value)
@@ -274,6 +327,7 @@ public class PlayerController : MonoBehaviour
     public void StopMovement()
     {
         movementInput = Vector2.zero;
+        dashController?.CancelActiveState();
         if (mover != null)
         {
             mover.SetMoveInput(Vector2.zero);
@@ -312,6 +366,8 @@ public class PlayerController : MonoBehaviour
             animator,
             hitboxObject);
     }
+
+    public bool IsDashing => dashController != null && dashController.IsDashing;
 
     private Vector2 ResolveAimInput()
     {

--- a/Assets/_Project/Settings/Input/PlayerControls.inputactions
+++ b/Assets/_Project/Settings/Input/PlayerControls.inputactions
@@ -34,6 +34,15 @@
                     "initialStateCheck": false
                 },
                 {
+                    "name": "Dash",
+                    "type": "Button",
+                    "id": "1b3a86d4-b07d-42e5-a97f-822a55fb5220",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
                     "name": "Repair",
                     "type": "Button",
                     "id": "aeb04078-27ae-4783-ba22-34d94795bc81",
@@ -286,6 +295,28 @@
                     "processors": "",
                     "groups": "",
                     "action": "Defend",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "f17175c9-140c-4cee-9e14-874388f9f526",
+                    "path": "<Keyboard>/leftCtrl",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Dash",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "1da4a31d-30d2-4b97-9926-47242b39d59b",
+                    "path": "<Gamepad>/leftStickPress",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Dash",
                     "isComposite": false,
                     "isPartOfComposite": false
                 },

--- a/Assets/_Project/_Tests/EditMode/Input/DashInputContractsTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Input/DashInputContractsTests.cs
@@ -1,0 +1,64 @@
+using System.IO;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+
+namespace Castlebound.Tests.Input
+{
+    public class DashInputContractsTests
+    {
+        private const string InputActionsPath =
+            "Assets/_Project/Settings/Input/PlayerControls.inputactions";
+        private const string GeneratedControlsPath =
+            "Assets/_Project/Scripts/_Project.Gameplay/Player/Input/PlayerControls.cs";
+        private const string MobileDriverPath =
+            "Assets/_Project/Scripts/_Project.Gameplay/Player/Input/MobileInputDriver.cs";
+        private const string PlayerPrefabPath = "Assets/_Project/Prefabs/Player.prefab";
+
+        [Test]
+        public void PlayerControls_DashUsesRequiredDesktopAndGamepadBindings()
+        {
+            string actions = File.ReadAllText(InputActionsPath);
+            string generated = File.ReadAllText(GeneratedControlsPath);
+
+            StringAssert.Contains("\"name\": \"Dash\"", actions);
+            StringAssert.Contains("<Keyboard>/leftCtrl", actions);
+            StringAssert.Contains("<Gamepad>/leftStickPress", actions);
+            StringAssert.Contains("m_Player_Dash", generated);
+            StringAssert.Contains("void OnDash(InputAction.CallbackContext context)", generated);
+        }
+
+        [Test]
+        public void MobileDash_UsesReleaseSampleAndVirtualLeftStickPressWithoutDedicatedButton()
+        {
+            string source = File.ReadAllText(MobileDriverPath);
+
+            StringAssert.Contains("movementZone.MovementReleased", source);
+            StringAssert.Contains("TryResolveMobileRelease(releaseSample", source);
+            StringAssert.Contains("GamepadButton.LeftStick", source);
+            StringAssert.Contains("state.leftStick = _pendingDashDirection", source);
+            StringAssert.DoesNotContain("dashbutton", source.ToLowerInvariant());
+        }
+
+        [Test]
+        public void PlayerPrefab_OwnsDashTuningAndNoAuthoredDistance()
+        {
+            var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(PlayerPrefabPath);
+            Assert.NotNull(prefab);
+
+            var dash = prefab.GetComponent<PlayerDashController>();
+            Assert.NotNull(dash);
+            var serializedDash = new SerializedObject(dash);
+
+            Assert.That(serializedDash.FindProperty("dashSpeed"), Is.Not.Null);
+            Assert.That(serializedDash.FindProperty("fullDashDuration"), Is.Not.Null);
+            Assert.That(serializedDash.FindProperty("rearDurationMultiplier").floatValue,
+                Is.EqualTo(0.6f).Within(0.0001f));
+            Assert.That(serializedDash.FindProperty("cooldown"), Is.Not.Null);
+            Assert.That(serializedDash.FindProperty("invulnerabilityDuration"), Is.Not.Null);
+            Assert.That(serializedDash.FindProperty("mobileOuterReleaseThreshold"), Is.Not.Null);
+            Assert.That(serializedDash.FindProperty("dashDistance"), Is.Null);
+            Assert.That(serializedDash.FindProperty("rearDashDistance"), Is.Null);
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Input/DashInputContractsTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Input/DashInputContractsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a688e9fa10aa4772b316ba992e36742f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/_Tests/EditMode/Input/TouchMovementZoneTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Input/TouchMovementZoneTests.cs
@@ -85,6 +85,36 @@ namespace Castlebound.Tests.Input
         }
 
         [Test]
+        public void SimulatePointerUp_PublishesCurrentReleaseSampleBeforeReset()
+        {
+            Vector2 observed = Vector2.zero;
+            _zone.MovementReleased += sample => observed = sample;
+            _zone.MaxRadius = 100f;
+            _zone.SimulatePointerDown(Vector2.zero);
+            _zone.SimulateDrag(new Vector2(95f, 0f));
+
+            _zone.SimulatePointerUp();
+
+            Assert.That(observed, Is.EqualTo(new Vector2(0.95f, 0f)));
+            Assert.That(_zone.MoveVector, Is.EqualTo(Vector2.zero));
+        }
+
+        [Test]
+        public void SimulatePointerUp_AfterReturningInward_PublishesInwardSampleNotHistoricalPeak()
+        {
+            Vector2 observed = Vector2.zero;
+            _zone.MovementReleased += sample => observed = sample;
+            _zone.MaxRadius = 100f;
+            _zone.SimulatePointerDown(Vector2.zero);
+            _zone.SimulateDrag(new Vector2(100f, 0f));
+            _zone.SimulateDrag(new Vector2(40f, 0f));
+
+            _zone.SimulatePointerUp();
+
+            Assert.That(observed, Is.EqualTo(new Vector2(0.4f, 0f)));
+        }
+
+        [Test]
         public void MoveVector_IsClamped_ToMagnitudeOfOne()
         {
             _zone.SimulatePointerDown(new Vector2(100f, 100f));

--- a/Assets/_Project/_Tests/EditMode/Inventory/PotionUseControllerTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Inventory/PotionUseControllerTests.cs
@@ -120,5 +120,40 @@ namespace Castlebound.Tests.Inventory
             Object.DestroyImmediate(playerGo);
             Object.DestroyImmediate(potion);
         }
+
+        [Test]
+        public void TryConsume_IsRejectedWhilePlayerIsDashing()
+        {
+            var playerGo = new GameObject("Player");
+            var inventory = playerGo.AddComponent<InventoryStateComponent>();
+            inventory.State.TryAddPotion("potion_basic", 2);
+            var healable = playerGo.AddComponent<DummyHealable>();
+            var dash = playerGo.AddComponent<PlayerDashController>();
+            dash.Configure(20f, 0.5f, 0.6f, 1f, 0.4f, 0.9f);
+
+            var potion = ScriptableObject.CreateInstance<PotionDefinition>();
+            potion.ItemId = "potion_basic";
+            potion.HealAmount = 10;
+            potion.CooldownSeconds = 0f;
+            var resolverGo = new GameObject("Resolver");
+            var resolver = resolverGo.AddComponent<PotionDefinitionResolverComponent>();
+            resolver.GetType()
+                .GetField("definitions", System.Reflection.BindingFlags.NonPublic |
+                                         System.Reflection.BindingFlags.Instance)
+                ?.SetValue(resolver, new[] { potion });
+            var controller = playerGo.AddComponent<PotionUseController>();
+            controller.SetResolverSource(resolver);
+            controller.SetInventorySource(inventory);
+            controller.SetHealTargetSource(healable);
+
+            Assert.IsTrue(dash.TryStart(Vector2.up, Vector2.up, true));
+            Assert.IsFalse(controller.TryConsume());
+            Assert.That(inventory.State.PotionCount, Is.EqualTo(2));
+            Assert.That(healable.Healed, Is.Zero);
+
+            Object.DestroyImmediate(resolverGo);
+            Object.DestroyImmediate(playerGo);
+            Object.DestroyImmediate(potion);
+        }
     }
 }

--- a/Assets/_Project/_Tests/EditMode/Player/PlayerDashCombatIntegrationTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Player/PlayerDashCombatIntegrationTests.cs
@@ -1,0 +1,122 @@
+using Castlebound.Gameplay.Combat;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Castlebound.Tests.Player
+{
+    public class PlayerDashCombatIntegrationTests
+    {
+        private GameObject player;
+        private PlayerController controller;
+        private PlayerDashController dash;
+        private PlayerFireInputController fireInput;
+        private PlayerAttackLoop attackLoop;
+        private PlayerDefenseController defense;
+
+        [SetUp]
+        public void SetUp()
+        {
+            player = new GameObject("Player");
+            player.tag = "Player";
+            player.AddComponent<Animator>();
+            player.AddComponent<Rigidbody2D>();
+            player.AddComponent<CircleCollider2D>();
+            player.AddComponent<PlayerCollisionMove2D>();
+            dash = player.AddComponent<PlayerDashController>();
+            dash.Configure(20f, 0.5f, 0.6f, 1f, 0.4f, 0.9f);
+            fireInput = player.AddComponent<PlayerFireInputController>();
+            attackLoop = player.AddComponent<PlayerAttackLoop>();
+            defense = player.AddComponent<PlayerDefenseController>();
+            defense.Configure(0.15f, 0.15f, 120f, 0.6f);
+            controller = player.AddComponent<PlayerController>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(player);
+        }
+
+        [Test]
+        public void SuccessfulDash_CancelsActiveAttackAndClearsHeldFire()
+        {
+            fireInput.Configure(null, () => true);
+            fireInput.OnFirePressedStateChanged(true);
+            attackLoop.Tick(0.01f, 1f, true);
+            Assert.IsTrue(attackLoop.IsSwingActive);
+
+            Assert.IsTrue(controller.TryStartDash());
+
+            Assert.IsFalse(fireInput.IsFireHeld);
+            Assert.IsFalse(attackLoop.IsSwingActive);
+        }
+
+        [Test]
+        public void Dash_IsRejectedDuringGuardParryAndRecovery()
+        {
+            defense.SetDefensePressed(true);
+            Assert.That(defense.State, Is.EqualTo(PlayerDefenseState.ParryWindow));
+            Assert.IsFalse(controller.TryStartDash());
+
+            defense.Tick(0.2f);
+            Assert.That(defense.State, Is.EqualTo(PlayerDefenseState.Blocking));
+            Assert.IsFalse(controller.TryStartDash());
+
+            defense.SetDefensePressed(false);
+            Assert.That(defense.State, Is.EqualTo(PlayerDefenseState.Recovery));
+            Assert.IsFalse(controller.TryStartDash());
+        }
+
+        [Test]
+        public void DefenseAndRepeatedDash_AreRejectedWhileDashing()
+        {
+            Assert.IsTrue(controller.TryStartDash());
+
+            defense.SetDefensePressed(true);
+
+            Assert.That(defense.State, Is.EqualTo(PlayerDefenseState.Idle));
+            Assert.IsFalse(controller.TryStartDash());
+            Assert.IsTrue(dash.IsDashing);
+        }
+
+        [Test]
+        public void StopMovement_ClearsActiveDashWithoutLeavingVelocityState()
+        {
+            Assert.IsTrue(controller.TryStartDash());
+            Assert.IsTrue(dash.IsDashing);
+
+            controller.StopMovement();
+
+            Assert.IsFalse(dash.IsDashing);
+            Assert.IsFalse(dash.IsInvulnerable);
+            Assert.That(dash.CurrentVelocity, Is.EqualTo(Vector2.zero));
+        }
+
+        [Test]
+        public void Repair_IsRejectedWhileDashing()
+        {
+            var barrier = new GameObject("Barrier");
+            try
+            {
+                barrier.layer = 0;
+                barrier.transform.position = Vector2.right;
+                barrier.AddComponent<BoxCollider2D>();
+                var barrierHealth = barrier.AddComponent<BarrierHealth>();
+                barrierHealth.MaxHealth = 10;
+                barrierHealth.CurrentHealth = 6;
+                controller.RepairRange = 2f;
+                controller.RepairBarrierMask = 1 << 0;
+                Physics2D.SyncTransforms();
+
+                Assert.IsTrue(controller.TryStartDash());
+                Assert.IsFalse(controller.TryRepair());
+                Assert.That(barrierHealth.CurrentHealth, Is.EqualTo(6));
+                Assert.That(controller.RepairCooldownRemaining, Is.Zero);
+            }
+            finally
+            {
+                Object.DestroyImmediate(barrier);
+            }
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Player/PlayerDashCombatIntegrationTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Player/PlayerDashCombatIntegrationTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 60e2d6cf50bd4f8b917ecdc1b3dbb59f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/_Tests/EditMode/Player/PlayerDashControllerTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Player/PlayerDashControllerTests.cs
@@ -1,0 +1,213 @@
+using System.Linq;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Castlebound.Tests.Player
+{
+    public class PlayerDashControllerTests
+    {
+        private GameObject player;
+        private PlayerDashController dash;
+
+        [SetUp]
+        public void SetUp()
+        {
+            player = new GameObject("PlayerDashControllerTests");
+            dash = player.AddComponent<PlayerDashController>();
+            dash.Configure(
+                speed: 20f,
+                fullDuration: 0.5f,
+                rearMultiplier: 0.6f,
+                cooldownSeconds: 1f,
+                invulnerabilitySeconds: 0.4f,
+                mobileReleaseThreshold: 0.9f);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(player);
+        }
+
+        [Test]
+        public void TryStart_NormalizesCardinalAndDiagonalDirections()
+        {
+            Assert.IsTrue(dash.TryStart(new Vector2(4f, 0f), Vector2.up, true));
+            Assert.That(dash.Direction, Is.EqualTo(Vector2.right));
+            Assert.That(dash.CurrentVelocity.magnitude, Is.EqualTo(20f).Within(0.0001f));
+
+            dash.ResetState();
+            Assert.IsTrue(dash.TryStart(new Vector2(3f, 3f), Vector2.up, true));
+            Assert.That(dash.Direction.magnitude, Is.EqualTo(1f).Within(0.0001f));
+            Assert.That(dash.CurrentVelocity.magnitude, Is.EqualTo(20f).Within(0.0001f));
+        }
+
+        [Test]
+        public void ClassifyDirection_UsesBroadRearHemisphere()
+        {
+            Vector2 facing = Vector2.up;
+
+            Assert.That(PlayerDashController.ClassifyDirection(Vector2.up, facing), Is.EqualTo(PlayerDashDirection.Full));
+            Assert.That(PlayerDashController.ClassifyDirection(Vector2.right, facing), Is.EqualTo(PlayerDashDirection.Full));
+            Assert.That(PlayerDashController.ClassifyDirection(new Vector2(1f, 1f), facing), Is.EqualTo(PlayerDashDirection.Full));
+            Assert.That(PlayerDashController.ClassifyDirection(Vector2.down, facing), Is.EqualTo(PlayerDashDirection.Rear));
+            Assert.That(PlayerDashController.ClassifyDirection(new Vector2(1f, -0.01f), facing), Is.EqualTo(PlayerDashDirection.Rear));
+            Assert.That(PlayerDashController.ClassifyDirection(new Vector2(-1f, -1f), facing), Is.EqualTo(PlayerDashDirection.Rear));
+        }
+
+        [Test]
+        public void TryStart_WithNeutralInput_DodgesStraightBackFromFacing()
+        {
+            Assert.IsTrue(dash.TryStart(Vector2.zero, Vector2.right, true));
+
+            Assert.That(dash.Direction, Is.EqualTo(Vector2.left));
+            Assert.That(dash.DirectionClass, Is.EqualTo(PlayerDashDirection.Rear));
+            Assert.That(dash.ActiveDuration, Is.EqualTo(0.3f).Within(0.0001f));
+        }
+
+        [Test]
+        public void ForwardSideAndRear_UseSameSpeed_WhileRearEndsSooner()
+        {
+            Vector2[] fullDirections =
+            {
+                Vector2.up,
+                Vector2.left,
+                Vector2.right,
+                new Vector2(1f, 1f)
+            };
+
+            foreach (Vector2 direction in fullDirections)
+            {
+                dash.ResetState();
+                Assert.IsTrue(dash.TryStart(direction, Vector2.up, true));
+                Assert.That(dash.CurrentVelocity.magnitude, Is.EqualTo(20f).Within(0.0001f));
+                Assert.That(dash.ActiveDuration, Is.EqualTo(0.5f).Within(0.0001f));
+            }
+
+            dash.ResetState();
+            Assert.IsTrue(dash.TryStart(Vector2.down, Vector2.up, true));
+            Assert.That(dash.CurrentVelocity.magnitude, Is.EqualTo(20f).Within(0.0001f));
+            Assert.That(dash.ActiveDuration, Is.EqualTo(0.3f).Within(0.0001f));
+        }
+
+        [Test]
+        public void Distance_IsDerivedFromSpeedAndSelectedDuration()
+        {
+            Assert.That(dash.FullDashDistance, Is.EqualTo(10f).Within(0.0001f));
+            Assert.That(dash.RearDashDuration, Is.EqualTo(0.3f).Within(0.0001f));
+            Assert.That(dash.RearDashDistance, Is.EqualTo(6f).Within(0.0001f));
+
+            string[] fieldNames = typeof(PlayerDashController)
+                .GetFields(System.Reflection.BindingFlags.Instance |
+                           System.Reflection.BindingFlags.NonPublic |
+                           System.Reflection.BindingFlags.Public)
+                .Select(field => field.Name.ToLowerInvariant())
+                .ToArray();
+
+            Assert.That(fieldNames.Any(name => name.Contains("distance")), Is.False,
+                "Dash distance must remain derived rather than independently authored.");
+            Assert.That(fieldNames.Any(name => name.Contains("weight") || name.Contains("shove")), Is.False,
+                "Issue #263 must not introduce enemy displacement configuration.");
+        }
+
+        [Test]
+        public void DefaultRearMultiplier_IsPointSix()
+        {
+            var defaults = new GameObject("DefaultDash");
+            try
+            {
+                var defaultDash = defaults.AddComponent<PlayerDashController>();
+                Assert.That(defaultDash.RearDurationMultiplier, Is.EqualTo(0.6f).Within(0.0001f));
+            }
+            finally
+            {
+                Object.DestroyImmediate(defaults);
+            }
+        }
+
+        [Test]
+        public void Direction_IsSnapshotted_AndCannotBeSteered()
+        {
+            Assert.IsTrue(dash.TryStart(Vector2.right, Vector2.up, true));
+            Vector2 snapshot = dash.Direction;
+
+            dash.Tick(0.1f);
+
+            Assert.That(dash.Direction, Is.EqualTo(snapshot));
+            Assert.That(dash.CurrentVelocity, Is.EqualTo(Vector2.right * 20f));
+        }
+
+        [Test]
+        public void Lifecycle_StartsCooldown_RejectsChaining_AndDoesNotBuffer()
+        {
+            Assert.IsTrue(dash.TryStart(Vector2.up, Vector2.up, true));
+            Assert.IsTrue(dash.IsDashing);
+            Assert.IsFalse(dash.IsReady);
+            Assert.That(dash.CooldownRemaining, Is.EqualTo(1f).Within(0.0001f));
+
+            Assert.IsFalse(dash.TryStart(Vector2.left, Vector2.up, true));
+            dash.Tick(0.5f);
+            Assert.IsFalse(dash.IsDashing);
+            Assert.That(dash.Direction, Is.EqualTo(Vector2.zero));
+
+            dash.Tick(0.49f);
+            Assert.IsFalse(dash.IsReady);
+            dash.Tick(0.01f);
+            Assert.IsTrue(dash.IsReady);
+            Assert.IsFalse(dash.IsDashing, "Rejected dash input must not be buffered.");
+        }
+
+        [Test]
+        public void RejectedState_DoesNotStartDashCooldownOrInvulnerability()
+        {
+            Assert.IsFalse(dash.TryStart(Vector2.up, Vector2.up, false));
+
+            Assert.IsFalse(dash.IsDashing);
+            Assert.IsFalse(dash.IsInvulnerable);
+            Assert.IsTrue(dash.IsReady);
+        }
+
+        [Test]
+        public void InvulnerabilityTimer_IsIndependent_AndCanOutlastRearMovement()
+        {
+            Assert.IsTrue(dash.TryStart(Vector2.down, Vector2.up, true));
+
+            dash.Tick(0.3f);
+
+            Assert.IsFalse(dash.IsDashing);
+            Assert.IsTrue(dash.IsInvulnerable);
+            Assert.That(dash.InvulnerabilityRemaining, Is.EqualTo(0.1f).Within(0.0001f));
+
+            dash.Tick(0.1f);
+            Assert.IsFalse(dash.IsInvulnerable);
+        }
+
+        [Test]
+        public void Health_RejectsDamageOnlyDuringConfiguredDashInvulnerability()
+        {
+            var health = player.AddComponent<Health>();
+            health.ConfigureMaxHealth(10, refill: true);
+            Assert.IsTrue(dash.TryStart(Vector2.down, Vector2.up, true));
+
+            Assert.That(health.ApplyDamage(3), Is.Zero);
+            Assert.That(health.Current, Is.EqualTo(10));
+
+            dash.Tick(0.4f);
+            Assert.That(health.ApplyDamage(3), Is.EqualTo(3));
+            Assert.That(health.Current, Is.EqualTo(7));
+        }
+
+        [Test]
+        public void MobileReleasePolicy_EvaluatesOnlyCurrentReleaseSample()
+        {
+            Assert.IsTrue(dash.TryResolveMobileRelease(new Vector2(0.9f, 0.9f), out Vector2 outer));
+            Assert.That(outer.magnitude, Is.EqualTo(1f).Within(0.0001f));
+
+            Assert.IsFalse(dash.TryResolveMobileRelease(new Vector2(0.89f, 0f), out Vector2 inward));
+            Assert.That(inward, Is.EqualTo(Vector2.zero));
+
+            Assert.IsFalse(dash.TryResolveMobileRelease(Vector2.zero, out _),
+                "An earlier outer throw must not arm a later inward release.");
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Player/PlayerDashControllerTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Player/PlayerDashControllerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d63b525b875c4d96a505bded1334c100
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/_Tests/PlayMode/Player.meta
+++ b/Assets/_Project/_Tests/PlayMode/Player.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fa7399823ab041e489f4bccf0407c289
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/_Tests/PlayMode/Player/PlayerDashPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/Player/PlayerDashPlayTests.cs
@@ -1,0 +1,411 @@
+using System.Collections;
+using System.Reflection;
+using Castlebound.Gameplay.Combat;
+using Castlebound.Gameplay.Input;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.InputSystem;
+using UnityEngine.TestTools;
+
+namespace Castlebound.Tests.PlayMode.Player
+{
+    public class PlayerDashPlayTests
+    {
+        [UnityTest]
+        public IEnumerator DesktopAndGamepadDashBindings_ResolveRequiredRuntimeControls()
+        {
+            var keyboard = InputSystem.AddDevice<Keyboard>();
+            var gamepad = InputSystem.AddDevice<Gamepad>();
+            var controls = new PlayerControls();
+
+            try
+            {
+                yield return null;
+                Assert.That(controls.Player.Dash.controls,
+                    Has.Some.Matches<InputControl>(control =>
+                        control.device == keyboard && control.path.EndsWith("/leftCtrl")));
+                Assert.That(controls.Player.Dash.controls,
+                    Has.Some.Matches<InputControl>(control =>
+                        control.device == gamepad && control.path.EndsWith("/leftStickPress")));
+                Assert.That(controls.Player.Move.controls,
+                    Has.Some.Matches<InputControl>(control =>
+                        control.device == keyboard && control.path.EndsWith("/w")));
+                Assert.That(controls.Player.Move.controls,
+                    Has.Some.Matches<InputControl>(control =>
+                        control.device == gamepad && control.path.EndsWith("/leftStick")));
+            }
+            finally
+            {
+                controls.Dispose();
+                InputSystem.RemoveDevice(keyboard);
+                InputSystem.RemoveDevice(gamepad);
+            }
+
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator ForwardAndRear_UseSameSpeed_WhileRearEndsSoonerAndTravelsLess()
+        {
+            GameObject forward = CreatePlayer(Vector2.zero, 0, out PlayerController forwardController,
+                out PlayerDashController forwardDash);
+            GameObject rear = CreatePlayer(new Vector2(5f, 0f), 0, out PlayerController rearController,
+                out PlayerDashController rearDash);
+
+            try
+            {
+                SetMovementInput(forwardController, Vector2.up);
+                SetMovementInput(rearController, Vector2.down);
+                Vector2 forwardStart = forward.transform.position;
+                Vector2 rearStart = rear.transform.position;
+
+                Assert.IsTrue(forwardController.TryStartDash());
+                Assert.IsTrue(rearController.TryStartDash());
+
+                yield return new WaitForFixedUpdate();
+                Vector2 forwardSampleStart = forward.transform.position;
+                Vector2 rearSampleStart = rear.transform.position;
+                yield return new WaitForFixedUpdate();
+
+                float forwardStep = Vector2.Distance(forward.transform.position, forwardSampleStart);
+                float rearStep = Vector2.Distance(rear.transform.position, rearSampleStart);
+                Assert.That(forwardStep, Is.EqualTo(rearStep).Within(0.001f));
+
+                float forwardDistance = -1f;
+                float rearDistance = -1f;
+                while (forwardDash.IsDashing || rearDash.IsDashing)
+                {
+                    yield return new WaitForFixedUpdate();
+                    if (!forwardDash.IsDashing && forwardDistance < 0f)
+                        forwardDistance = Vector2.Distance(forward.transform.position, forwardStart);
+                    if (!rearDash.IsDashing && rearDistance < 0f)
+                        rearDistance = Vector2.Distance(rear.transform.position, rearStart);
+                }
+
+                if (forwardDistance < 0f)
+                    forwardDistance = Vector2.Distance(forward.transform.position, forwardStart);
+                if (rearDistance < 0f)
+                    rearDistance = Vector2.Distance(rear.transform.position, rearStart);
+                Assert.That(forwardDistance, Is.EqualTo(forwardDash.FullDashDistance).Within(0.25f));
+                Assert.That(rearDistance, Is.EqualTo(rearDash.RearDashDistance).Within(0.25f));
+                Assert.That(rearDistance / forwardDistance, Is.EqualTo(0.6f).Within(0.08f));
+            }
+            finally
+            {
+                Object.Destroy(forward);
+                Object.Destroy(rear);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator Dash_SnapshotsDirection_DoesNotSteerOrRotateFacing()
+        {
+            GameObject player = CreatePlayer(Vector2.zero, 0, out PlayerController controller,
+                out PlayerDashController dash);
+            try
+            {
+                SetMovementInput(controller, Vector2.down);
+                Quaternion startingRotation = player.transform.rotation;
+                Assert.IsTrue(controller.TryStartDash());
+                Vector2 snapshot = dash.Direction;
+
+                SetMovementInput(controller, Vector2.right);
+                yield return new WaitForFixedUpdate();
+                yield return new WaitForFixedUpdate();
+
+                Assert.That(dash.Direction, Is.EqualTo(snapshot));
+                Assert.That(player.transform.position.x, Is.EqualTo(0f).Within(0.001f));
+                Assert.That(player.transform.rotation, Is.EqualTo(startingRotation));
+                Assert.That(controller.CurrentFacingDirection, Is.EqualTo(Vector2.up));
+            }
+            finally
+            {
+                Object.Destroy(player);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator BlockedDash_ContinuesTimer_SlidesAndRecoversNormalMovement()
+        {
+            int wallsMask = 1 << LayerMask.NameToLayer("Walls");
+            GameObject player = CreatePlayer(Vector2.zero, wallsMask, out PlayerController controller,
+                out PlayerDashController dash);
+            GameObject wall = new GameObject("Wall");
+            wall.layer = LayerMask.NameToLayer("Walls");
+            wall.transform.position = new Vector2(0.75f, 0f);
+            wall.AddComponent<BoxCollider2D>().size = new Vector2(0.5f, 4f);
+
+            try
+            {
+                SetMovementInput(controller, new Vector2(1f, 1f));
+                Assert.IsTrue(controller.TryStartDash());
+
+                yield return new WaitForFixedUpdate();
+                yield return new WaitForFixedUpdate();
+                yield return new WaitForFixedUpdate();
+
+                Assert.IsTrue(dash.IsDashing, "Collision must not cancel the active dash state.");
+                Assert.That(player.transform.position.x, Is.LessThanOrEqualTo(0.27f));
+                Assert.That(player.transform.position.y, Is.GreaterThan(0.1f),
+                    "The unblocked axis should retain the mover's existing sliding behavior.");
+
+                while (dash.IsDashing)
+                    yield return new WaitForFixedUpdate();
+                float blockedX = player.transform.position.x;
+                SetMovementInput(controller, Vector2.left);
+                yield return new WaitForFixedUpdate();
+                yield return new WaitForFixedUpdate();
+
+                Assert.IsFalse(dash.IsDashing);
+                Assert.That(player.transform.position.x, Is.LessThan(blockedX - 0.01f),
+                    "Normal movement should resume without stale dash velocity.");
+            }
+            finally
+            {
+                Object.Destroy(wall);
+                Object.Destroy(player);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator WallBarrierAndVault_AllClampWithoutCancellingDashState()
+        {
+            int wallsLayer = LayerMask.NameToLayer("Walls");
+            int environmentLayer = LayerMask.NameToLayer("Environment");
+            int solidMask = (1 << wallsLayer) | (1 << environmentLayer);
+            string[] names = { "Wall", "Barrier", "Vault" };
+            int[] layers = { wallsLayer, wallsLayer, environmentLayer };
+            var players = new GameObject[names.Length];
+            var blockers = new GameObject[names.Length];
+            var dashes = new PlayerDashController[names.Length];
+
+            try
+            {
+                for (int i = 0; i < names.Length; i++)
+                {
+                    float y = i * 2f;
+                    players[i] = CreatePlayer(new Vector2(0f, y), solidMask,
+                        out PlayerController controller, out dashes[i]);
+                    blockers[i] = new GameObject(names[i]);
+                    blockers[i].layer = layers[i];
+                    blockers[i].transform.position = new Vector2(0.75f, y);
+                    blockers[i].AddComponent<BoxCollider2D>().size = Vector2.one * 0.5f;
+                    SetMovementInput(controller, Vector2.right);
+                    Assert.IsTrue(controller.TryStartDash());
+                }
+
+                yield return new WaitForFixedUpdate();
+                yield return new WaitForFixedUpdate();
+                yield return new WaitForFixedUpdate();
+
+                for (int i = 0; i < names.Length; i++)
+                {
+                    Assert.IsTrue(dashes[i].IsDashing, $"{names[i]} collision cancelled dash state.");
+                    Assert.That(players[i].transform.position.x, Is.LessThanOrEqualTo(0.27f),
+                        $"Dash passed through representative {names[i]} geometry.");
+                }
+
+                while (dashes[0].IsDashing)
+                    yield return new WaitForFixedUpdate();
+
+                for (int i = 0; i < names.Length; i++)
+                    Assert.IsFalse(dashes[i].IsDashing);
+            }
+            finally
+            {
+                for (int i = 0; i < names.Length; i++)
+                {
+                    if (blockers[i] != null)
+                        Object.Destroy(blockers[i]);
+                    if (players[i] != null)
+                        Object.Destroy(players[i]);
+                }
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator RearMovementCanFinishBeforeDamageInvulnerabilityExpires()
+        {
+            GameObject player = CreatePlayer(Vector2.zero, 0, out PlayerController controller,
+                out PlayerDashController dash);
+            Health health = player.GetComponent<Health>();
+            try
+            {
+                SetMovementInput(controller, Vector2.down);
+                Assert.IsTrue(controller.TryStartDash());
+
+                while (dash.IsDashing)
+                    yield return new WaitForFixedUpdate();
+
+                Assert.IsTrue(dash.IsInvulnerable);
+                Assert.That(health.ApplyDamage(3), Is.Zero);
+
+                while (dash.IsInvulnerable)
+                    yield return new WaitForFixedUpdate();
+
+                Assert.That(health.ApplyDamage(3), Is.EqualTo(3));
+            }
+            finally
+            {
+                Object.Destroy(player);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator ActiveAttackIsCancelled_AndDefenseIsRejectedDuringDash()
+        {
+            GameObject player = CreatePlayer(Vector2.zero, 0, out PlayerController controller,
+                out PlayerDashController dash);
+            var fire = player.GetComponent<PlayerFireInputController>();
+            var attack = player.GetComponent<PlayerAttackLoop>();
+            var defense = player.GetComponent<PlayerDefenseController>();
+            try
+            {
+                fire.Configure(null, () => true);
+                fire.OnFirePressedStateChanged(true);
+                attack.Tick(0.01f, 1f, true);
+
+                Assert.IsTrue(controller.TryStartDash());
+                defense.SetDefensePressed(true);
+                yield return new WaitForFixedUpdate();
+
+                Assert.IsFalse(fire.IsFireHeld);
+                Assert.IsFalse(attack.IsSwingActive);
+                Assert.That(defense.State, Is.EqualTo(PlayerDefenseState.Idle));
+                Assert.IsTrue(dash.IsDashing);
+            }
+            finally
+            {
+                Object.Destroy(player);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator MobileRelease_UsesVirtualGamepadDashActionAndCurrentReleaseDirection()
+        {
+            var inputRoot = new GameObject("MobileDashInput");
+            inputRoot.SetActive(false);
+            var movementZone = inputRoot.AddComponent<TouchMovementZone>();
+            var driver = inputRoot.AddComponent<MobileInputDriver>();
+            var dashRoot = new GameObject("DashOwner");
+            var dash = dashRoot.AddComponent<PlayerDashController>();
+            dash.Configure(20f, 0.5f, 0.6f, 1f, 0.4f, 0.9f);
+            SetField(driver, "movementZone", movementZone);
+            SetField(driver, "dashController", dash);
+            SetField(driver, "enableInEditor", true);
+
+            var controls = new PlayerControls();
+            bool dashPerformed = false;
+            Vector2 performedDirection = Vector2.zero;
+            controls.Player.Dash.performed += _ =>
+            {
+                dashPerformed = true;
+                performedDirection = controls.Player.Move.ReadValue<Vector2>();
+            };
+            controls.Player.Enable();
+
+            try
+            {
+                inputRoot.SetActive(true);
+                movementZone.MaxRadius = 100f;
+                movementZone.SimulatePointerDown(Vector2.zero);
+                movementZone.SimulateDrag(new Vector2(95f, 0f));
+                movementZone.SimulatePointerUp();
+
+                yield return null;
+                yield return null;
+
+                Assert.IsTrue(dashPerformed);
+                Assert.That(performedDirection.x, Is.GreaterThanOrEqualTo(0.9f));
+
+                dashPerformed = false;
+                movementZone.SimulatePointerDown(Vector2.zero);
+                movementZone.SimulateDrag(new Vector2(100f, 0f));
+                movementZone.SimulateDrag(new Vector2(40f, 0f));
+                movementZone.SimulatePointerUp();
+                yield return null;
+                yield return null;
+
+                Assert.IsFalse(dashPerformed,
+                    "Returning below the threshold before release must not retain historical arming.");
+            }
+            finally
+            {
+                controls.Dispose();
+                Object.Destroy(inputRoot);
+                Object.Destroy(dashRoot);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator DashDealsNoDamage_AndDoesNotAddEnemyDisplacementBehavior()
+        {
+            int enemiesMask = 1 << LayerMask.NameToLayer("Enemies");
+            GameObject player = CreatePlayer(Vector2.zero, enemiesMask, out PlayerController controller,
+                out PlayerDashController dash);
+            GameObject enemy = new GameObject("Enemy");
+            enemy.tag = "Enemy";
+            enemy.layer = LayerMask.NameToLayer("Enemies");
+            enemy.transform.position = new Vector2(0f, 0.8f);
+            enemy.AddComponent<BoxCollider2D>().size = Vector2.one * 0.5f;
+            Health enemyHealth = enemy.AddComponent<Health>();
+            enemyHealth.ConfigureMaxHealth(10, refill: true);
+            Vector2 enemyStart = enemy.transform.position;
+
+            try
+            {
+                SetMovementInput(controller, Vector2.up);
+                Assert.IsTrue(controller.TryStartDash());
+                while (dash.IsDashing)
+                    yield return new WaitForFixedUpdate();
+
+                Assert.That(enemyHealth.Current, Is.EqualTo(10));
+                Assert.That((Vector2)enemy.transform.position, Is.EqualTo(enemyStart));
+            }
+            finally
+            {
+                Object.Destroy(enemy);
+                Object.Destroy(player);
+            }
+        }
+
+        private static GameObject CreatePlayer(
+            Vector2 position,
+            int solidMask,
+            out PlayerController controller,
+            out PlayerDashController dash)
+        {
+            var player = new GameObject("Player");
+            player.tag = "Player";
+            player.layer = LayerMask.NameToLayer("Player");
+            player.transform.position = position;
+            var body = player.AddComponent<Rigidbody2D>();
+            body.gravityScale = 0f;
+            player.AddComponent<BoxCollider2D>().size = Vector2.one * 0.5f;
+            var mover = player.AddComponent<PlayerCollisionMove2D>();
+            SetField(mover, "solidMask", (LayerMask)solidMask);
+            dash = player.AddComponent<PlayerDashController>();
+            dash.Configure(10f, 0.2f, 0.6f, 0.4f, 0.25f, 0.9f);
+            player.AddComponent<PlayerFireInputController>();
+            player.AddComponent<PlayerAttackLoop>();
+            player.AddComponent<PlayerDefenseController>().Configure(0.15f, 0.15f, 120f, 0.6f);
+            controller = player.AddComponent<PlayerController>();
+            player.GetComponent<Health>().ConfigureMaxHealth(10, refill: true);
+            return player;
+        }
+
+        private static void SetMovementInput(PlayerController controller, Vector2 value)
+        {
+            SetField(controller, "movementInput", value);
+        }
+
+        private static void SetField(object instance, string fieldName, object value)
+        {
+            FieldInfo field = instance.GetType().GetField(
+                fieldName,
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(field, $"Expected field {fieldName} on {instance.GetType().Name}.");
+            field.SetValue(instance, value);
+        }
+    }
+}

--- a/Assets/_Project/_Tests/PlayMode/Player/PlayerDashPlayTests.cs.meta
+++ b/Assets/_Project/_Tests/PlayMode/Player/PlayerDashPlayTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6a4b398bd7914c2f8144846d7405857d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/_Tests/PlayMode/_Project.Tests.PlayMode.asmdef
+++ b/Assets/_Project/_Tests/PlayMode/_Project.Tests.PlayMode.asmdef
@@ -5,6 +5,7 @@
     "_Project.Core",
     "_Project.Gameplay",
     "Unity.TextMeshPro",
+    "Unity.InputSystem",
     "GUID:476f7c6c6dfeed041b063446a926e656"
   ],
   "includePlatforms": [],

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,23 @@
 
 ---
 
+## 2026-08-10 - feat-player-directional-combat-dash
+
+### Summary
+- Added a focused directional dash owner with normalized snapshot direction, broad rear-hemisphere duration reduction, cooldown, and independently timed invulnerability.
+- Routed desktop, gamepad, and mobile release input through the shared Dash action while preserving movement, facing, defense, attack-reset, and collision ownership.
+- Integrated collision-clamped dash velocity and action restrictions without adding enemy displacement, progression, floating-control presentation, or general collider redesign.
+
+### New or Updated Tests
+**EditMode**
+- PlayerDashControllerTests, PlayerDashCombatIntegrationTests, DashInputContractsTests, TouchMovementZoneTests, and PotionUseControllerTests — direction, speed/duration/distance, lifecycle, i-frames, combat restrictions, generated input, mobile release semantics, prefab tuning, repair, potion, and damage regression coverage.
+
+**PlayMode**
+- PlayerDashPlayTests — desktop/gamepad bindings, full/rear movement, facing independence, no steering, Wall/Barrier/Vault clamping and recovery, independent i-frames, combat cancellation, mobile virtual-gamepad release, and zero enemy damage/displacement.
+
+### Notes
+- Full isolated-project suites pass: EditMode 950/950 and PlayMode 88/88; MainPrototype manual validation was not run because Windows app control could not access the existing Unity editor session.
+
 ## 2026-07-29 - feat-60-pixel-perfect-camera
 
 ### Summary


### PR DESCRIPTION
## Why
Player combat needs a reliable active repositioning and dodge option across desktop, gamepad, and Android touch controls without taking ownership from movement, facing, defense, or existing combat-state systems.

## What changed
- Added a focused `PlayerDashController` that owns normalized snapshotted direction, shared directional speed, full/rear duration, cooldown, mobile threshold, and independently timed i-frames
- Added full-duration directional dashes and a neutral backward dodge, with broad rear-hemisphere movement using the issue-defined `0.60` duration multiplier at the same speed
- Added Left Ctrl and L3 bindings, plus movement-stick release dashes through the existing mobile virtual-gamepad/Input System path
- Reused existing attack reset, defense state, repair, potion, and health/damage contracts to enforce dash restrictions and invulnerability
- Routed dash velocity through collision-aware player movement while leaving facing execution independent
- Wired the player prefab/input asset and added focused EditMode and PlayMode regression coverage

## How to test
1. Open MainPrototype and validate directional WASD + Left Ctrl dashes, including neutral straight-back dodge
2. Validate gamepad L3 directional and neutral straight-back dodge behavior
3. Validate a qualifying mobile movement-stick release and pull-back-inside-threshold cancellation
4. Compare forward/lateral and rear timing/distance, confirming equal speed and unchanged facing
5. Dash into representative Wall, Barrier, and Vault geometry; confirm collision clamping, supported sliding, continued dash state, and clean post-dash movement recovery
6. Validate attack/defense/action restrictions and independently timed i-frames, including i-frames outlasting rear movement
7. Run tests:
   - EditMode — 950/950 passed locally
   - PlayMode — 88/88 passed locally
   - GitHub CI — EditMode, PlayMode, and Android Debug Build passed

Hands-on MainPrototype validation was completed successfully and the directional combat dash behavior feels correct.

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode coverage added or updated
- [x] MainPrototype/manual validation completed
- [x] Demo scene updated (N/A - existing MainPrototype consumes the updated player prefab)
- [x] Prefab/input links, tags, and layers validated through automated contract coverage
- [x] README / Docs touched (TEST_LOG.md updated)

## Related
- Closes #263
- Refs #276 for the intentionally deferred general collider/sticking scope
- Refs #287 for the deferred floating-mobile-control presentation scope