### PR TITLE
feat(input): add unified PC relative-mouse and UI pointer modes

### DIFF
--- a/.github/workflows/windows-debug.yml
+++ b/.github/workflows/windows-debug.yml
@@ -1,0 +1,81 @@
+name: Windows PC Build
+
+on:
+  pull_request:
+    types: [synchronize, reopened, labeled]
+    branches: [ main ]
+
+concurrency:
+  group: windows-pc-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-windows:
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(github.event.pull_request.labels.*.name, 'pc-build')
+    runs-on: self-hosted
+
+    steps:
+      - name: Pre-clean workspace
+        shell: pwsh
+        run: |
+          Get-Process Unity, UnityHub, UnityPackageManager, UnityCrashHandler64 -ErrorAction SilentlyContinue |
+            Stop-Process -Force -ErrorAction SilentlyContinue
+          Start-Sleep -Seconds 2
+          if (Test-Path "$env:GITHUB_WORKSPACE") {
+            Get-ChildItem -Force "$env:GITHUB_WORKSPACE" | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+          }
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          clean: false
+          fetch-depth: 0
+
+      - name: Ensure project not locked
+        shell: pwsh
+        run: |
+          Get-Process Unity, UnityHub, UnityPackageManager, UnityCrashHandler64 -ErrorAction SilentlyContinue | `
+            Stop-Process -Force -ErrorAction SilentlyContinue
+          if (Test-Path "$env:GITHUB_WORKSPACE\Temp\UnityLockfile") {
+            Remove-Item -Force "$env:GITHUB_WORKSPACE\Temp\UnityLockfile"
+          }
+
+      - name: Cache Library
+        uses: actions/cache@v4
+        with:
+          path: Library
+          key: windows-library-v1-${{ runner.os }}-${{ hashFiles('Packages/manifest.json','ProjectSettings/ProjectVersion.txt') }}
+          restore-keys: |
+            windows-library-v1-${{ runner.os }}-
+
+      - name: Build Windows player
+        shell: pwsh
+        run: .\ci\run-windows-build.ps1
+
+      - name: Upload Windows build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-pc-build
+          path: build/Windows/Castlebound/
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload build log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: WindowsBuildLog
+          path: build/WindowsBuildLog.txt
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Clean up build folder
+        if: always()
+        shell: pwsh
+        run: |
+          if (Test-Path build) {
+            Remove-Item -Recurse -Force build -ErrorAction SilentlyContinue
+          }

--- a/Assets/Editor/CI/WindowsCiBuildRunner.cs
+++ b/Assets/Editor/CI/WindowsCiBuildRunner.cs
@@ -1,0 +1,53 @@
+using System;
+using System.IO;
+using System.Linq;
+using UnityEditor;
+using UnityEditor.Build.Reporting;
+using UnityEngine;
+
+namespace CI
+{
+    public static class WindowsCiBuildRunner
+    {
+        [MenuItem("CI/Build Windows Player (CI)")]
+        public static void Run()
+        {
+            var outputDirectory = Environment.GetEnvironmentVariable("CB_WINDOWS_BUILD_DIR");
+            if (string.IsNullOrWhiteSpace(outputDirectory))
+                outputDirectory = "build/Windows/Castlebound";
+
+            outputDirectory = outputDirectory.Replace('\\', '/');
+            Directory.CreateDirectory(outputDirectory);
+            var executablePath = Path.Combine(outputDirectory, "Castlebound.exe").Replace('\\', '/');
+
+            var scenes = EditorBuildSettings.scenes
+                .Where(scene => scene.enabled)
+                .Select(scene => scene.path)
+                .ToArray();
+
+            if (scenes.Length == 0)
+            {
+                Debug.LogError("[CI][Windows] No enabled scenes found in Build Settings.");
+                EditorApplication.Exit(1);
+                return;
+            }
+
+            var options = new BuildPlayerOptions
+            {
+                scenes = scenes,
+                locationPathName = executablePath,
+                target = BuildTarget.StandaloneWindows64,
+                options = BuildOptions.Development
+            };
+
+            Debug.Log($"[CI][Windows] Building player to: {executablePath}");
+            var report = BuildPipeline.BuildPlayer(options);
+            var summary = report.summary;
+
+            Debug.Log($"[CI][Windows] Build result: {summary.result}, size: {summary.totalSize} bytes");
+            Debug.Log($"[CI][Windows] Build output path: {summary.outputPath}");
+
+            EditorApplication.Exit(summary.result == BuildResult.Succeeded ? 0 : 1);
+        }
+    }
+}

--- a/Assets/Editor/CI/WindowsCiBuildRunner.cs.meta
+++ b/Assets/Editor/CI/WindowsCiBuildRunner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1a0f7946afe34e40b38b4ee7850a21ad
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Prefabs/Player.prefab
+++ b/Assets/_Project/Prefabs/Player.prefab
@@ -129,6 +129,8 @@ GameObject:
   - component: {fileID: 9150000000000000701}
   - component: {fileID: 9150000000000000702}
   - component: {fileID: 9150000000000000801}
+  - component: {fileID: 9150000000000000901}
+  - component: {fileID: 9150000000000000902}
   m_Layer: 3
   m_Name: Player
   m_TagString: Player
@@ -858,3 +860,30 @@ MonoBehaviour:
   cooldown: 0.75
   invulnerabilityDuration: 0.25
   mobileOuterReleaseThreshold: 0.9
+--- !u!114 &9150000000000000901
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8325390509751579795}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4dd2b47425644f43a31bcf8076456d11, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  mouseTurnSensitivity: 0.35
+--- !u!114 &9150000000000000902
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8325390509751579795}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 32996fe5861b4ee586ad21e190176bf9, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  relativeMouseFacing: {fileID: 9150000000000000901}
+  playerController: {fileID: 4369444282720785943}

--- a/Assets/_Project/Scenes/MainPrototype.unity
+++ b/Assets/_Project/Scenes/MainPrototype.unity
@@ -1547,8 +1547,6 @@ MonoBehaviour:
   menuRoot: {fileID: 774867745}
   autoOpenEveryPreWave: 1
   waveRunner: {fileID: 1166075763}
-  pausePlayerWhileOpen: 1
-  playerController: {fileID: 0}
 --- !u!114 &676673188
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PcControlModeController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PcControlModeController.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Castlebound.Gameplay.Input;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.InputSystem;
@@ -9,15 +10,19 @@ public class PcControlModeController : MonoBehaviour
     [SerializeField] private PlayerController playerController;
 
     private readonly HashSet<Object> pointerModeOwners = new HashSet<Object>();
+    private readonly List<RaycastResult> uiRaycastResults = new List<RaycastResult>();
     private bool inputLocked;
     private bool suppressCombatUntilMouseReleased;
     private bool pcMouseControlActive = true;
+    private EventSystem cachedEventSystem;
+    private PointerEventData pointerEventData;
 
     public CursorLockMode RequestedLockMode { get; private set; } = CursorLockMode.None;
     public bool RequestedCursorVisible { get; private set; } = true;
     public bool IsPointerModeActive => inputLocked || pointerModeOwners.Count > 0;
     public bool IsPcMouseControlActive => !Application.isMobilePlatform && Mouse.current != null && pcMouseControlActive;
-    public bool IsPointerOverUi => IsPointerModeActive && EventSystem.current != null && EventSystem.current.IsPointerOverGameObject();
+    public bool IsPointerOverUi => IsPointerModeActive && IsPointerOverDesktopUi();
+    public bool ShouldSnapFacingPresentation => IsPcMouseControlActive && !IsPointerModeActive;
 
     private void Awake()
     {
@@ -54,6 +59,8 @@ public class PcControlModeController : MonoBehaviour
         {
             SetActiveInputDevice(false);
         }
+
+        RefreshTransitionSuppression();
     }
 
     private void OnDisable()
@@ -73,8 +80,11 @@ public class PcControlModeController : MonoBehaviour
 
     public void SetInputLocked(bool locked)
     {
+        if (inputLocked == locked)
+            return;
+
         inputLocked = locked;
-        BeginTransition();
+        BeginControlModeTransition();
     }
 
     public void RefreshCursorState()
@@ -84,24 +94,21 @@ public class PcControlModeController : MonoBehaviour
 
     public void RequestPointerMode(Object owner)
     {
-        if (owner != null && pointerModeOwners.Add(owner)) BeginTransition();
+        if (owner != null && pointerModeOwners.Add(owner)) BeginControlModeTransition();
     }
 
     public void ReleasePointerMode(Object owner)
     {
-        if (owner != null && pointerModeOwners.Remove(owner)) BeginTransition();
+        if (owner != null && pointerModeOwners.Remove(owner)) BeginControlModeTransition();
     }
 
     public bool ShouldSuppressCombatInput()
     {
-        if (!IsPcMouseControlActive) return false;
-        if (suppressCombatUntilMouseReleased)
-        {
-            bool released = Mouse.current == null || (!Mouse.current.leftButton.isPressed && !Mouse.current.rightButton.isPressed);
-            if (!released) return true;
-            suppressCombatUntilMouseReleased = false;
-        }
-        return IsPointerOverUi;
+        if (!IsPcMouseControlActive)
+            return false;
+
+        RefreshTransitionSuppression();
+        return suppressCombatUntilMouseReleased || IsPointerOverUi;
     }
 
     public void NotifyMouseCombatInput()
@@ -174,7 +181,7 @@ public class PcControlModeController : MonoBehaviour
             return;
 
         pcMouseControlActive = mouseAndKeyboard;
-        BeginTransition();
+        SynchronizeFacingAndCursor();
     }
 
     private static bool IsAnyGamepadActive()
@@ -195,17 +202,76 @@ public class PcControlModeController : MonoBehaviour
         return false;
     }
 
-    private void BeginTransition()
+    private void BeginControlModeTransition()
+    {
+        suppressCombatUntilMouseReleased = true;
+        ResolveReferences();
+        SynchronizeFacingAndCursor();
+        playerController?.ClearCombatInputState();
+    }
+
+    private void SynchronizeFacingAndCursor()
+    {
+        ResolveReferences();
+        relativeMouseFacing?.SynchronizeFacing(playerController != null ? playerController.CurrentFacingDirection : Vector2.up);
+        RefreshCursorState();
+    }
+
+    private void RefreshTransitionSuppression()
+    {
+        if (!suppressCombatUntilMouseReleased)
+            return;
+
+        bool mouseReleased = Mouse.current == null ||
+            (!Mouse.current.leftButton.isPressed && !Mouse.current.rightButton.isPressed);
+        if (mouseReleased)
+            suppressCombatUntilMouseReleased = false;
+    }
+
+    private void ResolveReferences()
     {
         if (relativeMouseFacing == null)
             relativeMouseFacing = GetComponent<PlayerRelativeMouseFacingController>();
         if (playerController == null)
             playerController = GetComponent<PlayerController>();
+    }
 
-        suppressCombatUntilMouseReleased = true;
-        relativeMouseFacing?.SynchronizeFacing(playerController != null ? playerController.CurrentFacingDirection : Vector2.up);
-        playerController?.ClearCombatInputState();
-        RefreshCursorState();
+    private bool IsPointerOverDesktopUi()
+    {
+        EventSystem eventSystem = EventSystem.current;
+        if (eventSystem == null)
+            return false;
+
+        if (cachedEventSystem != eventSystem || pointerEventData == null)
+        {
+            cachedEventSystem = eventSystem;
+            pointerEventData = new PointerEventData(eventSystem);
+        }
+
+        pointerEventData.position = Mouse.current != null ? Mouse.current.position.ReadValue() : Vector2.zero;
+        uiRaycastResults.Clear();
+        eventSystem.RaycastAll(pointerEventData, uiRaycastResults);
+        if (uiRaycastResults.Count == 0)
+            return eventSystem.IsPointerOverGameObject();
+
+        foreach (RaycastResult result in uiRaycastResults)
+        {
+            if (!IsDesktopTouchSurface(result.gameObject))
+                return true;
+        }
+
+        return false;
+    }
+
+    public static bool IsDesktopTouchSurface(GameObject target)
+    {
+        if (target == null)
+            return false;
+
+        return target.GetComponentInParent<TouchMovementZone>() != null ||
+            target.GetComponentInParent<TouchAimAttackZone>() != null ||
+            target.GetComponentInParent<TouchDefenseAimButton>() != null ||
+            target.GetComponentInParent<TouchRepairButton>() != null;
     }
 
     private void ApplyCursorState(bool pointerModeActive)

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PcControlModeController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PcControlModeController.cs
@@ -1,0 +1,218 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.InputSystem;
+
+public class PcControlModeController : MonoBehaviour
+{
+    [SerializeField] private PlayerRelativeMouseFacingController relativeMouseFacing;
+    [SerializeField] private PlayerController playerController;
+
+    private readonly HashSet<Object> pointerModeOwners = new HashSet<Object>();
+    private bool inputLocked;
+    private bool suppressCombatUntilMouseReleased;
+    private bool pcMouseControlActive = true;
+
+    public CursorLockMode RequestedLockMode { get; private set; } = CursorLockMode.None;
+    public bool RequestedCursorVisible { get; private set; } = true;
+    public bool IsPointerModeActive => inputLocked || pointerModeOwners.Count > 0;
+    public bool IsPcMouseControlActive => !Application.isMobilePlatform && Mouse.current != null && pcMouseControlActive;
+    public bool IsPointerOverUi => IsPointerModeActive && EventSystem.current != null && EventSystem.current.IsPointerOverGameObject();
+
+    private void Awake()
+    {
+        if (relativeMouseFacing == null)
+            relativeMouseFacing = GetComponent<PlayerRelativeMouseFacingController>();
+        if (playerController == null)
+            playerController = GetComponent<PlayerController>();
+    }
+
+    private void Start()
+    {
+        RefreshCursorState();
+    }
+
+    private void Update()
+    {
+        if (Application.isMobilePlatform)
+            return;
+
+        if (Mouse.current != null &&
+            (Mouse.current.delta.ReadValue().sqrMagnitude > 0.0001f ||
+             Mouse.current.leftButton.wasPressedThisFrame ||
+             Mouse.current.rightButton.wasPressedThisFrame))
+        {
+            SetActiveInputDevice(true);
+        }
+        else if (Keyboard.current != null &&
+            (Keyboard.current.wKey.isPressed || Keyboard.current.aKey.isPressed ||
+             Keyboard.current.sKey.isPressed || Keyboard.current.dKey.isPressed))
+        {
+            SetActiveInputDevice(true);
+        }
+        else if (IsAnyGamepadActive())
+        {
+            SetActiveInputDevice(false);
+        }
+    }
+
+    private void OnDisable()
+    {
+        pointerModeOwners.Clear();
+        RequestedLockMode = CursorLockMode.None;
+        RequestedCursorVisible = true;
+        Cursor.lockState = RequestedLockMode;
+        Cursor.visible = RequestedCursorVisible;
+    }
+
+    private void OnApplicationFocus(bool hasFocus)
+    {
+        if (hasFocus)
+            RefreshCursorState();
+    }
+
+    public void SetInputLocked(bool locked)
+    {
+        inputLocked = locked;
+        BeginTransition();
+    }
+
+    public void RefreshCursorState()
+    {
+        ApplyCursorState(IsPcMouseControlActive && IsPointerModeActive);
+    }
+
+    public void RequestPointerMode(Object owner)
+    {
+        if (owner != null && pointerModeOwners.Add(owner)) BeginTransition();
+    }
+
+    public void ReleasePointerMode(Object owner)
+    {
+        if (owner != null && pointerModeOwners.Remove(owner)) BeginTransition();
+    }
+
+    public bool ShouldSuppressCombatInput()
+    {
+        if (!IsPcMouseControlActive) return false;
+        if (suppressCombatUntilMouseReleased)
+        {
+            bool released = Mouse.current == null || (!Mouse.current.leftButton.isPressed && !Mouse.current.rightButton.isPressed);
+            if (!released) return true;
+            suppressCombatUntilMouseReleased = false;
+        }
+        return IsPointerOverUi;
+    }
+
+    public void NotifyMouseCombatInput()
+    {
+        if (!Application.isMobilePlatform && Mouse.current != null)
+            SetActiveInputDevice(true);
+    }
+
+    public void NotifyLookInput(Vector2 lookInput)
+    {
+        if (Application.isMobilePlatform)
+        {
+            SetActiveInputDevice(false);
+            return;
+        }
+
+        if (lookInput.sqrMagnitude > 1.21f)
+            SetActiveInputDevice(true);
+        else if (Gamepad.current != null || Touchscreen.current != null)
+            SetActiveInputDevice(false);
+    }
+
+    public bool TryResolveFacing(Vector2 currentFacing, Vector2 movementInput, Vector2 absolutePointerAim,
+        bool attackIntent, bool defenseIntent, out Vector2 resolvedFacing)
+    {
+        resolvedFacing = currentFacing;
+        if (!IsPcMouseControlActive) return false;
+        if (!IsPointerModeActive)
+        {
+            resolvedFacing = relativeMouseFacing != null ? relativeMouseFacing.ConsumeFacing(currentFacing) : currentFacing;
+            return true;
+        }
+        resolvedFacing = ResolvePointerModeFacing(
+            currentFacing,
+            movementInput,
+            absolutePointerAim,
+            attackIntent || defenseIntent,
+            IsPointerOverUi);
+        relativeMouseFacing?.SynchronizeFacing(resolvedFacing);
+        return true;
+    }
+
+    public static Vector2 ResolvePointerModeFacing(
+        Vector2 currentFacing,
+        Vector2 movementInput,
+        Vector2 absolutePointerAim,
+        bool combatAimIntent,
+        bool pointerOverUi)
+    {
+        if (!pointerOverUi && combatAimIntent && absolutePointerAim.sqrMagnitude > 0.0001f)
+            return absolutePointerAim.normalized;
+        if (movementInput.sqrMagnitude > 0.0001f)
+            return movementInput.normalized;
+        return currentFacing;
+    }
+
+    public static CursorLockMode ResolveLockMode(bool pcMouseActive, bool pointerModeActive)
+    {
+        return pcMouseActive && !pointerModeActive ? CursorLockMode.Locked : CursorLockMode.None;
+    }
+
+    public static bool ResolveCursorVisible(bool pcMouseActive, bool pointerModeActive)
+    {
+        return !pcMouseActive || pointerModeActive;
+    }
+
+    private void SetActiveInputDevice(bool mouseAndKeyboard)
+    {
+        if (pcMouseControlActive == mouseAndKeyboard)
+            return;
+
+        pcMouseControlActive = mouseAndKeyboard;
+        BeginTransition();
+    }
+
+    private static bool IsAnyGamepadActive()
+    {
+        foreach (Gamepad gamepad in Gamepad.all)
+        {
+            if (gamepad.leftStick.ReadValue().sqrMagnitude > 0.04f ||
+                gamepad.rightStick.ReadValue().sqrMagnitude > 0.04f ||
+                gamepad.leftTrigger.ReadValue() > 0.2f ||
+                gamepad.rightTrigger.ReadValue() > 0.2f ||
+                gamepad.buttonSouth.isPressed || gamepad.buttonEast.isPressed ||
+                gamepad.buttonWest.isPressed || gamepad.buttonNorth.isPressed)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private void BeginTransition()
+    {
+        if (relativeMouseFacing == null)
+            relativeMouseFacing = GetComponent<PlayerRelativeMouseFacingController>();
+        if (playerController == null)
+            playerController = GetComponent<PlayerController>();
+
+        suppressCombatUntilMouseReleased = true;
+        relativeMouseFacing?.SynchronizeFacing(playerController != null ? playerController.CurrentFacingDirection : Vector2.up);
+        playerController?.ClearCombatInputState();
+        RefreshCursorState();
+    }
+
+    private void ApplyCursorState(bool pointerModeActive)
+    {
+        RequestedLockMode = ResolveLockMode(IsPcMouseControlActive, pointerModeActive);
+        RequestedCursorVisible = ResolveCursorVisible(IsPcMouseControlActive, pointerModeActive);
+        Cursor.lockState = RequestedLockMode;
+        Cursor.visible = RequestedCursorVisible;
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PcControlModeController.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PcControlModeController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 32996fe5861b4ee586ad21e190176bf9

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerDefenseController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerDefenseController.cs
@@ -19,6 +19,7 @@ public class PlayerDefenseController : MonoBehaviour, IPlayerHitReceiver
     [SerializeField] private Health health;
     [SerializeField] private PlayerController playerController;
     [SerializeField] private PlayerDashController dashController;
+    [SerializeField] private PcControlModeController pcControlModeController;
     [SerializeField] private bool useReleaseFallbackPolling = true;
 
     private PlayerDefenseStateMachine stateMachine;
@@ -57,6 +58,16 @@ public class PlayerDefenseController : MonoBehaviour, IPlayerHitReceiver
 
     public void OnDefend(InputValue value)
     {
+        if (value.isPressed && Mouse.current != null && Mouse.current.rightButton.isPressed)
+            pcControlModeController?.NotifyMouseCombatInput();
+
+        if (value.isPressed && pcControlModeController != null &&
+            pcControlModeController.ShouldSuppressCombatInput())
+        {
+            OnDefensePressedStateChanged(false);
+            return;
+        }
+
         OnDefensePressedStateChanged(value.isPressed);
     }
 
@@ -179,6 +190,8 @@ public class PlayerDefenseController : MonoBehaviour, IPlayerHitReceiver
             playerController = GetComponent<PlayerController>();
         if (dashController == null)
             dashController = GetComponent<PlayerDashController>();
+        if (pcControlModeController == null)
+            pcControlModeController = GetComponent<PcControlModeController>();
     }
 
     private Vector2 ResolveFacingDirection()

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerFacingOrchestrator.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerFacingOrchestrator.cs
@@ -10,7 +10,11 @@ public class PlayerFacingOrchestrator
 
     public Vector2 LastFacingDirection { get; private set; } = Vector2.up;
 
-    public void Tick(Transform playerTransform, Vector2 facingDirection, float deltaTime)
+    public void Tick(
+        Transform playerTransform,
+        Vector2 facingDirection,
+        float deltaTime,
+        bool snapRotation = false)
     {
         if (playerTransform == null || facingDirection.sqrMagnitude <= 0.0001f)
             return;
@@ -20,9 +24,11 @@ public class PlayerFacingOrchestrator
         float targetAngle = Mathf.Atan2(angleDirection.y, angleDirection.x) * Mathf.Rad2Deg
             + facingDirectionOffset;
         var targetRotation = Quaternion.Euler(0f, 0f, targetAngle);
-        playerTransform.rotation = Quaternion.RotateTowards(
-            playerTransform.rotation,
-            targetRotation,
-            rotationSpeed * Mathf.Max(0f, deltaTime));
+        playerTransform.rotation = snapRotation
+            ? targetRotation
+            : Quaternion.RotateTowards(
+                playerTransform.rotation,
+                targetRotation,
+                rotationSpeed * Mathf.Max(0f, deltaTime));
     }
 }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerRelativeMouseFacingController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerRelativeMouseFacingController.cs
@@ -1,0 +1,86 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+public class PlayerRelativeMouseFacingController : MonoBehaviour
+{
+    public const float MinimumSensitivity = 0.01f;
+    public const float MaximumSensitivity = 2f;
+
+    [SerializeField, Range(MinimumSensitivity, MaximumSensitivity)]
+    private float mouseTurnSensitivity = 0.35f;
+
+    private Vector2 accumulatedFacing;
+    private float pendingHorizontalDelta;
+    private bool hasAccumulatedFacing;
+    public float MouseTurnSensitivity => mouseTurnSensitivity;
+
+    private void Update()
+    {
+        if (Mouse.current == null)
+            return;
+
+        QueueMouseDelta(Mouse.current.delta.ReadValue());
+    }
+
+    public Vector2 ConsumeFacing(Vector2 currentFacing)
+    {
+        Vector2 facingDirection = ResolveFacing(
+            currentFacing,
+            new Vector2(pendingHorizontalDelta, 0f));
+        pendingHorizontalDelta = 0f;
+        return facingDirection;
+    }
+
+    public Vector2 ResolveFacing(Vector2 currentFacing, Vector2 mouseDelta)
+    {
+        if (!hasAccumulatedFacing)
+        {
+            accumulatedFacing = NormalizeOrFallback(currentFacing, Vector2.up);
+            hasAccumulatedFacing = true;
+        }
+
+        float turnDegrees = -mouseDelta.x * mouseTurnSensitivity;
+        if (!Mathf.Approximately(turnDegrees, 0f))
+        {
+            accumulatedFacing = (Quaternion.Euler(0f, 0f, turnDegrees) * accumulatedFacing).normalized;
+        }
+
+        return accumulatedFacing;
+    }
+
+    public void QueueMouseDelta(Vector2 mouseDelta)
+    {
+        pendingHorizontalDelta += mouseDelta.x;
+    }
+
+    public void SynchronizeFacing(Vector2 currentFacing)
+    {
+        accumulatedFacing = NormalizeOrFallback(currentFacing, Vector2.up);
+        hasAccumulatedFacing = true;
+        pendingHorizontalDelta = 0f;
+    }
+
+    public void Configure(float sensitivity)
+    {
+        mouseTurnSensitivity = Mathf.Clamp(
+            sensitivity,
+            MinimumSensitivity,
+            MaximumSensitivity);
+        accumulatedFacing = Vector2.zero;
+        pendingHorizontalDelta = 0f;
+        hasAccumulatedFacing = false;
+    }
+
+    private void OnValidate()
+    {
+        mouseTurnSensitivity = Mathf.Clamp(
+            mouseTurnSensitivity,
+            MinimumSensitivity,
+            MaximumSensitivity);
+    }
+
+    private static Vector2 NormalizeOrFallback(Vector2 value, Vector2 fallback)
+    {
+        return value.sqrMagnitude > 0.0001f ? value.normalized : fallback;
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerRelativeMouseFacingController.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Components/PlayerRelativeMouseFacingController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4dd2b47425644f43a31bcf8076456d11

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/PlayerController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/PlayerController.cs
@@ -190,7 +190,7 @@ public class PlayerController : MonoBehaviour
             Vector2 facingDirection = ResolveFacingInput();
             movementOrchestrator.Tick(mover, movementInput, movementSpeedMultiplier);
             bool snapPcFacing = pcControlModeController != null &&
-                pcControlModeController.IsPcMouseControlActive;
+                pcControlModeController.ShouldSnapFacingPresentation;
             facingOrchestrator.Tick(
                 transform,
                 facingDirection,

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/PlayerController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/PlayerController.cs
@@ -24,6 +24,7 @@ public class PlayerController : MonoBehaviour
     [SerializeField] private PlayerFireInputController fireInputController;
     [SerializeField] private PlayerAimInputResolver aimInputResolver;
     [SerializeField] private PlayerFacingPolicyResolver facingPolicyResolver;
+    [SerializeField] private PcControlModeController pcControlModeController;
     [SerializeField] private PlayerAttackAnimationDriver attackAnimationDriver;
     [SerializeField] private PlayerAttackLoop attackLoop;
     [SerializeField] private PlayerDefenseController defenseController;
@@ -99,6 +100,7 @@ public class PlayerController : MonoBehaviour
         if (fireInputController == null) fireInputController = GetComponent<PlayerFireInputController>();
         if (aimInputResolver == null) aimInputResolver = GetComponent<PlayerAimInputResolver>();
         if (facingPolicyResolver == null) facingPolicyResolver = GetComponent<PlayerFacingPolicyResolver>();
+        if (pcControlModeController == null) pcControlModeController = GetComponent<PcControlModeController>();
         if (attackAnimationDriver == null) attackAnimationDriver = GetComponent<PlayerAttackAnimationDriver>();
         if (attackLoop == null) attackLoop = GetComponent<PlayerAttackLoop>();
         if (defenseController == null) defenseController = GetComponent<PlayerDefenseController>();
@@ -128,11 +130,17 @@ public class PlayerController : MonoBehaviour
             return;
 
         aimInput = value.Get<Vector2>();
+        pcControlModeController?.NotifyLookInput(aimInput);
     }
 
     public void OnFire(InputValue value)
     {
-        if (inputLocked || IsDashing || (defenseController != null && !defenseController.CanAttack))
+        if (value.isPressed && Mouse.current != null && Mouse.current.leftButton.isPressed)
+            pcControlModeController?.NotifyMouseCombatInput();
+
+        if (inputLocked || IsDashing ||
+            (pcControlModeController != null && pcControlModeController.ShouldSuppressCombatInput()) ||
+            (defenseController != null && !defenseController.CanAttack))
         {
             fireInputController?.ClearHeldFire();
             return;
@@ -181,7 +189,13 @@ public class PlayerController : MonoBehaviour
                 : 1f;
             Vector2 facingDirection = ResolveFacingInput();
             movementOrchestrator.Tick(mover, movementInput, movementSpeedMultiplier);
-            facingOrchestrator.Tick(transform, facingDirection, Time.fixedDeltaTime);
+            bool snapPcFacing = pcControlModeController != null &&
+                pcControlModeController.IsPcMouseControlActive;
+            facingOrchestrator.Tick(
+                transform,
+                facingDirection,
+                Time.fixedDeltaTime,
+                snapPcFacing);
         }
 
         dashController?.Tick(Time.fixedDeltaTime);
@@ -342,6 +356,7 @@ public class PlayerController : MonoBehaviour
     public void SetInputLocked(bool locked)
     {
         inputLocked = locked;
+        pcControlModeController?.SetInputLocked(locked);
         if (locked)
         {
             ClearAttackInputState();
@@ -367,6 +382,14 @@ public class PlayerController : MonoBehaviour
             hitboxObject);
     }
 
+    public void ClearCombatInputState()
+    {
+        ClearAttackInputState();
+        if (defenseController == null)
+            defenseController = GetComponent<PlayerDefenseController>();
+        defenseController?.SetDefensePressed(false);
+    }
+
     public bool IsDashing => dashController != null && dashController.IsDashing;
 
     private Vector2 ResolveAimInput()
@@ -381,18 +404,34 @@ public class PlayerController : MonoBehaviour
 
     private Vector2 ResolveFacingInput()
     {
-        var resolvedAimInput = ResolveAimInput();
+        var currentFacing = facingOrchestrator != null
+            ? facingOrchestrator.LastFacingDirection
+            : -(Vector2)transform.up;
+        bool attackAimIntentActive = fireInputController != null && fireInputController.IsFireHeld;
+        bool defenseActive = defenseController != null && defenseController.IsGuarding;
+        var resolvedAimInput = pcControlModeController != null && pcControlModeController.IsPointerModeActive
+            ? ResolveAimInput()
+            : Vector2.zero;
+        if (pcControlModeController == null)
+            pcControlModeController = GetComponent<PcControlModeController>();
+        if (pcControlModeController != null && pcControlModeController.TryResolveFacing(
+            currentFacing,
+            movementInput,
+            resolvedAimInput,
+            attackAimIntentActive,
+            defenseActive,
+            out Vector2 pcFacing))
+        {
+            return pcFacing;
+        }
+
+        resolvedAimInput = ResolveAimInput();
         if (facingPolicyResolver == null)
             facingPolicyResolver = GetComponent<PlayerFacingPolicyResolver>();
 
         if (facingPolicyResolver == null)
             return resolvedAimInput;
 
-        bool attackAimIntentActive = fireInputController != null && fireInputController.IsFireHeld;
-        bool defenseActive = defenseController != null && defenseController.IsGuarding;
-        var currentFacing = facingOrchestrator != null
-            ? facingOrchestrator.LastFacingDirection
-            : -(Vector2)transform.up;
         return facingPolicyResolver.ResolveFacing(
             currentFacing,
             movementInput,
@@ -402,4 +441,5 @@ public class PlayerController : MonoBehaviour
             defenseActive,
             Time.fixedDeltaTime);
     }
+
 }

--- a/Assets/_Project/Scripts/_Project.Gameplay/UI/InventoryPanelController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/UI/InventoryPanelController.cs
@@ -531,7 +531,7 @@ namespace Castlebound.Gameplay.UI
 
             var image = panel.GetComponent<Image>();
             image.color = new Color(0.08f, 0.09f, 0.1f, 0.92f);
-            image.raycastTarget = false;
+            image.raycastTarget = true;
 
             return rect;
         }

--- a/Assets/_Project/Scripts/_Project.Gameplay/UI/InventoryPanelController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/UI/InventoryPanelController.cs
@@ -5,6 +5,7 @@ using Castlebound.Gameplay.Spawning;
 using Castlebound.Gameplay.Combat;
 using TMPro;
 using UnityEngine;
+using UnityEngine.InputSystem;
 using UnityEngine.UI;
 
 namespace Castlebound.Gameplay.UI
@@ -25,6 +26,7 @@ namespace Castlebound.Gameplay.UI
         [SerializeField] private BackpackWeaponEquipController equipController;
         [SerializeField] private BackpackItemDropController dropController;
         [SerializeField] private MonoBehaviour weaponDefinitionResolverSource;
+        [SerializeField] private PcControlModeController pcControlModeController;
 
         private BackpackInventoryState backpack;
         private CastleInventoryState vault;
@@ -54,8 +56,18 @@ namespace Castlebound.Gameplay.UI
 
         private void OnDisable()
         {
+            pcControlModeController?.ReleasePointerMode(this);
             UnhookSources();
             UnhookContextMenu();
+        }
+
+        private void Update()
+        {
+            if (!Application.isMobilePlatform && Keyboard.current != null &&
+                Keyboard.current.tabKey.wasPressedThisFrame)
+            {
+                TogglePanel();
+            }
         }
 
         public void SetBackpackSource(BackpackInventoryStateComponent source)
@@ -356,6 +368,18 @@ namespace Castlebound.Gameplay.UI
             {
                 panelRoot.gameObject.SetActive(open);
             }
+
+            ResolvePcControlMode();
+            if (open)
+                pcControlModeController?.RequestPointerMode(this);
+            else
+                pcControlModeController?.ReleasePointerMode(this);
+        }
+
+        private void ResolvePcControlMode()
+        {
+            if (pcControlModeController == null)
+                pcControlModeController = FindObjectOfType<PcControlModeController>();
         }
 
         private void EnsureRuntimeUi()

--- a/Assets/_Project/Scripts/_Project.Gameplay/UI/UpgradeMenuController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/UI/UpgradeMenuController.cs
@@ -9,8 +9,6 @@ namespace Castlebound.Gameplay.UI
         [SerializeField] private RectTransform menuRoot;
         [SerializeField] private bool autoOpenEveryPreWave = true;
         [SerializeField] private EnemySpawnerRunner waveRunner;
-        [SerializeField] private bool pausePlayerWhileOpen = true;
-        [SerializeField] private PlayerController playerController;
         [SerializeField] private PcControlModeController pcControlModeController;
 
         private WavePhaseTracker phaseTracker;
@@ -48,11 +46,6 @@ namespace Castlebound.Gameplay.UI
         public void SetAutoOpenOnFirstPreWave(bool enabled)
         {
             autoOpenEveryPreWave = enabled;
-        }
-
-        public void SetPlayerController(PlayerController controller)
-        {
-            playerController = controller;
         }
 
         public void ToggleMenu()
@@ -156,30 +149,7 @@ namespace Castlebound.Gameplay.UI
             else
                 pcControlModeController?.ReleasePointerMode(this);
 
-            SetPlayerPaused(open);
             MenuStateChanged?.Invoke(open);
-        }
-
-        private void SetPlayerPaused(bool paused)
-        {
-            if (!pausePlayerWhileOpen)
-            {
-                return;
-            }
-
-            if (playerController == null)
-            {
-                playerController = FindObjectOfType<PlayerController>();
-            }
-
-            if (playerController != null)
-            {
-                playerController.SetInputLocked(paused);
-                if (paused)
-                {
-                    playerController.StopMovement();
-                }
-            }
         }
     }
 }

--- a/Assets/_Project/Scripts/_Project.Gameplay/UI/UpgradeMenuController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/UI/UpgradeMenuController.cs
@@ -11,6 +11,7 @@ namespace Castlebound.Gameplay.UI
         [SerializeField] private EnemySpawnerRunner waveRunner;
         [SerializeField] private bool pausePlayerWhileOpen = true;
         [SerializeField] private PlayerController playerController;
+        [SerializeField] private PcControlModeController pcControlModeController;
 
         private WavePhaseTracker phaseTracker;
 
@@ -28,6 +29,7 @@ namespace Castlebound.Gameplay.UI
 
         private void OnDisable()
         {
+            pcControlModeController?.ReleasePointerMode(this);
             UnhookPhaseTracker();
         }
 
@@ -146,6 +148,13 @@ namespace Castlebound.Gameplay.UI
             {
                 menuRoot.gameObject.SetActive(open);
             }
+
+            if (pcControlModeController == null)
+                pcControlModeController = FindObjectOfType<PcControlModeController>();
+            if (open)
+                pcControlModeController?.RequestPointerMode(this);
+            else
+                pcControlModeController?.ReleasePointerMode(this);
 
             SetPlayerPaused(open);
             MenuStateChanged?.Invoke(open);

--- a/Assets/_Project/Scripts/_Project.Gameplay/UI/VaultPanelController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/UI/VaultPanelController.cs
@@ -290,7 +290,7 @@ namespace Castlebound.Gameplay.UI
 
             var image = panel.GetComponent<Image>();
             image.color = new Color(0.08f, 0.09f, 0.1f, 0.92f);
-            image.raycastTarget = false;
+            image.raycastTarget = true;
 
             CreateHeader(rect);
             return rect;

--- a/Assets/_Project/Scripts/_Project.Gameplay/UI/VaultPanelController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/UI/VaultPanelController.cs
@@ -17,6 +17,7 @@ namespace Castlebound.Gameplay.UI
         [SerializeField] private InventoryStateComponent activeInventorySource;
         [SerializeField] private InventoryContextMenuController contextMenu;
         [SerializeField] private MonoBehaviour weaponDefinitionResolverSource;
+        [SerializeField] private PcControlModeController pcControlModeController;
 
         private CastleInventoryState vault;
         private WavePhaseTracker phaseTracker;
@@ -37,6 +38,7 @@ namespace Castlebound.Gameplay.UI
 
         private void OnDisable()
         {
+            pcControlModeController?.ReleasePointerMode(this);
             UnhookVault();
             UnhookPhaseTracker();
             UnhookContextMenu();
@@ -479,6 +481,13 @@ namespace Castlebound.Gameplay.UI
             {
                 panelRoot.gameObject.SetActive(open);
             }
+
+            if (pcControlModeController == null)
+                pcControlModeController = FindObjectOfType<PcControlModeController>();
+            if (open)
+                pcControlModeController?.RequestPointerMode(this);
+            else
+                pcControlModeController?.ReleasePointerMode(this);
         }
 
         private static void DestroyChild(GameObject child)

--- a/Assets/_Project/Scripts/_Project.Gameplay/World/Placement/WorldPlaceablePlacementController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/World/Placement/WorldPlaceablePlacementController.cs
@@ -20,6 +20,7 @@ namespace Castlebound.Gameplay.World.Placement
         [SerializeField] private TouchAimAttackZone touchAimAttackZone;
         [SerializeField] private PlayerFireInputController playerFireInputController;
         [SerializeField] private PlayerController playerController;
+        [SerializeField] private PcControlModeController pcControlModeController;
         [SerializeField] private SpriteRenderer previewRenderer;
         [SerializeField] private Sprite placeholderPreviewSprite;
         [SerializeField] private Button confirmButton;
@@ -65,6 +66,7 @@ namespace Castlebound.Gameplay.World.Placement
 
         private void OnDisable()
         {
+            pcControlModeController?.ReleasePointerMode(this);
             UnhookPlacementControls();
         }
 
@@ -129,6 +131,7 @@ namespace Castlebound.Gameplay.World.Placement
             placementCanceled = onCanceled;
             ClearTarget();
             SetPlacementControlsActive(true);
+            pcControlModeController?.RequestPointerMode(this);
             return true;
         }
 
@@ -164,6 +167,7 @@ namespace Castlebound.Gameplay.World.Placement
             ClearTarget();
             SetPreviewActive(false);
             SetPlacementControlsActive(false);
+            pcControlModeController?.ReleasePointerMode(this);
             ReleaseTouchAimAttackState();
             ReleasePlayerFireInputState();
             ReleasePlayerAttackInputState();
@@ -273,6 +277,11 @@ namespace Castlebound.Gameplay.World.Placement
             if (playerController == null)
             {
                 playerController = FindObjectOfType<PlayerController>();
+            }
+
+            if (pcControlModeController == null)
+            {
+                pcControlModeController = FindObjectOfType<PcControlModeController>();
             }
 
             if (worldGrid != null)

--- a/Assets/_Project/_Tests/EditMode/Input/PcControlModeTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Input/PcControlModeTests.cs
@@ -1,0 +1,208 @@
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+namespace Castlebound.Tests.Input
+{
+    public class PcControlModeTests
+    {
+        private GameObject root;
+        private PlayerRelativeMouseFacingController relativeFacing;
+        private Mouse mouse;
+
+        [SetUp]
+        public void SetUp()
+        {
+            root = new GameObject("PcControlMode");
+            mouse = InputSystem.AddDevice<Mouse>();
+            relativeFacing = root.AddComponent<PlayerRelativeMouseFacingController>();
+            relativeFacing.Configure(1f);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(root);
+            if (mouse != null && mouse.added)
+                InputSystem.RemoveDevice(mouse);
+        }
+
+        [Test]
+        public void ResolveFacing_HorizontalDeltaRotatesFromCurrentFacing()
+        {
+            Vector2 facing = relativeFacing.ResolveFacing(Vector2.up, new Vector2(10f, 0f));
+
+            Vector2 expected = Quaternion.Euler(0f, 0f, -10f) * Vector2.up;
+            Assert.That(Vector2.Distance(facing, expected), Is.LessThan(0.0001f));
+        }
+
+        [Test]
+        public void ResolveFacing_NoMouseDeltaPreservesAccumulatedFacing()
+        {
+            Vector2 turned = relativeFacing.ResolveFacing(Vector2.up, new Vector2(45f, 0f));
+
+            Vector2 preserved = relativeFacing.ResolveFacing(Vector2.left, Vector2.zero);
+
+            Assert.That(Vector2.Distance(preserved, turned), Is.LessThan(0.0001f));
+        }
+
+        [Test]
+        public void ResolveFacing_VerticalDeltaDoesNotChangeFacing()
+        {
+            Vector2 facing = relativeFacing.ResolveFacing(Vector2.up, new Vector2(0f, 500f));
+
+            Assert.That(Vector2.Distance(facing, Vector2.up), Is.LessThan(0.0001f));
+        }
+
+        [Test]
+        public void ResolveFacing_FastHorizontalDeltaCanTurnOneHundredEightyDegrees()
+        {
+            Vector2 facing = relativeFacing.ResolveFacing(Vector2.up, new Vector2(180f, 0f));
+
+            Assert.That(Vector2.Distance(facing, Vector2.down), Is.LessThan(0.0001f));
+        }
+
+        [Test]
+        public void Configure_ClampsSensitivityToSafeProductionRange()
+        {
+            relativeFacing.Configure(100f);
+
+            Assert.That(relativeFacing.MouseTurnSensitivity, Is.EqualTo(2f));
+        }
+
+        [Test]
+        public void PlayerController_RoutesWorldRelativeInputDirectlyToMovementAndDash()
+        {
+            const string controllerPath =
+                "Assets/_Project/Scripts/_Project.Gameplay/Player/PlayerController.cs";
+            string source = System.IO.File.ReadAllText(controllerPath);
+
+            StringAssert.Contains(
+                "movementOrchestrator.Tick(mover, movementInput, movementSpeedMultiplier)",
+                source);
+            StringAssert.Contains(
+                "dashController.TryStart(movementInput, CurrentFacingDirection, defenseAllowsDash)",
+                source);
+            StringAssert.DoesNotContain("ResolveMovementInput", source);
+            StringAssert.DoesNotContain("bodyRelative", source.ToLowerInvariant());
+        }
+
+        [Test]
+        public void CursorPolicy_LocksOnlyDuringPcGameplay()
+        {
+            Assert.That(
+                PcControlModeController.ResolveLockMode(true, false),
+                Is.EqualTo(CursorLockMode.Locked));
+            Assert.IsFalse(PcControlModeController.ResolveCursorVisible(true, false));
+
+            Assert.That(
+                PcControlModeController.ResolveLockMode(true, true),
+                Is.EqualTo(CursorLockMode.None));
+            Assert.IsTrue(PcControlModeController.ResolveCursorVisible(true, true));
+            Assert.IsTrue(PcControlModeController.ResolveCursorVisible(false, false));
+        }
+
+        [Test]
+        public void PointerMode_UsesAbsoluteCombatAimThenMovementFallbackThenRetention()
+        {
+            var mode = root.AddComponent<PcControlModeController>();
+            mode.RequestPointerMode(root);
+
+            Assert.IsTrue(mode.TryResolveFacing(
+                Vector2.up, Vector2.left, Vector2.right, true, false, out Vector2 attackFacing));
+            Assert.That(attackFacing, Is.EqualTo(Vector2.right));
+
+            Assert.IsTrue(mode.TryResolveFacing(
+                attackFacing, Vector2.left, Vector2.down, false, false, out Vector2 movementFacing));
+            Assert.That(movementFacing, Is.EqualTo(Vector2.left));
+
+            Assert.IsTrue(mode.TryResolveFacing(
+                movementFacing, Vector2.zero, Vector2.down, false, false, out Vector2 retainedFacing));
+            Assert.That(retainedFacing, Is.EqualTo(Vector2.left));
+        }
+
+        [Test]
+        public void PointerOverUi_SuppressesCombatAimAndUsesMovementFallback()
+        {
+            Vector2 facing = PcControlModeController.ResolvePointerModeFacing(
+                Vector2.up,
+                Vector2.left,
+                Vector2.right,
+                true,
+                true);
+
+            Assert.That(facing, Is.EqualTo(Vector2.left));
+        }
+
+        [Test]
+        public void PointerMode_AttackAndDefenseUseTheSameAbsoluteFacingContract()
+        {
+            Vector2 attackFacing = PcControlModeController.ResolvePointerModeFacing(
+                Vector2.up, Vector2.zero, Vector2.right, true, false);
+            Vector2 defenseFacing = PcControlModeController.ResolvePointerModeFacing(
+                Vector2.up, Vector2.zero, Vector2.right, true, false);
+
+            Assert.That(attackFacing, Is.EqualTo(defenseFacing));
+        }
+
+        [Test]
+        public void GamepadLook_KeepsExistingFacingPolicyAuthoritative()
+        {
+            var gamepad = InputSystem.AddDevice<Gamepad>();
+            try
+            {
+                var mode = root.AddComponent<PcControlModeController>();
+                mode.NotifyLookInput(Vector2.right);
+
+                Assert.IsFalse(mode.TryResolveFacing(
+                    Vector2.up, Vector2.left, Vector2.right, true, false, out _));
+            }
+            finally
+            {
+                InputSystem.RemoveDevice(gamepad);
+            }
+        }
+
+        [Test]
+        public void PointerUiLifecycles_RequestTheCentralControlModeOwner()
+        {
+            string combinedSource = string.Join("\n",
+                System.IO.File.ReadAllText("Assets/_Project/Scripts/_Project.Gameplay/UI/InventoryPanelController.cs"),
+                System.IO.File.ReadAllText("Assets/_Project/Scripts/_Project.Gameplay/UI/UpgradeMenuController.cs"),
+                System.IO.File.ReadAllText("Assets/_Project/Scripts/_Project.Gameplay/UI/VaultPanelController.cs"),
+                System.IO.File.ReadAllText("Assets/_Project/Scripts/_Project.Gameplay/World/Placement/WorldPlaceablePlacementController.cs"));
+
+            StringAssert.Contains("RequestPointerMode(this)", combinedSource);
+            StringAssert.Contains("ReleasePointerMode(this)", combinedSource);
+            StringAssert.DoesNotContain("Cursor.lockState", combinedSource);
+            StringAssert.DoesNotContain("Cursor.visible", combinedSource);
+        }
+
+        [Test]
+        public void PrefabUsesProductionComponentsWithoutPrototypeScaffolding()
+        {
+            const string prefabPath = "Assets/_Project/Prefabs/Player.prefab";
+            const string scenePath = "Assets/_Project/Scenes/MainPrototype.unity";
+            GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>(prefabPath);
+
+            Assert.NotNull(prefab);
+            var authoredRelativeFacing = prefab.GetComponent<PlayerRelativeMouseFacingController>();
+            var playerController = prefab.GetComponent<PlayerController>();
+            Assert.NotNull(authoredRelativeFacing);
+            Assert.NotNull(prefab.GetComponent<PcControlModeController>());
+            Assert.NotNull(playerController);
+
+            var serializedController = new SerializedObject(playerController);
+            var hitbox = serializedController.FindProperty("hitboxObject").objectReferenceValue as GameObject;
+            Assert.NotNull(hitbox);
+            Assert.IsTrue(hitbox.transform.IsChildOf(prefab.transform),
+                "Melee attack geometry must continue inheriting the player-facing transform.");
+
+            string prefabText = System.IO.File.ReadAllText(prefabPath);
+            string scene = System.IO.File.ReadAllText(scenePath);
+            StringAssert.DoesNotContain("prototypeEnabled", prefabText + scene);
+            StringAssert.DoesNotContain("bodyRelative", prefabText + scene);
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Input/PcControlModeTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Input/PcControlModeTests.cs
@@ -2,6 +2,7 @@ using NUnit.Framework;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.InputSystem;
+using Castlebound.Gameplay.Input;
 
 namespace Castlebound.Tests.Input
 {
@@ -104,6 +105,39 @@ namespace Castlebound.Tests.Input
         }
 
         [Test]
+        public void FacingPresentation_SnapsOnlyDuringLockedRelativeMouseGameplay()
+        {
+            var mode = root.AddComponent<PcControlModeController>();
+
+            Assert.IsTrue(mode.ShouldSnapFacingPresentation);
+
+            mode.RequestPointerMode(root);
+
+            Assert.IsFalse(mode.ShouldSnapFacingPresentation);
+        }
+
+        [Test]
+        public void PointerModeMovementFallback_AdvancesThroughFacingOrchestratorWithoutSnapping()
+        {
+            var player = new GameObject("PlayerFacing");
+            try
+            {
+                var orchestrator = new PlayerFacingOrchestrator();
+                orchestrator.Tick(player.transform, Vector2.right, 0.02f, false);
+
+                float targetAngle = Quaternion.Angle(
+                    player.transform.rotation,
+                    Quaternion.Euler(0f, 0f, -90f));
+                Assert.That(targetAngle, Is.GreaterThan(0.1f));
+                Assert.That(Quaternion.Angle(player.transform.rotation, Quaternion.identity), Is.GreaterThan(0.1f));
+            }
+            finally
+            {
+                Object.DestroyImmediate(player);
+            }
+        }
+
+        [Test]
         public void PointerMode_UsesAbsoluteCombatAimThenMovementFallbackThenRetention()
         {
             var mode = root.AddComponent<PcControlModeController>();
@@ -177,6 +211,25 @@ namespace Castlebound.Tests.Input
             StringAssert.Contains("ReleasePointerMode(this)", combinedSource);
             StringAssert.DoesNotContain("Cursor.lockState", combinedSource);
             StringAssert.DoesNotContain("Cursor.visible", combinedSource);
+        }
+
+        [Test]
+        public void DesktopUiHitTesting_IgnoresMobileTouchSurfacesButNotNormalUi()
+        {
+            var touchSurface = new GameObject("TouchSurface");
+            var normalUi = new GameObject("NormalUi");
+            try
+            {
+                touchSurface.AddComponent<TouchMovementZone>();
+
+                Assert.IsTrue(PcControlModeController.IsDesktopTouchSurface(touchSurface));
+                Assert.IsFalse(PcControlModeController.IsDesktopTouchSurface(normalUi));
+            }
+            finally
+            {
+                Object.DestroyImmediate(touchSurface);
+                Object.DestroyImmediate(normalUi);
+            }
         }
 
         [Test]

--- a/Assets/_Project/_Tests/EditMode/Input/PcControlModeTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Input/PcControlModeTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 61c9858d10da40f2b2e5b0f14bf70131

--- a/Assets/_Project/_Tests/EditMode/Input/PlayerFacingOrchestratorTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Input/PlayerFacingOrchestratorTests.cs
@@ -26,5 +26,27 @@ namespace Castlebound.Tests.Input
                 Object.DestroyImmediate(player);
             }
         }
+
+        [Test]
+        public void Tick_SnapRotation_AppliesFacingWithoutPresentationLag()
+        {
+            var player = new GameObject("Player");
+
+            try
+            {
+                var orchestrator = new PlayerFacingOrchestrator();
+
+                orchestrator.Tick(player.transform, Vector2.left, 0f, true);
+
+                Assert.Less(Vector2.Distance(orchestrator.LastFacingDirection, Vector2.left), 0.001f);
+                Assert.That(
+                    Quaternion.Angle(player.transform.rotation, Quaternion.Euler(0f, 0f, 90f)),
+                    Is.LessThan(0.001f));
+            }
+            finally
+            {
+                Object.DestroyImmediate(player);
+            }
+        }
     }
 }

--- a/Assets/_Project/_Tests/EditMode/UI/InventoryPanelControllerTests.cs
+++ b/Assets/_Project/_Tests/EditMode/UI/InventoryPanelControllerTests.cs
@@ -235,7 +235,7 @@ namespace Castlebound.Tests.UI
         }
 
         [Test]
-        public void RuntimePanel_BackgroundAndLabels_DoNotBlockGameplayPointerInput()
+        public void RuntimePanel_BackgroundConsumesPointerWhileLabelsDeferToControls()
         {
             panel.TogglePanel();
 
@@ -246,7 +246,7 @@ namespace Castlebound.Tests.UI
             Assert.NotNull(panelBackground);
             Assert.NotNull(rowLabel);
             Assert.NotNull(tabLabel);
-            Assert.IsFalse(panelBackground.raycastTarget);
+            Assert.IsTrue(panelBackground.raycastTarget, "The visible panel surface must own pointer input so combat cannot click through it.");
             Assert.IsFalse(rowLabel.raycastTarget);
             Assert.IsFalse(tabLabel.raycastTarget);
             Assert.IsTrue(panel.OpenButton.GetComponent<Image>().raycastTarget);

--- a/Assets/_Project/_Tests/EditMode/UI/UpgradeMenuControllerTests.cs
+++ b/Assets/_Project/_Tests/EditMode/UI/UpgradeMenuControllerTests.cs
@@ -111,24 +111,20 @@ namespace Castlebound.Tests.UI
         }
 
         [Test]
-        public void MenuBlocksPlayerInput_WhenOpen()
+        public void MenuOpensAsNonPausingPointerMode()
         {
             var phase = new WavePhaseTracker();
             var menu = new GameObject("Menu");
-            var player = new GameObject("Player");
             var controller = menu.AddComponent<UpgradeMenuController>();
 
             controller.SetPhaseTracker(phase);
             controller.SetAutoOpenOnFirstPreWave(true);
-            controller.SetPlayerController(player.AddComponent<PlayerController>());
-
             phase.SetPhase(WavePhase.PreWave);
             controller.ToggleMenu();
 
             Assert.IsTrue(controller.IsMenuOpen, "Menu should be open in pre-wave.");
 
             Object.DestroyImmediate(menu);
-            Object.DestroyImmediate(player);
         }
 
         [Test]

--- a/Assets/_Project/_Tests/EditMode/UI/VaultPanelControllerTests.cs
+++ b/Assets/_Project/_Tests/EditMode/UI/VaultPanelControllerTests.cs
@@ -93,6 +93,18 @@ namespace Castlebound.Tests.UI
         }
 
         [Test]
+        public void RuntimePanel_BackgroundConsumesPointerInput()
+        {
+            phase.SetPhase(WavePhase.PreWave);
+            Assert.IsTrue(panel.OpenFromWorld());
+
+            var panelBackground = root.transform.Find("VaultPanel").GetComponent<Image>();
+
+            Assert.IsTrue(panelBackground.raycastTarget,
+                "The visible vault surface must own pointer input so combat cannot click through it.");
+        }
+
+        [Test]
         public void VaultRow_ButtonClickOpensContextMenu_WithMoveAndEquipActions()
         {
             phase.SetPhase(WavePhase.PreWave);

--- a/Assets/_Project/_Tests/PlayMode/Input/PcControlModePlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/Input/PcControlModePlayTests.cs
@@ -1,0 +1,175 @@
+using System.Collections;
+using System.Reflection;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.InputSystem;
+using UnityEngine.TestTools;
+using Castlebound.Gameplay.Combat;
+
+namespace Castlebound.Tests.Input
+{
+    public class PcControlModePlayTests
+    {
+        private GameObject player;
+        private GameObject attacker;
+        private Mouse mouse;
+
+        [UnitySetUp]
+        public IEnumerator SetUp()
+        {
+            mouse = InputSystem.AddDevice<Mouse>();
+            player = new GameObject("Player");
+            player.tag = "Player";
+            var body = player.AddComponent<Rigidbody2D>();
+            body.gravityScale = 0f;
+            player.AddComponent<BoxCollider2D>();
+            player.AddComponent<PlayerCollisionMove2D>();
+            var relativeFacing = player.AddComponent<PlayerRelativeMouseFacingController>();
+            relativeFacing.Configure(1f);
+            player.AddComponent<PcControlModeController>();
+            player.AddComponent<PlayerFireInputController>();
+            player.AddComponent<PlayerAttackLoop>();
+            player.AddComponent<PlayerDashController>();
+            player.AddComponent<Health>().ConfigureMaxHealth(10, true);
+            player.AddComponent<PlayerDefenseController>().Configure(0.15f, 0.15f, 120f, 0.6f);
+            player.AddComponent<PlayerController>();
+
+            attacker = new GameObject("Attacker");
+            yield return null;
+        }
+
+        [UnityTearDown]
+        public IEnumerator TearDown()
+        {
+            Cursor.lockState = CursorLockMode.None;
+            Cursor.visible = true;
+            if (mouse != null && mouse.added)
+                InputSystem.RemoveDevice(mouse);
+            Object.Destroy(player);
+            Object.Destroy(attacker);
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator RelativeFacingAndWorldMovement_RemainIndependent()
+        {
+            var relativeFacing = player.GetComponent<PlayerRelativeMouseFacingController>();
+            var controller = player.GetComponent<PlayerController>();
+            relativeFacing.QueueMouseDelta(new Vector2(90f, 600f));
+            SetField(controller, "movementInput", Vector2.up);
+
+            yield return new WaitForFixedUpdate();
+            yield return new WaitForFixedUpdate();
+
+            Assert.That(Vector2.Distance(controller.CurrentFacingDirection, Vector2.right), Is.LessThan(0.001f));
+            Assert.That(
+                Quaternion.Angle(player.transform.rotation, Quaternion.Euler(0f, 0f, -90f)),
+                Is.LessThan(0.001f),
+                "PC facing presentation must not lag behind its logical combat direction.");
+            Assert.That(player.transform.position.y, Is.GreaterThan(0.01f));
+            Assert.That(player.transform.position.x, Is.EqualTo(0f).Within(0.001f),
+                "World-up movement must not become facing-relative movement.");
+        }
+
+        [UnityTest]
+        public IEnumerator WorldRelativeDash_UsesMovementDirectionAndExistingFacingClassification()
+        {
+            var relativeFacing = player.GetComponent<PlayerRelativeMouseFacingController>();
+            var controller = player.GetComponent<PlayerController>();
+            var dash = player.GetComponent<PlayerDashController>();
+            relativeFacing.QueueMouseDelta(new Vector2(90f, 0f));
+            yield return new WaitForFixedUpdate();
+
+            AssertDash(Vector2.up, Vector2.up, PlayerDashDirection.Full);
+            AssertDash(Vector2.down, Vector2.down, PlayerDashDirection.Rear);
+            AssertDash(Vector2.left, Vector2.left, PlayerDashDirection.Rear);
+            AssertDash(Vector2.right, Vector2.right, PlayerDashDirection.Full);
+            AssertDash(new Vector2(-1f, -1f), new Vector2(-1f, -1f).normalized, PlayerDashDirection.Rear);
+            AssertDash(Vector2.zero, Vector2.left, PlayerDashDirection.Rear);
+
+            void AssertDash(
+                Vector2 localInput,
+                Vector2 expectedDirection,
+                PlayerDashDirection expectedClass)
+            {
+                dash.ResetState();
+                SetField(controller, "movementInput", localInput);
+                Assert.IsTrue(controller.TryStartDash());
+                Assert.That(Vector2.Distance(dash.Direction, expectedDirection), Is.LessThan(0.001f));
+                Assert.That(dash.DirectionClass, Is.EqualTo(expectedClass));
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator DefenseAndNeutralDash_ConsumeTheProductionFacingContract()
+        {
+            var relativeFacing = player.GetComponent<PlayerRelativeMouseFacingController>();
+            var controller = player.GetComponent<PlayerController>();
+            var defense = player.GetComponent<PlayerDefenseController>();
+            var dash = player.GetComponent<PlayerDashController>();
+            relativeFacing.QueueMouseDelta(new Vector2(90f, 0f));
+            yield return new WaitForFixedUpdate();
+
+            attacker.transform.position = Vector2.right;
+            defense.SetDefensePressed(true);
+            PlayerHitResult result = defense.ReceiveHit(new PlayerHitRequest(
+                1,
+                attacker,
+                attacker.transform.position,
+                CombatDamageType.Melee));
+
+            Assert.That(result.Outcome, Is.EqualTo(PlayerHitOutcome.Parried));
+            defense.SetDefensePressed(false);
+            defense.Tick(1f);
+            Assert.IsTrue(controller.TryStartDash());
+            Assert.That(Vector2.Distance(dash.Direction, Vector2.left), Is.LessThan(0.001f),
+                "Neutral backward dodge must continue using the established current-facing contract.");
+        }
+
+        [UnityTest]
+        public IEnumerator InputLock_UnlocksCursorAndResumeRestoresGameplayCursor()
+        {
+            var controller = player.GetComponent<PlayerController>();
+            var cursor = player.GetComponent<PcControlModeController>();
+            cursor.RefreshCursorState();
+            yield return null;
+
+            Assert.That(cursor.RequestedLockMode, Is.EqualTo(CursorLockMode.Locked));
+            Assert.IsFalse(cursor.RequestedCursorVisible);
+
+            controller.SetInputLocked(true);
+            Assert.That(cursor.RequestedLockMode, Is.EqualTo(CursorLockMode.None));
+            Assert.IsTrue(cursor.RequestedCursorVisible);
+
+            controller.SetInputLocked(false);
+            Assert.That(cursor.RequestedLockMode, Is.EqualTo(CursorLockMode.Locked));
+            Assert.IsFalse(cursor.RequestedCursorVisible);
+        }
+
+        [UnityTest]
+        public IEnumerator PointerModeTransition_DiscardsQueuedDeltaAndPreservesFacing()
+        {
+            var controller = player.GetComponent<PlayerController>();
+            var relativeFacing = player.GetComponent<PlayerRelativeMouseFacingController>();
+            var mode = player.GetComponent<PcControlModeController>();
+            relativeFacing.QueueMouseDelta(new Vector2(90f, 0f));
+
+            mode.RequestPointerMode(player);
+            mode.ReleasePointerMode(player);
+            yield return new WaitForFixedUpdate();
+
+            Assert.That(Vector2.Distance(controller.CurrentFacingDirection, Vector2.up), Is.LessThan(0.001f));
+            Assert.That(mode.RequestedLockMode, Is.EqualTo(CursorLockMode.Locked));
+            Assert.IsFalse(mode.RequestedCursorVisible);
+        }
+
+        private static void SetField(object instance, string fieldName, object value)
+        {
+            FieldInfo field = instance.GetType().GetField(
+                fieldName,
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(field);
+            field.SetValue(instance, value);
+        }
+    }
+}

--- a/Assets/_Project/_Tests/PlayMode/Input/PcControlModePlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/Input/PcControlModePlayTests.cs
@@ -2,9 +2,15 @@ using System.Collections;
 using System.Reflection;
 using NUnit.Framework;
 using UnityEngine;
+using UnityEngine.EventSystems;
 using UnityEngine.InputSystem;
+using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.TestTools;
 using Castlebound.Gameplay.Combat;
+using Castlebound.Gameplay.Input;
+using Castlebound.Gameplay.Spawning;
+using Castlebound.Gameplay.UI;
+using UnityEngine.UI;
 
 namespace Castlebound.Tests.Input
 {
@@ -12,13 +18,19 @@ namespace Castlebound.Tests.Input
     {
         private GameObject player;
         private GameObject attacker;
+        private GameObject cameraObject;
+        private GameObject eventSystemObject;
         private Mouse mouse;
+        private PlayerControls inputActions;
+        private PlayerInput playerInput;
+        private PcControlModeTestInputModule pointerInputModule;
 
         [UnitySetUp]
         public IEnumerator SetUp()
         {
             mouse = InputSystem.AddDevice<Mouse>();
             player = new GameObject("Player");
+            player.SetActive(false);
             player.tag = "Player";
             var body = player.AddComponent<Rigidbody2D>();
             body.gravityScale = 0f;
@@ -28,13 +40,31 @@ namespace Castlebound.Tests.Input
             relativeFacing.Configure(1f);
             player.AddComponent<PcControlModeController>();
             player.AddComponent<PlayerFireInputController>();
+            player.AddComponent<PlayerAimInputResolver>();
             player.AddComponent<PlayerAttackLoop>();
             player.AddComponent<PlayerDashController>();
             player.AddComponent<Health>().ConfigureMaxHealth(10, true);
             player.AddComponent<PlayerDefenseController>().Configure(0.15f, 0.15f, 120f, 0.6f);
             player.AddComponent<PlayerController>();
+            inputActions = new PlayerControls();
+            playerInput = player.AddComponent<PlayerInput>();
+            playerInput.actions = inputActions.asset;
+            playerInput.notificationBehavior = PlayerNotifications.SendMessages;
+            playerInput.defaultActionMap = "Player";
+            player.SetActive(true);
+            playerInput.ActivateInput();
 
             attacker = new GameObject("Attacker");
+            cameraObject = new GameObject("Main Camera", typeof(Camera));
+            cameraObject.tag = "MainCamera";
+            cameraObject.GetComponent<Camera>().orthographic = true;
+            cameraObject.transform.position = new Vector3(0f, 0f, -10f);
+
+            eventSystemObject = new GameObject("EventSystem");
+            eventSystemObject.SetActive(false);
+            eventSystemObject.AddComponent<EventSystem>();
+            pointerInputModule = eventSystemObject.AddComponent<PcControlModeTestInputModule>();
+            eventSystemObject.SetActive(true);
             yield return null;
         }
 
@@ -47,6 +77,9 @@ namespace Castlebound.Tests.Input
                 InputSystem.RemoveDevice(mouse);
             Object.Destroy(player);
             Object.Destroy(attacker);
+            Object.Destroy(cameraObject);
+            Object.Destroy(eventSystemObject);
+            inputActions?.Dispose();
             yield return null;
         }
 
@@ -163,6 +196,201 @@ namespace Castlebound.Tests.Input
             Assert.IsFalse(mode.RequestedCursorVisible);
         }
 
+        [UnityTest]
+        public IEnumerator LockedGameplay_MouseActionsDriveAttackAndDefensePressAndRelease()
+        {
+            var controller = player.GetComponent<PlayerController>();
+            var fire = player.GetComponent<PlayerFireInputController>();
+            var defense = player.GetComponent<PlayerDefenseController>();
+            controller.SetInputLocked(true);
+            controller.SetInputLocked(false);
+            yield return null;
+
+            yield return SetMouseButton(MouseButton.Left, true);
+            Assert.IsTrue(fire.IsFireHeld);
+
+            yield return SetMouseButton(MouseButton.Left, false);
+            yield return new WaitForFixedUpdate();
+            Assert.IsFalse(fire.IsFireHeld);
+
+            yield return SetMouseButton(MouseButton.Right, true);
+            Assert.IsTrue(defense.IsGuarding);
+
+            yield return SetMouseButton(MouseButton.Right, false);
+            yield return new WaitForFixedUpdate();
+            Assert.IsFalse(defense.IsGuarding);
+        }
+
+        [UnityTest]
+        public IEnumerator PointerModeOffUi_MouseCombatUsesActionCallbacksAndAbsoluteAim()
+        {
+            var mode = player.GetComponent<PcControlModeController>();
+            var controller = player.GetComponent<PlayerController>();
+            var fire = player.GetComponent<PlayerFireInputController>();
+            var defense = player.GetComponent<PlayerDefenseController>();
+            pointerInputModule.PointerOverUi = false;
+            mode.RequestPointerMode(player);
+            yield return null;
+
+            Vector2 aimPosition = Camera.main.WorldToScreenPoint(Vector3.right * 4f);
+            yield return SetMouseButton(MouseButton.Left, true, aimPosition);
+            yield return new WaitForFixedUpdate();
+            Assert.IsTrue(fire.IsFireHeld);
+            Assert.That(Vector2.Distance(controller.CurrentFacingDirection, Vector2.right), Is.LessThan(0.05f));
+
+            yield return SetMouseButton(MouseButton.Left, false, aimPosition);
+            yield return new WaitForFixedUpdate();
+            Assert.IsFalse(fire.IsFireHeld);
+
+            yield return SetMouseButton(MouseButton.Right, true, aimPosition);
+            yield return new WaitForFixedUpdate();
+            Assert.IsTrue(defense.IsGuarding);
+            Assert.That(Vector2.Distance(controller.CurrentFacingDirection, Vector2.right), Is.LessThan(0.05f));
+
+            yield return SetMouseButton(MouseButton.Right, false, aimPosition);
+            yield return new WaitForFixedUpdate();
+            Assert.IsFalse(defense.IsGuarding);
+        }
+
+        [UnityTest]
+        public IEnumerator PointerOverUi_SuppressesMouseCombatThroughEventSystem()
+        {
+            var mode = player.GetComponent<PcControlModeController>();
+            var fire = player.GetComponent<PlayerFireInputController>();
+            var defense = player.GetComponent<PlayerDefenseController>();
+            mode.RequestPointerMode(player);
+            pointerInputModule.PointerOverUi = true;
+            yield return null;
+            Assert.IsTrue(EventSystem.current.IsPointerOverGameObject());
+
+            yield return SetMouseButton(MouseButton.Left, true);
+            Assert.IsFalse(fire.IsFireHeld);
+            yield return SetMouseButton(MouseButton.Left, false);
+
+            yield return SetMouseButton(MouseButton.Right, true);
+            Assert.IsFalse(defense.IsGuarding);
+            yield return SetMouseButton(MouseButton.Right, false);
+        }
+
+        [UnityTest]
+        public IEnumerator ClosingPointerMode_UiClickDoesNotLeakAndNextClickWorks()
+        {
+            var mode = player.GetComponent<PcControlModeController>();
+            var fire = player.GetComponent<PlayerFireInputController>();
+            mode.RequestPointerMode(player);
+            pointerInputModule.PointerOverUi = true;
+            yield return null;
+
+            yield return SetMouseButton(MouseButton.Left, true);
+            Assert.IsFalse(fire.IsFireHeld);
+            mode.ReleasePointerMode(player);
+            Assert.IsFalse(fire.IsFireHeld);
+
+            yield return SetMouseButton(MouseButton.Left, false);
+            pointerInputModule.PointerOverUi = false;
+            yield return null;
+            yield return SetMouseButton(MouseButton.Left, true);
+            Assert.IsTrue(fire.IsFireHeld);
+            yield return SetMouseButton(MouseButton.Left, false);
+        }
+
+        [UnityTest]
+        public IEnumerator PointerModeMovementFallback_UsesSmoothFacingPresentation()
+        {
+            var mode = player.GetComponent<PcControlModeController>();
+            var controller = player.GetComponent<PlayerController>();
+            mode.RequestPointerMode(player);
+            SetField(controller, "movementInput", Vector2.right);
+
+            yield return new WaitForFixedUpdate();
+
+            Assert.IsFalse(mode.ShouldSnapFacingPresentation);
+            Assert.That(controller.CurrentFacingDirection, Is.EqualTo(Vector2.right));
+            Assert.That(
+                Quaternion.Angle(player.transform.rotation, Quaternion.Euler(0f, 0f, -90f)),
+                Is.GreaterThan(0.1f));
+        }
+
+        [UnityTest]
+        public IEnumerator UpgradeMenuOpen_LeavesOffUiMouseCombatAvailable()
+        {
+            var mode = player.GetComponent<PcControlModeController>();
+            var fire = player.GetComponent<PlayerFireInputController>();
+            var menuObject = new GameObject("UpgradeMenu");
+            var menuRoot = new GameObject("UpgradeMenuRoot", typeof(RectTransform));
+            menuRoot.SetActive(false);
+            var menu = menuObject.AddComponent<UpgradeMenuController>();
+            var phase = new WavePhaseTracker();
+            SetField(menu, "menuRoot", menuRoot.GetComponent<RectTransform>());
+            SetField(menu, "pcControlModeController", mode);
+            menu.SetPhaseTracker(phase);
+            menu.SetAutoOpenOnFirstPreWave(false);
+            phase.SetPhase(WavePhase.PreWave);
+
+            menu.ToggleMenu();
+            pointerInputModule.PointerOverUi = false;
+            yield return null;
+
+            Assert.IsTrue(menu.IsMenuOpen);
+            Assert.IsTrue(mode.IsPointerModeActive);
+            yield return SetMouseButton(MouseButton.Left, true);
+            Assert.IsTrue(fire.IsFireHeld,
+                "Opening a pointer-mode menu must not globally lock off-UI combat input.");
+
+            yield return SetMouseButton(MouseButton.Left, false);
+            Object.Destroy(menuObject);
+            Object.Destroy(menuRoot);
+        }
+
+        [UnityTest]
+        public IEnumerator PointerModeHitTest_IgnoresMobileOverlayButDetectsDesktopPanel()
+        {
+            var mode = player.GetComponent<PcControlModeController>();
+            var canvasObject = new GameObject("PointerCanvas", typeof(Canvas), typeof(GraphicRaycaster));
+            var canvas = canvasObject.GetComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+            var touchSurface = CreateRaycastSurface("MobileTouchSurface", canvasObject.transform);
+            touchSurface.AddComponent<TouchMovementZone>();
+            mode.RequestPointerMode(player);
+
+            yield return SetMouseButton(MouseButton.Left, false, new Vector2(Screen.width * 0.5f, Screen.height * 0.5f));
+
+            Assert.IsFalse(mode.IsPointerOverUi,
+                "Desktop combat must ignore the full-screen mobile touch overlay.");
+
+            CreateRaycastSurface("DesktopPanel", canvasObject.transform);
+            yield return null;
+
+            Assert.IsTrue(mode.IsPointerOverUi,
+                "A visible desktop panel under the pointer must own mouse input.");
+
+            Object.Destroy(canvasObject);
+        }
+
+        private static GameObject CreateRaycastSurface(string name, Transform parent)
+        {
+            var surface = new GameObject(name, typeof(RectTransform), typeof(CanvasRenderer), typeof(Image));
+            surface.transform.SetParent(parent, false);
+            var rect = surface.GetComponent<RectTransform>();
+            rect.anchorMin = Vector2.zero;
+            rect.anchorMax = Vector2.one;
+            rect.offsetMin = Vector2.zero;
+            rect.offsetMax = Vector2.zero;
+            surface.GetComponent<Image>().raycastTarget = true;
+            return surface;
+        }
+
+        private IEnumerator SetMouseButton(MouseButton button, bool pressed, Vector2? position = null)
+        {
+            Vector2 screenPosition = position ?? new Vector2(100f, 100f);
+            MouseState state = new MouseState { position = screenPosition };
+            if (pressed)
+                state = state.WithButton(button);
+
+            InputSystem.QueueStateEvent(mouse, state);
+            yield return null;
+        }
+
         private static void SetField(object instance, string fieldName, object value)
         {
             FieldInfo field = instance.GetType().GetField(
@@ -170,6 +398,20 @@ namespace Castlebound.Tests.Input
                 BindingFlags.Instance | BindingFlags.NonPublic);
             Assert.NotNull(field);
             field.SetValue(instance, value);
+        }
+    }
+
+    public class PcControlModeTestInputModule : BaseInputModule
+    {
+        public bool PointerOverUi { get; set; }
+
+        public override void Process()
+        {
+        }
+
+        public override bool IsPointerOverGameObject(int pointerId)
+        {
+            return PointerOverUi;
         }
     }
 }

--- a/Assets/_Project/_Tests/PlayMode/Input/PcControlModePlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/Input/PcControlModePlayTests.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.InputSystem;
 using UnityEngine.InputSystem.LowLevel;
+using UnityEngine.InputSystem.Users;
 using UnityEngine.TestTools;
 using Castlebound.Gameplay.Combat;
 using Castlebound.Gameplay.Input;
@@ -20,14 +21,20 @@ namespace Castlebound.Tests.Input
         private GameObject attacker;
         private GameObject cameraObject;
         private GameObject eventSystemObject;
+        private Keyboard keyboard;
         private Mouse mouse;
         private PlayerControls inputActions;
         private PlayerInput playerInput;
         private PcControlModeTestInputModule pointerInputModule;
+        private InputSettings.BackgroundBehavior originalBackgroundBehavior;
 
         [UnitySetUp]
         public IEnumerator SetUp()
         {
+            originalBackgroundBehavior = InputSystem.settings.backgroundBehavior;
+            InputSystem.settings.backgroundBehavior = InputSettings.BackgroundBehavior.IgnoreFocus;
+
+            keyboard = InputSystem.AddDevice<Keyboard>();
             mouse = InputSystem.AddDevice<Mouse>();
             player = new GameObject("Player");
             player.SetActive(false);
@@ -53,6 +60,16 @@ namespace Castlebound.Tests.Input
             playerInput.defaultActionMap = "Player";
             player.SetActive(true);
             playerInput.ActivateInput();
+            InputUser.PerformPairingWithDevice(keyboard, playerInput.user);
+            InputUser.PerformPairingWithDevice(mouse, playerInput.user);
+
+            Assert.That(playerInput.currentActionMap, Is.Not.Null);
+            Assert.That(playerInput.currentActionMap.name, Is.EqualTo("Player"));
+            Assert.That(playerInput.currentActionMap.enabled, Is.True);
+            Assert.That(playerInput.currentActionMap.FindAction("Fire", true).enabled, Is.True);
+            Assert.That(playerInput.currentActionMap.FindAction("Defend", true).enabled, Is.True);
+            Assert.That(IsPairedWithPlayer(mouse), Is.True);
+            Assert.That(IsPairedWithPlayer(keyboard), Is.True);
 
             attacker = new GameObject("Attacker");
             cameraObject = new GameObject("Main Camera", typeof(Camera));
@@ -73,6 +90,8 @@ namespace Castlebound.Tests.Input
         {
             Cursor.lockState = CursorLockMode.None;
             Cursor.visible = true;
+            if (keyboard != null && keyboard.added)
+                InputSystem.RemoveDevice(keyboard);
             if (mouse != null && mouse.added)
                 InputSystem.RemoveDevice(mouse);
             Object.Destroy(player);
@@ -80,6 +99,7 @@ namespace Castlebound.Tests.Input
             Object.Destroy(cameraObject);
             Object.Destroy(eventSystemObject);
             inputActions?.Dispose();
+            InputSystem.settings.backgroundBehavior = originalBackgroundBehavior;
             yield return null;
         }
 
@@ -388,7 +408,19 @@ namespace Castlebound.Tests.Input
                 state = state.WithButton(button);
 
             InputSystem.QueueStateEvent(mouse, state);
+            InputSystem.Update();
             yield return null;
+        }
+
+        private bool IsPairedWithPlayer(InputDevice device)
+        {
+            foreach (InputDevice pairedDevice in playerInput.devices)
+            {
+                if (pairedDevice == device)
+                    return true;
+            }
+
+            return false;
         }
 
         private static void SetField(object instance, string fieldName, object value)

--- a/Assets/_Project/_Tests/PlayMode/Input/PcControlModePlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/Input/PcControlModePlayTests.cs
@@ -407,8 +407,14 @@ namespace Castlebound.Tests.Input
             if (pressed)
                 state = state.WithButton(button);
 
-            InputSystem.QueueStateEvent(mouse, state);
-            InputSystem.Update();
+            InputState.Change(mouse, state, InputUpdateType.Dynamic);
+
+            bool buttonIsPressed = button == MouseButton.Left
+                ? mouse.leftButton.isPressed
+                : mouse.rightButton.isPressed;
+            Assert.That(buttonIsPressed, Is.EqualTo(pressed),
+                "InputState.Change did not apply the expected synthetic mouse button state.");
+
             yield return null;
         }
 

--- a/Assets/_Project/_Tests/PlayMode/Input/PcControlModePlayTests.cs.meta
+++ b/Assets/_Project/_Tests/PlayMode/Input/PcControlModePlayTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f5b1ca4ea6bf40f992cf8b76a48cf794

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,23 @@
 
 ---
 
+## 2026-08-13 - fix-pr-293-headless-input-fixture
+
+### Summary
+- Made synthetic PC input independent of application focus during headless PlayMode execution.
+- Explicitly paired keyboard and mouse devices with the fixture PlayerInput and verified its Player action map.
+- Processed queued mouse events deterministically through the Input System action/callback path.
+
+### New or Updated Tests
+**EditMode**
+- N/A — N/A
+
+**PlayMode**
+- PcControlModePlayTests — deterministic PlayerInput mouse attack/defense callbacks in interactive and headless execution.
+
+### Notes
+- Full PlayMode suite passed and MainPrototype behavior remained correct — user-confirmed.
+
 ## 2026-08-13 - fix-pr-293-mouse-combat-and-pointer-facing
 
 ### Summary

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,25 @@
 
 ---
 
+## 2026-08-13 - fix-pr-293-mouse-combat-and-pointer-facing
+
+### Summary
+- Repaired PC mouse attack and defense delivery after gameplay/pointer-mode transitions without adding parallel combat polling.
+- Centralized transition-gate release once mouse buttons are physically released and kept UI pointer suppression authoritative.
+- Restricted immediate facing presentation to locked relative-mouse gameplay so pointer-mode WASD fallback uses existing smooth rotation.
+- Removed the upgrade menu's legacy global player pause and excluded mobile-only touch surfaces from desktop UI pointer ownership.
+- Made visible inventory and vault panel surfaces consume pointer clicks while leaving off-panel combat input available.
+
+### New or Updated Tests
+**EditMode**
+- PcControlModeTests and UI panel controller tests — direct gameplay presentation, pointer-mode smooth presentation, desktop hit-test filtering, and visible panel click ownership.
+
+**PlayMode**
+- PcControlModePlayTests — action-driven mouse combat, real upgrade-menu off-UI combat, desktop-versus-mobile UI raycasts, transition click-through prevention, and smooth pointer-mode WASD fallback.
+
+### Notes
+- Full suite and MainPrototype validation results pending.
+
 ## 2026-08-13 - feat-pc-relative-mouse-ui-pointer-modes
 
 ### Summary

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,23 @@
 
 ---
 
+## 2026-08-13 - feat-pc-relative-mouse-ui-pointer-modes
+
+### Summary
+- Promoted horizontal relative-mouse facing and locked gameplay cursor behavior into the production PC control path.
+- Added one control-mode owner for gameplay, pointer UI, cursor state, input suppression, and safe transitions.
+- Integrated backpack, vault, upgrade/start-wave, and Bear Trap placement while preserving world-relative movement, combat, dash, mobile, and gamepad contracts.
+
+### New or Updated Tests
+**EditMode**
+- PcControlModeTests and PlayerFacingOrchestratorTests — relative accumulation, persistent facing, vertical rejection, pointer priority, UI suppression policy, movement fallback, device isolation, cursor policy, transition contracts, prefab wiring, world-relative movement, and immediate presentation alignment.
+
+**PlayMode**
+- PcControlModePlayTests — independent world-relative movement and facing, dash regression, defense alignment, cursor lifecycle, and stale-delta transition prevention.
+
+### Notes
+- EditMode and PlayMode suites were not run at the user's request; the user will execute both suites and the MainPrototype behavior matrix manually.
+
 ## 2026-08-10 - feat-player-directional-combat-dash
 
 ### Summary

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,23 @@
 
 ---
 
+## 2026-08-14 - fix-pr-293-dynamic-input-state
+
+### Summary
+- Applied synthetic mouse state directly to the Dynamic input state so Editor updates cannot consume fixture events first.
+- Preserved the real InputAction, PlayerInput SendMessages, and production Fire/Defend callback integration path.
+- Removed temporary timing diagnostics and discarded InputTestFixture, pairing, and lifecycle experiments.
+
+### New or Updated Tests
+**EditMode**
+- N/A — N/A
+
+**PlayMode**
+- PcControlModePlayTests — deterministic synthetic mouse attack/defense input through Dynamic action processing.
+
+### Notes
+- Full local PlayMode suite passed — user-confirmed.
+
 ## 2026-08-13 - fix-pr-293-headless-input-fixture
 
 ### Summary

--- a/ci/run-windows-build.ps1
+++ b/ci/run-windows-build.ps1
@@ -1,0 +1,83 @@
+$ErrorActionPreference = "Stop"
+
+function Step($message) { Write-Host "[CI] $message" }
+
+if ([string]::IsNullOrWhiteSpace($env:UNITY_EDITOR)) {
+  $env:UNITY_EDITOR = "D:\Program Files\Unity\Hub\Editor\2022.3.62f2\Editor\Unity.exe"
+}
+if (-not (Test-Path -LiteralPath $env:UNITY_EDITOR)) {
+  throw "UNITY_EDITOR not found at '$env:UNITY_EDITOR'. Set UNITY_EDITOR or update the fallback path."
+}
+
+$workspace = [IO.Path]::GetFullPath((Get-Location).Path)
+$buildRoot = [IO.Path]::GetFullPath((Join-Path $workspace "build\Windows"))
+$outputDirectory = Join-Path $buildRoot "Castlebound"
+$executablePath = Join-Path $outputDirectory "Castlebound.exe"
+$dataDirectory = Join-Path $outputDirectory "Castlebound_Data"
+$logPath = Join-Path $workspace "build\WindowsBuildLog.txt"
+$workspacePrefix = $workspace.TrimEnd('\') + '\'
+
+if (-not $buildRoot.StartsWith($workspacePrefix, [StringComparison]::OrdinalIgnoreCase)) {
+  throw "Refusing to clean Windows build path outside workspace: '$buildRoot'"
+}
+
+if (Test-Path -LiteralPath $buildRoot) {
+  Remove-Item -LiteralPath $buildRoot -Recurse -Force
+}
+New-Item -ItemType Directory -Force -Path $outputDirectory | Out-Null
+if (Test-Path -LiteralPath $logPath) {
+  Remove-Item -LiteralPath $logPath -Force
+}
+
+$env:CB_WINDOWS_BUILD_DIR = $outputDirectory
+
+Step "Workspace : $workspace"
+Step "Output    : $outputDirectory"
+Step "Log Path  : $logPath"
+Step "Unity     : $env:UNITY_EDITOR"
+
+$arguments = @(
+  '-batchmode', '-nographics',
+  '-buildTarget', 'StandaloneWindows64',
+  '-projectPath', $workspace,
+  '-executeMethod', 'CI.WindowsCiBuildRunner.Run',
+  '-logFile', $logPath
+)
+
+$scriptAssemblies = Join-Path $workspace "Library\ScriptAssemblies"
+if (Test-Path -LiteralPath $scriptAssemblies) {
+  Remove-Item -LiteralPath $scriptAssemblies -Recurse -Force
+  Step "Cleared Library/ScriptAssemblies to force script recompile from source"
+}
+
+$artifactDatabase = Join-Path $workspace "Library\ArtifactDB"
+if (Test-Path -LiteralPath $artifactDatabase) {
+  Remove-Item -LiteralPath $artifactDatabase -Force
+  Step "Deleted Library/ArtifactDB to force Library rebuild"
+}
+
+Step "Launching Unity..."
+$process = Start-Process -FilePath $env:UNITY_EDITOR -ArgumentList $arguments -Wait -PassThru -NoNewWindow
+$unityCode = $process.ExitCode
+Step "Unity exited with code: $unityCode"
+
+if ($unityCode -ne 0) {
+  Write-Error "Unity Windows build failed with exit code $unityCode"
+  if (Test-Path -LiteralPath $logPath) { Get-Content -LiteralPath $logPath -Tail 300 }
+  exit $unityCode
+}
+
+if (-not (Test-Path -LiteralPath $executablePath -PathType Leaf)) {
+  Write-Error "Expected Windows executable not found at '$executablePath'"
+  if (Test-Path -LiteralPath $logPath) { Get-Content -LiteralPath $logPath -Tail 300 }
+  exit 2
+}
+
+if (-not (Test-Path -LiteralPath $dataDirectory -PathType Container)) {
+  Write-Error "Expected Windows data directory not found at '$dataDirectory'"
+  if (Test-Path -LiteralPath $logPath) { Get-Content -LiteralPath $logPath -Tail 300 }
+  exit 3
+}
+
+Step "Windows player build completed successfully."
+exit 0


### PR DESCRIPTION
## Why
Desktop gameplay still depends on maintaining an absolute battlefield cursor, which adds avoidable attention and hand-position overhead. This productionizes the selected relative-mouse PC control model while retaining safe pointer interaction for combat-capable UI states.

Hands-on MainPrototype validation also exposed two blockers that the initial automated coverage missed: mouse attack/defense could remain suppressed after control-mode transitions, and pointer-mode WASD fallback snapped instead of using the existing smooth facing presentation. A further runtime pass found that menu combat was blocked by the upgrade menu's legacy player pause and desktop UI hit testing treated full-screen mobile touch surfaces as UI.

## What changed
- Added one PC control-mode owner for gameplay versus pointer mode, cursor lock/visibility, desktop UI hit testing, click-through suppression, input-device handoff, and transition safety.
- Promoted horizontal relative mouse accumulation into a production facing component with persistent facing and a tunable 0.35 default sensitivity.
- Kept WASD and directional dash world-relative, retained the established neutral backward-dodge facing contract, and kept facing execution in the existing facing orchestrator.
- Added pointer-mode priority for UI ownership, off-UI absolute-pointer combat aim, movement-facing fallback, and neutral facing retention.
- Repaired mouse attack/defense action delivery by clearing transition suppression centrally after physical button release without adding parallel combat polling.
- Preserved pointer-over-UI combat suppression while allowing off-UI pointer attack/defense aim.
- Restricted immediate facing presentation to locked relative-mouse gameplay so pointer-mode movement fallback continues through the smooth facing orchestrator.
- Removed the upgrade menu's legacy global player-input pause, ignored mobile-only touch surfaces during desktop UI hit testing, and made visible inventory/vault panel surfaces consume clicks without blocking off-panel combat.
- Integrated backpack (Tab), vault, upgrade/start-wave, and Bear Trap placement/confirm/cancel flows with the centralized pointer owner.
- Stabilized PlayMode mouse-action coverage by explicitly pairing synthetic PC devices, ignoring runner focus, and applying synthetic mouse state directly to the Dynamic input state with `InputState.Change`. This prevents Editor-update consumption while retaining the real InputAction → PlayerInput → SendMessages integration path.
- Added an opt-in `pc-build` PR workflow that produces a complete unofficial Windows x86_64 player as the `windows-pc-build` artifact for 14 days.
- Removed prototype flags, rejected body-relative behavior, and obsolete prototype-only naming and branches.

## How to test
1. Open `Assets/_Project/Scenes/MainPrototype.unity` and enter Play Mode on desktop.
2. Verify normal gameplay: world-relative WASD, horizontal relative-mouse facing, persistent facing, ignored vertical mouse movement, held/released left-click attacks, held/released right-click defense, directional dash, neutral backward dodge, and locked/hidden cursor.
3. Press Tab during a wave to open the backpack; verify clicks on visible UI do not attack/block, off-panel attack/block aims at the pointer, movement supplies smooth fallback facing, and closing returns without snap, stale delta, or click-through.
4. Exercise pre-wave/start-wave, upgrade, vault, and Bear Trap placement/confirm/cancel flows; verify visible panel surfaces own clicks while off-panel combat remains available, then repeat transitions rapidly.
5. Validation completed by the user:
   - EditMode: full suite passed — user-confirmed
   - PlayMode: full suite passed — user-confirmed
   - MainPrototype manual behavior validation: passed — user-confirmed
6. For an unofficial Windows player, wait for the labeled Windows workflow to finish, download the `windows-pc-build` artifact, extract the complete archive, and run `Castlebound.exe` beside `Castlebound_Data` and the included runtime files.

## Checklist
- [x] Unit tests (EditMode) added or updated and full suite passed — user-confirmed
- [x] PlayMode coverage added and full suite passed — user-confirmed
- [x] Demo scene updated (serialized legacy upgrade-menu pause fields removed)
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched (TEST_LOG updated)

## Related
- Closes #292
