### PR TITLE
fix(player): prevent sticking against solid colliders

### DIFF
--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Movement/PlayerCollisionMove2D.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Movement/PlayerCollisionMove2D.cs
@@ -1,19 +1,27 @@
 using UnityEngine;
 
 [RequireComponent(typeof(Rigidbody2D))]
-[RequireComponent(typeof(Collider2D))]
+[RequireComponent(typeof(CircleCollider2D))]
 [DefaultExecutionOrder(100)]
 public class PlayerCollisionMove2D : MonoBehaviour
 {
+    private const int MaxSlideIterations = 4;
+    private const int HitCapacity = 24;
+    private const int ContactNormalCapacity = 8;
+    private const float MinDisplacement = 0.00001f;
+    private const float ContactMergeDistance = 0.001f;
+
     [SerializeField] private float moveSpeed = 6f;
     [SerializeField] private LayerMask solidMask;
     [SerializeField] private float skin = 0.02f;
 
     private Rigidbody2D _rb;
-    private Collider2D _col;
+    private CircleCollider2D _col;
     private Vector2 _input;
     private Vector2 _velocityOverride;
     private bool _useVelocityOverride;
+    private Vector2 _previousCenterOffset;
+    private bool _hasPreviousCenterOffset;
 
     public float MoveSpeed
     {
@@ -21,8 +29,8 @@ public class PlayerCollisionMove2D : MonoBehaviour
         set => moveSpeed = Mathf.Max(0f, value);
     }
 
-    // Reused, no per-frame allocations
-    private static readonly RaycastHit2D[] sHits = new RaycastHit2D[8];
+    private readonly RaycastHit2D[] _hits = new RaycastHit2D[HitCapacity];
+    private readonly Vector2[] _contactNormals = new Vector2[ContactNormalCapacity];
 
     public void SetMoveInput(Vector2 input)
     {
@@ -41,10 +49,12 @@ public class PlayerCollisionMove2D : MonoBehaviour
     private void Awake()
     {
         _rb = GetComponent<Rigidbody2D>();
-        _col = GetComponent<Collider2D>();
+        _col = GetComponent<CircleCollider2D>();
 
         if (_rb != null && _rb.bodyType != RigidbodyType2D.Kinematic)
             _rb.bodyType = RigidbodyType2D.Kinematic;
+
+        RefreshCenterOffset();
     }
 
     private void Reset()
@@ -62,49 +72,148 @@ public class PlayerCollisionMove2D : MonoBehaviour
             ? _velocityOverride * dt
             : _input * moveSpeed * dt;
 
-        // Prepare filter (stack struct, no allocation)
         ContactFilter2D filter = new ContactFilter2D();
         filter.useLayerMask = true;
         filter.layerMask = solidMask;
         filter.useTriggers = false;
 
-        Vector2 pos = _rb.position;
-
-        // X pass
-        float dx = 0f;
-        float ax = Mathf.Abs(delta.x);
-        if (ax > 0f)
+        Vector2 currentCenterOffset = GetCurrentCenterOffset();
+        if (!_hasPreviousCenterOffset)
         {
-            float signX = delta.x > 0f ? 1f : -1f;
-            Vector2 dirX = new Vector2(signX, 0f);
-            int countX = _col.Cast(dirX, filter, sHits, ax + skin);
-            float allowX = ax;
-            for (int i = 0; i < countX; i++)
-            {
-                float d = sHits[i].distance - skin;
-                if (d < allowX) allowX = d < 0f ? 0f : d;
-            }
-            dx = signX * allowX;
+            _previousCenterOffset = currentCenterOffset;
+            _hasPreviousCenterOffset = true;
         }
 
-        // Y pass
-        float dy = 0f;
-        float ay = Mathf.Abs(delta.y);
-        if (ay > 0f)
+        Vector2 startCenter = _rb.position + _previousCenterOffset;
+        Vector2 requestedCenterDisplacement = delta + currentCenterOffset - _previousCenterOffset;
+        float worldRadius = PlayerSweepSlideMath.GetWorldRadius(_col.radius, transform.lossyScale);
+        Vector2 resolvedCenterDisplacement = ResolveCenterDisplacement(
+            startCenter,
+            worldRadius,
+            requestedCenterDisplacement,
+            filter);
+
+        Vector2 resolvedBodyPosition = startCenter + resolvedCenterDisplacement - currentCenterOffset;
+        _rb.MovePosition(resolvedBodyPosition);
+        _previousCenterOffset = currentCenterOffset;
+    }
+
+    private Vector2 ResolveCenterDisplacement(
+        Vector2 startCenter,
+        float radius,
+        Vector2 requestedDisplacement,
+        ContactFilter2D filter)
+    {
+        Vector2 resolved = Vector2.zero;
+        Vector2 remaining = requestedDisplacement;
+        Vector2 virtualCenter = startCenter;
+        float effectiveSkin = Mathf.Max(0f, skin);
+
+        for (int iteration = 0; iteration < MaxSlideIterations; iteration++)
         {
-            float signY = delta.y > 0f ? 1f : -1f;
-            Vector2 dirY = new Vector2(0f, signY);
-            int countY = _col.Cast(dirY, filter, sHits, ay + skin);
-            float allowY = ay;
-            for (int i = 0; i < countY; i++)
+            float distance = remaining.magnitude;
+            if (distance <= MinDisplacement)
             {
-                float d = sHits[i].distance - skin;
-                if (d < allowY) allowY = d < 0f ? 0f : d;
+                break;
             }
-            dy = signY * allowY;
+
+            Vector2 direction = remaining / distance;
+            int hitCount = Physics2D.CircleCast(
+                virtualCenter,
+                radius,
+                direction,
+                filter,
+                _hits,
+                distance + effectiveSkin);
+
+            float nearestDistance = float.PositiveInfinity;
+            for (int i = 0; i < hitCount; i++)
+            {
+                RaycastHit2D hit = _hits[i];
+                if (!IsBlockingHit(hit))
+                {
+                    continue;
+                }
+
+                nearestDistance = Mathf.Min(nearestDistance, Mathf.Max(0f, hit.distance));
+            }
+
+            if (float.IsPositiveInfinity(nearestDistance))
+            {
+                resolved += remaining;
+                break;
+            }
+
+            int normalCount = 0;
+            float contactLimit = nearestDistance + ContactMergeDistance;
+            for (int i = 0; i < hitCount; i++)
+            {
+                RaycastHit2D hit = _hits[i];
+                if (!IsBlockingHit(hit) || hit.distance > contactLimit)
+                {
+                    continue;
+                }
+
+                PlayerSweepSlideMath.AddSortedUniqueNormal(
+                    _contactNormals,
+                    ref normalCount,
+                    hit.normal);
+            }
+
+            float travelDistance = PlayerSweepSlideMath.GetAllowedTravelDistance(
+                nearestDistance,
+                distance,
+                effectiveSkin,
+                direction,
+                _contactNormals,
+                normalCount);
+            Vector2 advance = direction * travelDistance;
+            resolved += advance;
+            virtualCenter += advance;
+
+            Vector2 untraveled = remaining - advance;
+            Vector2 clipped = PlayerSweepSlideMath.ClipAgainstNormals(
+                untraveled,
+                _contactNormals,
+                normalCount);
+            if (clipped.sqrMagnitude <= MinDisplacement * MinDisplacement)
+            {
+                break;
+            }
+
+            if (travelDistance <= MinDisplacement &&
+                (clipped - remaining).sqrMagnitude <= MinDisplacement * MinDisplacement)
+            {
+                break;
+            }
+
+            remaining = clipped;
         }
 
-        // Apply final clamped move
-        _rb.MovePosition(pos + new Vector2(dx, dy));
+        return resolved;
+    }
+
+    private bool IsBlockingHit(RaycastHit2D hit)
+    {
+        return hit.collider != null && hit.rigidbody != _rb;
+    }
+
+    private Vector2 GetCurrentCenterOffset()
+    {
+        return PlayerSweepSlideMath.GetWorldCenterOffset(
+            _col.offset,
+            transform.lossyScale,
+            transform.eulerAngles.z);
+    }
+
+    private void RefreshCenterOffset()
+    {
+        if (_col == null)
+        {
+            return;
+        }
+
+        _previousCenterOffset = GetCurrentCenterOffset();
+        _hasPreviousCenterOffset = true;
     }
 }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Movement/PlayerSweepSlideMath.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Movement/PlayerSweepSlideMath.cs
@@ -1,0 +1,128 @@
+using UnityEngine;
+
+public static class PlayerSweepSlideMath
+{
+    private const float NormalDuplicateDot = 0.9999f;
+    private const float MinApproach = 0.0001f;
+
+    public static Vector2 GetWorldCenterOffset(
+        Vector2 colliderOffset,
+        Vector3 lossyScale,
+        float rotationDegrees)
+    {
+        Vector2 scaledOffset = new Vector2(
+            colliderOffset.x * lossyScale.x,
+            colliderOffset.y * lossyScale.y);
+        float radians = rotationDegrees * Mathf.Deg2Rad;
+        float sin = Mathf.Sin(radians);
+        float cos = Mathf.Cos(radians);
+
+        return new Vector2(
+            scaledOffset.x * cos - scaledOffset.y * sin,
+            scaledOffset.x * sin + scaledOffset.y * cos);
+    }
+
+    public static float GetWorldRadius(float colliderRadius, Vector3 lossyScale)
+    {
+        float largestAxis = Mathf.Max(Mathf.Abs(lossyScale.x), Mathf.Abs(lossyScale.y));
+        return Mathf.Max(0f, colliderRadius) * largestAxis;
+    }
+
+    public static void AddSortedUniqueNormal(Vector2[] normals, ref int count, Vector2 normal)
+    {
+        if (normals == null || count >= normals.Length || normal.sqrMagnitude <= Mathf.Epsilon)
+        {
+            return;
+        }
+
+        normal.Normalize();
+        for (int i = 0; i < count; i++)
+        {
+            if (Vector2.Dot(normals[i], normal) >= NormalDuplicateDot)
+            {
+                return;
+            }
+        }
+
+        float angle = Mathf.Atan2(normal.y, normal.x);
+        int insertIndex = count;
+        while (insertIndex > 0)
+        {
+            Vector2 previous = normals[insertIndex - 1];
+            float previousAngle = Mathf.Atan2(previous.y, previous.x);
+            if (previousAngle <= angle)
+            {
+                break;
+            }
+
+            normals[insertIndex] = previous;
+            insertIndex--;
+        }
+
+        normals[insertIndex] = normal;
+        count++;
+    }
+
+    public static Vector2 ClipAgainstNormals(Vector2 displacement, Vector2[] normals, int count)
+    {
+        if (normals == null || count <= 0)
+        {
+            return displacement;
+        }
+
+        Vector2 clipped = displacement;
+        int validCount = Mathf.Min(count, normals.Length);
+
+        // Revisit earlier constraints after each projection. In 2D this converges quickly,
+        // and the angle-sorted input keeps the result deterministic at corners.
+        for (int pass = 0; pass < validCount; pass++)
+        {
+            bool changed = false;
+            for (int i = 0; i < validCount; i++)
+            {
+                float inward = Vector2.Dot(clipped, normals[i]);
+                if (inward >= 0f)
+                {
+                    continue;
+                }
+
+                clipped -= normals[i] * inward;
+                changed = true;
+            }
+
+            if (!changed)
+            {
+                break;
+            }
+        }
+
+        return clipped;
+    }
+
+    public static float GetAllowedTravelDistance(
+        float contactDistance,
+        float requestedDistance,
+        float skin,
+        Vector2 direction,
+        Vector2[] normals,
+        int count)
+    {
+        float retreatDistance = 0f;
+        int validCount = normals == null ? 0 : Mathf.Min(count, normals.Length);
+        for (int i = 0; i < validCount; i++)
+        {
+            float approach = -Vector2.Dot(direction, normals[i]);
+            if (approach > MinApproach)
+            {
+                retreatDistance = Mathf.Max(retreatDistance, skin / approach);
+            }
+        }
+
+        if (validCount == 0)
+        {
+            retreatDistance = skin;
+        }
+
+        return Mathf.Clamp(contactDistance - retreatDistance, 0f, requestedDistance);
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Movement/PlayerSweepSlideMath.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Movement/PlayerSweepSlideMath.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e9ef7a9b13354db8a6f43d8bf4bda67b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/_Tests/EditMode/Balance/PlayerBalanceApplierTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Balance/PlayerBalanceApplierTests.cs
@@ -17,7 +17,7 @@ namespace Castlebound.Tests.Balance
             try
             {
                 player.AddComponent<Rigidbody2D>();
-                player.AddComponent<BoxCollider2D>();
+                player.AddComponent<CircleCollider2D>();
                 var health = player.AddComponent<Health>();
                 var mover = player.AddComponent<PlayerCollisionMove2D>();
                 var controller = player.AddComponent<PlayerController>();
@@ -56,7 +56,7 @@ namespace Castlebound.Tests.Balance
             try
             {
                 player.AddComponent<Rigidbody2D>();
-                player.AddComponent<BoxCollider2D>();
+                player.AddComponent<CircleCollider2D>();
                 var health = player.AddComponent<Health>();
                 var mover = player.AddComponent<PlayerCollisionMove2D>();
                 var controller = player.AddComponent<PlayerController>();

--- a/Assets/_Project/_Tests/EditMode/Player/PlayerSweepSlideMathTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Player/PlayerSweepSlideMathTests.cs
@@ -1,0 +1,122 @@
+using System;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Castlebound.Tests.Player
+{
+    public class PlayerSweepSlideMathTests
+    {
+        [Test]
+        public void GetWorldCenterOffset_AppliesScaleAndRotation()
+        {
+            Vector2 result = PlayerSweepSlideMath.GetWorldCenterOffset(
+                new Vector2(0.25f, -0.5f),
+                new Vector3(2f, 3f, 1f),
+                90f);
+
+            Assert.That(result.x, Is.EqualTo(1.5f).Within(0.0001f));
+            Assert.That(result.y, Is.EqualTo(0.5f).Within(0.0001f));
+        }
+
+        [Test]
+        public void GetWorldRadius_UsesLargestAbsoluteScaleAxis()
+        {
+            float radius = PlayerSweepSlideMath.GetWorldRadius(
+                0.4f,
+                new Vector3(-2f, 3f, 1f));
+
+            Assert.That(radius, Is.EqualTo(1.2f).Within(0.0001f));
+        }
+
+        [Test]
+        public void ClipAgainstNormals_RemovesOnlyInwardMotion()
+        {
+            var normals = new Vector2[2];
+            int count = 0;
+            PlayerSweepSlideMath.AddSortedUniqueNormal(normals, ref count, Vector2.left);
+
+            Vector2 clipped = PlayerSweepSlideMath.ClipAgainstNormals(
+                new Vector2(2f, 3f),
+                normals,
+                count);
+
+            Assert.That(clipped.x, Is.EqualTo(0f).Within(0.0001f));
+            Assert.That(clipped.y, Is.EqualTo(3f).Within(0.0001f));
+        }
+
+        [Test]
+        public void ClipAgainstNormals_InsideCornerIsDeterministicAcrossInputOrder()
+        {
+            Vector2 first = ResolveCorner(Vector2.left, Vector2.down);
+            Vector2 reversed = ResolveCorner(Vector2.down, Vector2.left);
+
+            Assert.That(first.sqrMagnitude, Is.LessThan(0.000001f));
+            Assert.That(reversed, Is.EqualTo(first));
+        }
+
+        [Test]
+        public void GetAllowedTravelDistance_DiagonalContactReservesSkinAlongNormal()
+        {
+            var normals = new Vector2[1];
+            int count = 0;
+            PlayerSweepSlideMath.AddSortedUniqueNormal(normals, ref count, Vector2.left);
+            Vector2 direction = Vector2.one.normalized;
+            float contactDistance = 0.25f / direction.x;
+
+            float travel = PlayerSweepSlideMath.GetAllowedTravelDistance(
+                contactDistance,
+                1f,
+                0.02f,
+                direction,
+                normals,
+                count);
+
+            Assert.That(travel * direction.x, Is.EqualTo(0.23f).Within(0.0001f));
+        }
+
+        [Test]
+        public void RepeatedGeometryAndClipping_PerformsWithoutManagedAllocations()
+        {
+            var normals = new Vector2[4];
+            RunRepeatedMath(normals, 8);
+            long before = GC.GetAllocatedBytesForCurrentThread();
+
+            RunRepeatedMath(normals, 1024);
+
+            long after = GC.GetAllocatedBytesForCurrentThread();
+            Assert.That(after - before, Is.Zero);
+        }
+
+        private static Vector2 ResolveCorner(Vector2 firstNormal, Vector2 secondNormal)
+        {
+            var normals = new Vector2[2];
+            int count = 0;
+            PlayerSweepSlideMath.AddSortedUniqueNormal(normals, ref count, firstNormal);
+            PlayerSweepSlideMath.AddSortedUniqueNormal(normals, ref count, secondNormal);
+            return PlayerSweepSlideMath.ClipAgainstNormals(Vector2.one, normals, count);
+        }
+
+        private static void RunRepeatedMath(Vector2[] normals, int iterations)
+        {
+            for (int i = 0; i < iterations; i++)
+            {
+                int count = 0;
+                PlayerSweepSlideMath.AddSortedUniqueNormal(normals, ref count, Vector2.left);
+                PlayerSweepSlideMath.AddSortedUniqueNormal(normals, ref count, Vector2.down);
+                PlayerSweepSlideMath.ClipAgainstNormals(Vector2.one, normals, count);
+                PlayerSweepSlideMath.GetAllowedTravelDistance(
+                    1f,
+                    1f,
+                    0.02f,
+                    Vector2.one.normalized,
+                    normals,
+                    count);
+                PlayerSweepSlideMath.GetWorldCenterOffset(
+                    new Vector2(0.1f, -0.2f),
+                    new Vector3(1.5f, 0.75f, 1f),
+                    i % 360);
+                PlayerSweepSlideMath.GetWorldRadius(0.5f, new Vector3(1.5f, 0.75f, 1f));
+            }
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/Player/PlayerSweepSlideMathTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/Player/PlayerSweepSlideMathTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0cd0e48c9e7c410a937726039914454a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/_Tests/PlayMode/Input/PcControlModePlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/Input/PcControlModePlayTests.cs
@@ -41,7 +41,7 @@ namespace Castlebound.Tests.Input
             player.tag = "Player";
             var body = player.AddComponent<Rigidbody2D>();
             body.gravityScale = 0f;
-            player.AddComponent<BoxCollider2D>();
+            player.AddComponent<CircleCollider2D>();
             player.AddComponent<PlayerCollisionMove2D>();
             var relativeFacing = player.AddComponent<PlayerRelativeMouseFacingController>();
             relativeFacing.Configure(1f);

--- a/Assets/_Project/_Tests/PlayMode/Player/PlayerCollisionMove2DPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/Player/PlayerCollisionMove2DPlayTests.cs
@@ -1,0 +1,300 @@
+using System.Collections;
+using System.Reflection;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Castlebound.Tests.PlayMode.Player
+{
+    public class PlayerCollisionMove2DPlayTests
+    {
+        private const float PlayerRadius = 0.25f;
+
+        [UnityTest]
+        public IEnumerator DiagonalEntryIntoIsolatedCorner_DoesNotOverlapOrTunnel()
+        {
+            int wallsLayer = LayerMask.NameToLayer("Walls");
+            GameObject player = CreatePlayer(Vector2.zero, 1 << wallsLayer, Vector2.zero, out PlayerCollisionMove2D mover);
+            BoxCollider2D corner = CreateBox("IsolatedCorner", wallsLayer, new Vector2(0.65f, 0.65f), new Vector2(0.4f, 0.4f));
+
+            try
+            {
+                mover.MoveSpeed = 30f;
+                mover.SetMoveInput(Vector2.one);
+                yield return WaitFixedSteps(2);
+
+                AssertNotOverlapped(player, corner);
+                Assert.That(player.transform.position.x, Is.LessThan(0.4f));
+                Assert.That(player.transform.position.y, Is.LessThan(0.4f));
+            }
+            finally
+            {
+                Object.Destroy(corner.gameObject);
+                Object.Destroy(player);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator BarrierStraightEdge_SustainedDiagonalInputSlidesAndChangedInputReleases()
+        {
+            int barriersLayer = LayerMask.NameToLayer("Barriers");
+            GameObject player = CreatePlayer(Vector2.zero, 1 << barriersLayer, Vector2.zero, out PlayerCollisionMove2D mover);
+            BoxCollider2D barrier = CreateBox("Barrier", barriersLayer, new Vector2(0.75f, 0f), new Vector2(0.5f, 20f));
+
+            try
+            {
+                mover.SetMoveInput(Vector2.one);
+                yield return WaitFixedSteps(12);
+
+                AssertNotOverlapped(player, barrier);
+                Assert.That(player.transform.position.x, Is.LessThanOrEqualTo(0.24f));
+                Assert.That(player.transform.position.y, Is.GreaterThan(1f));
+
+                float contactX = player.transform.position.x;
+                mover.SetMoveInput(Vector2.left);
+                yield return WaitFixedSteps(2);
+
+                Assert.That(player.transform.position.x, Is.LessThan(contactX - 0.1f));
+                AssertNotOverlapped(player, barrier);
+            }
+            finally
+            {
+                Object.Destroy(barrier.gameObject);
+                Object.Destroy(player);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator TwoWallInsideCorner_SustainedInputStopsDeterministicallyWithoutOverlap()
+        {
+            int wallsLayer = LayerMask.NameToLayer("Walls");
+            GameObject player = CreatePlayer(Vector2.zero, 1 << wallsLayer, Vector2.zero, out PlayerCollisionMove2D mover);
+            BoxCollider2D vertical = CreateBox("VerticalWall", wallsLayer, new Vector2(0.75f, 0f), new Vector2(0.5f, 4f));
+            BoxCollider2D horizontal = CreateBox("HorizontalWall", wallsLayer, new Vector2(0f, 0.75f), new Vector2(4f, 0.5f));
+
+            try
+            {
+                mover.SetMoveInput(Vector2.one);
+                yield return WaitFixedSteps(8);
+                Vector2 settled = player.transform.position;
+                yield return WaitFixedSteps(8);
+
+                AssertNotOverlapped(player, vertical);
+                AssertNotOverlapped(player, horizontal);
+                Assert.That(Vector2.Distance(player.transform.position, settled), Is.LessThan(0.001f));
+            }
+            finally
+            {
+                Object.Destroy(vertical.gameObject);
+                Object.Destroy(horizontal.gameObject);
+                Object.Destroy(player);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator SlopedRotatedBlocker_UsesContactNormalForTangentialMotion()
+        {
+            int wallsLayer = LayerMask.NameToLayer("Walls");
+            GameObject player = CreatePlayer(Vector2.zero, 1 << wallsLayer, Vector2.zero, out PlayerCollisionMove2D mover);
+            BoxCollider2D slope = CreateBox(
+                "SlopedBlocker",
+                wallsLayer,
+                new Vector2(0.85f, 0.45f),
+                new Vector2(0.3f, 1.4f),
+                -30f);
+
+            try
+            {
+                mover.SetMoveInput(Vector2.right);
+                yield return WaitFixedSteps(12);
+
+                AssertNotOverlapped(player, slope);
+                Assert.That(Mathf.Abs(player.transform.position.y), Is.GreaterThan(0.05f));
+            }
+            finally
+            {
+                Object.Destroy(slope.gameObject);
+                Object.Destroy(player);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator BarrierCornerAndSeam_RemainBlockingDuringSustainedSlide()
+        {
+            int barriersLayer = LayerMask.NameToLayer("Barriers");
+            GameObject player = CreatePlayer(new Vector2(0f, -0.7f), 1 << barriersLayer, Vector2.zero, out PlayerCollisionMove2D mover);
+            BoxCollider2D lower = CreateBox("BarrierLower", barriersLayer, new Vector2(0.75f, -2f), new Vector2(0.5f, 4f));
+            BoxCollider2D upper = CreateBox("BarrierUpper", barriersLayer, new Vector2(0.75f, 2f), new Vector2(0.5f, 4f));
+
+            try
+            {
+                mover.SetMoveInput(Vector2.one);
+                yield return WaitFixedSteps(18);
+
+                AssertNotOverlapped(player, lower);
+                AssertNotOverlapped(player, upper);
+                Assert.That(player.transform.position.x, Is.LessThanOrEqualTo(0.24f));
+                Assert.That(player.transform.position.y, Is.GreaterThan(1f));
+            }
+            finally
+            {
+                Object.Destroy(lower.gameObject);
+                Object.Destroy(upper.gameObject);
+                Object.Destroy(player);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator VaultEdge_BlocksSustainedInputWithoutOverlap()
+        {
+            int wallsLayer = LayerMask.NameToLayer("Walls");
+            GameObject player = CreatePlayer(new Vector2(0f, 0.7f), 1 << wallsLayer, Vector2.zero, out PlayerCollisionMove2D mover);
+            BoxCollider2D vault = CreateVault(wallsLayer, new Vector2(0.9f, 0.7f));
+
+            try
+            {
+                mover.SetMoveInput(Vector2.right);
+                yield return WaitFixedSteps(20);
+
+                AssertNotOverlapped(player, vault);
+                Assert.That(player.transform.position.x, Is.LessThanOrEqualTo(0.34f));
+            }
+            finally
+            {
+                Object.Destroy(vault.gameObject);
+                Object.Destroy(player);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator VaultCorner_DiagonalApproachCannotEnterCollider()
+        {
+            int wallsLayer = LayerMask.NameToLayer("Walls");
+            GameObject player = CreatePlayer(Vector2.zero, 1 << wallsLayer, Vector2.zero, out PlayerCollisionMove2D mover);
+            BoxCollider2D vault = CreateVault(wallsLayer, new Vector2(0.9f, 0.7f));
+
+            try
+            {
+                mover.SetMoveInput(Vector2.one);
+                yield return WaitFixedSteps(20);
+
+                AssertNotOverlapped(player, vault);
+            }
+            finally
+            {
+                Object.Destroy(vault.gameObject);
+                Object.Destroy(player);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator RapidFacingRotationAtWall_SweepsOffsetCenterAndRemainsRecoverable()
+        {
+            int wallsLayer = LayerMask.NameToLayer("Walls");
+            GameObject player = CreatePlayer(Vector2.zero, 1 << wallsLayer, new Vector2(0f, -0.15f), out PlayerCollisionMove2D mover);
+            BoxCollider2D wall = CreateBox("Wall", wallsLayer, new Vector2(0.75f, 0f), new Vector2(0.5f, 4f));
+
+            try
+            {
+                mover.SetMoveInput(Vector2.right);
+                yield return WaitFixedSteps(6);
+
+                for (int i = 0; i < 12; i++)
+                {
+                    player.transform.rotation = Quaternion.Euler(0f, 0f, i * 90f);
+                    yield return new WaitForFixedUpdate();
+                    AssertNotOverlapped(player, wall);
+                }
+
+                float contactX = player.transform.position.x;
+                mover.SetMoveInput(Vector2.left);
+                yield return WaitFixedSteps(2);
+
+                Assert.That(player.transform.position.x, Is.LessThan(contactX - 0.1f));
+                AssertNotOverlapped(player, wall);
+            }
+            finally
+            {
+                Object.Destroy(wall.gameObject);
+                Object.Destroy(player);
+            }
+        }
+
+        private static GameObject CreatePlayer(
+            Vector2 position,
+            int solidMask,
+            Vector2 colliderOffset,
+            out PlayerCollisionMove2D mover)
+        {
+            var player = new GameObject("Player");
+            player.tag = "Player";
+            player.layer = LayerMask.NameToLayer("Player");
+            player.transform.position = position;
+            var body = player.AddComponent<Rigidbody2D>();
+            body.bodyType = RigidbodyType2D.Kinematic;
+            body.gravityScale = 0f;
+            body.collisionDetectionMode = CollisionDetectionMode2D.Continuous;
+            var collider = player.AddComponent<CircleCollider2D>();
+            collider.radius = PlayerRadius;
+            collider.offset = colliderOffset;
+            mover = player.AddComponent<PlayerCollisionMove2D>();
+            mover.MoveSpeed = 12f;
+            SetField(mover, "solidMask", (LayerMask)solidMask);
+            Physics2D.SyncTransforms();
+            return player;
+        }
+
+        private static BoxCollider2D CreateVault(int layer, Vector2 position)
+        {
+            BoxCollider2D vault = CreateBox("Vault", layer, position, new Vector2(1.1f, 0.9f));
+            vault.edgeRadius = 0.06f;
+            return vault;
+        }
+
+        private static BoxCollider2D CreateBox(
+            string name,
+            int layer,
+            Vector2 position,
+            Vector2 size,
+            float rotation = 0f)
+        {
+            var gameObject = new GameObject(name);
+            gameObject.layer = layer;
+            gameObject.transform.SetPositionAndRotation(position, Quaternion.Euler(0f, 0f, rotation));
+            var collider = gameObject.AddComponent<BoxCollider2D>();
+            collider.size = size;
+            Physics2D.SyncTransforms();
+            return collider;
+        }
+
+        private static IEnumerator WaitFixedSteps(int count)
+        {
+            for (int i = 0; i < count; i++)
+            {
+                yield return new WaitForFixedUpdate();
+            }
+        }
+
+        private static void AssertNotOverlapped(GameObject player, Collider2D blocker)
+        {
+            Physics2D.SyncTransforms();
+            ColliderDistance2D distance = Physics2D.Distance(
+                player.GetComponent<CircleCollider2D>(),
+                blocker);
+            Assert.IsTrue(distance.isValid);
+            Assert.IsFalse(
+                distance.isOverlapped,
+                $"Player overlapped {blocker.name} at {player.transform.position}; " +
+                $"separation={distance.distance}, normal={distance.normal}.");
+        }
+
+        private static void SetField(object instance, string fieldName, object value)
+        {
+            FieldInfo field = instance.GetType().GetField(
+                fieldName,
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(field, $"Expected field {fieldName} on {instance.GetType().Name}.");
+            field.SetValue(instance, value);
+        }
+    }
+}

--- a/Assets/_Project/_Tests/PlayMode/Player/PlayerCollisionMove2DPlayTests.cs.meta
+++ b/Assets/_Project/_Tests/PlayMode/Player/PlayerCollisionMove2DPlayTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4138bfed4f74440e9c6b07f001b74050
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/_Tests/PlayMode/Player/PlayerDashPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/Player/PlayerDashPlayTests.cs
@@ -148,6 +148,10 @@ namespace Castlebound.Tests.PlayMode.Player
                 Assert.That(player.transform.position.x, Is.LessThanOrEqualTo(0.27f));
                 Assert.That(player.transform.position.y, Is.GreaterThan(0.1f),
                     "The unblocked axis should retain the mover's existing sliding behavior.");
+                Assert.IsFalse(Physics2D.Distance(
+                    player.GetComponent<CircleCollider2D>(),
+                    wall.GetComponent<BoxCollider2D>()).isOverlapped,
+                    "Blocked dash must not leave the Player overlapping the wall.");
 
                 while (dash.IsDashing)
                     yield return new WaitForFixedUpdate();
@@ -203,6 +207,10 @@ namespace Castlebound.Tests.PlayMode.Player
                     Assert.IsTrue(dashes[i].IsDashing, $"{names[i]} collision cancelled dash state.");
                     Assert.That(players[i].transform.position.x, Is.LessThanOrEqualTo(0.27f),
                         $"Dash passed through representative {names[i]} geometry.");
+                    Assert.IsFalse(Physics2D.Distance(
+                        players[i].GetComponent<CircleCollider2D>(),
+                        blockers[i].GetComponent<BoxCollider2D>()).isOverlapped,
+                        $"Dash left the Player overlapping representative {names[i]} geometry.");
                 }
 
                 while (dashes[0].IsDashing)
@@ -381,7 +389,7 @@ namespace Castlebound.Tests.PlayMode.Player
             player.transform.position = position;
             var body = player.AddComponent<Rigidbody2D>();
             body.gravityScale = 0f;
-            player.AddComponent<BoxCollider2D>().size = Vector2.one * 0.5f;
+            player.AddComponent<CircleCollider2D>().radius = 0.25f;
             var mover = player.AddComponent<PlayerCollisionMove2D>();
             SetField(mover, "solidMask", (LayerMask)solidMask);
             dash = player.AddComponent<PlayerDashController>();

--- a/Docs/LIVING_ISSUE_TREE.md
+++ b/Docs/LIVING_ISSUE_TREE.md
@@ -1,5 +1,5 @@
 # Castlebound — Living Issue Tree
-**Last synced:** 2026-07-14 | **Repo:** https://github.com/f1cklepickle/Castlebound
+**Last synced:** 2026-08-15 | **Repo:** https://github.com/f1cklepickle/Castlebound
 
 > This doc mirrors GitHub milestone/issue state as a readable progress snapshot.
 > It is not the source of truth — GitHub is. Update this after planning sessions or milestone closes.
@@ -15,8 +15,9 @@
 | P2 — Castle Responds to Care | Prove the castle subtly assists defense | ✅ Complete (4/4) |
 | P3 — Authored Defense Under Pressure | Prove the player is authoring defense, not reacting randomly | ✅ Complete (47/47) |
 | P4 — Castle Memory & Trust | Prove the castle remembers what the player brings back | ✅ Complete (14/14) |
-| P5 — Meaningful Failure | Teach Castlebound's philosophy through loss | ⬜ Not Started (0/5) |
-| P6 — Prototype Lock & Polish | Stop adding systems and make the experience readable and stable | ⬜ Not Started (0/24) |
+| P5 — Meaningful Failure | Teach Castlebound's philosophy through loss | ✅ Complete (5/5) |
+| P6 — Prototype Content Lock | Lock the remaining combat and defensive-choice feature set | 🟨 In Progress (13/19, 68%) |
+| P7 — Prototype Lock & Polish | Make the locked prototype readable, stable, and demonstrable | 🟨 In Progress (16/28, 57%) |
 
 ---
 
@@ -52,60 +53,77 @@
 
 ---
 
-## P5 — Meaningful Failure ⬜
+## P5 — Meaningful Failure ✅
 **Purpose:** Teach the philosophy of Castlebound through loss.
 **Must establish:** Failure screen, waves survived displayed, one non-blaming philosophical line, fast restart flow.
 
-- ⬜ #100 feat(stats): run stats tracking service
-- ⬜ #99 feat(ui): run summary stats (kills, damage, repairs, gold)
-- ⬜ #98 feat(flow): fast restart flow
-- ⬜ #97 feat(ui): philosophical failure line
-- ⬜ #96 feat(ui): failure screen with waves survived
+- ✅ All 5 issues closed
 
 ---
 
-## P6 — Prototype Lock & Polish ⬜
-**Purpose:** Stop adding systems and make the experience readable and stable.
-**Must establish:** Feedback noise reduction, camera clarity, core tuning pass, bug fixes only, no new mechanics.
-**Completion definition:** *"This is a complete Castlebound prototype."*
+## P6 — Prototype Content Lock 🟨
+**Purpose:** Prove the remaining combat and defensive-choice pillars before prototype polish.
+**Must establish:** Readable melee goblin attacks, active defense through dash/block/parry, authored melee and ranged waves, two tower choices, two trap choices, and reliable broken-gate traversal.
+**Completion definition:** *The prototype demonstrates skilled combat and meaningful defensive variety; its feature set is locked.*
 
-- ⬜ #157 feat(gameplay): add additional prototype weapons with distinct swing-speed tiers
+- ⬜ #279 refactor(spawning): consolidate wave scheduling architecture
+- ⬜ #267 feat(tower): add second prototype tower archetype
+- ⬜ #264 feat(defense): add second prototype trap archetype
+- ⬜ #112 refactor(player): split PlayerController responsibilities
+- ⬜ #43 Implement enemy pass-through movement via broken gates
+- ⬜ #31 Docs: Add short design doc for Spawning + Waves behavior
+
+---
+
+## P7 — Prototype Lock & Polish 🟨
+**Purpose:** Lock the prototype content and make the experience readable, stable, and demonstrable.
+**Must establish:** Presentation and feedback clarity, final input-contract regeneration, core tuning, bug fixes only, and no new mechanics.
+**Completion definition:** *This is a complete Castlebound prototype.*
+
+- ⬜ #287 feat(input): refine responsive floating mobile joysticks
+- ⬜ #277 fix(ai): prevent enemies from stacking directly
+- ⬜ #276 fix(player): prevent sticking against barrier and vault colliders
+- ⬜ #275 fix(visual): split castle wall floor from foreground wall
 - ⬜ #156 feat(visual): improve attack presentation readability at high swing speeds
-- ⬜ #144 refactor(ui): extract close button construction out of TouchUIBindings
 - ⬜ #132 feat(visual): basic ground tileset
 - ⬜ #120 Locked Palette + Palette-based Tints
-- ⬜ #119 Auto-wiring (Editor Tool)
-- ⬜ #118 Prefab Creator (Editor Tool)
-- ⬜ #117 Scene Validator (Editor Tool)
-- ⬜ #113 refactor(ui): centralize upgrade button feedback handling
-- ⬜ #112 refactor(player): split PlayerController responsibilities
-- ⬜ #111 perf(ui): pool upgrade menu rows
 - ⬜ #110 chore(input): regenerate PlayerControls.cs from inputactions
-- ⬜ #106 feat(player): movement/defense polish pass
-- ⬜ #105 feat(art): castle wall/tower/enemy sprite set + basic animations
+- ⬜ #105 feat(art): polish castle wall and tower sprite presentation
 - ⬜ #104 fix(gameplay): bug fix sweep only (no new mechanics)
 - ⬜ #103 chore(balance): core tuning pass
-- ⬜ #102 fix(ui): feedback noise reduction sweep
-- ⬜ #60 feat(camera): pixel-perfect setup + 2D best-practice defaults
-- ⬜ #45 Add feedback cooldown/aggregation to reduce hit flash spam
-- ⬜ #44 Remove unused releaseMargin from barrier hold behavior
-- ⬜ #43 Implement enemy pass-through movement via broken gates
-- ⬜ #42 Fix barrier damage gating when player and enemy are inside
-- ⬜ #31 Docs: Add short design doc for Spawning + Waves behavior
 - ⬜ #30 UX: Add basic visual/audio feedback for melee hits and gate repairs
 
 ---
 
-## Unassigned
-- ⬜ #122 Docs — Living Checklists + Decisions Log *(no milestone assigned)*
-- ⬜ #71 feat(loot): coin tier values (small/medium/large) *(no milestone assigned)*
-- ⬜ #70 feat(loot): pickup object pooling *(no milestone assigned)*
-- ⬜ #69 feat(loot): hybrid coin bursts (shower + stack remainder) *(no milestone assigned)*
-- ⬜ #59 feat(inventory): add item pull (magnet) near player *(no milestone assigned)*
-- ⬜ #36 Define Android versioning strategy for CI and test builds *(no milestone assigned)*
-- ⬜ #35 Android milestone release workflow (GitHub Releases) *(no milestone assigned)*
-- ⬜ #34 PR-gated Android APK artifact build (label-based) *(no milestone assigned)*
-- ⬜ #24 UI: Add "Feedback / Bug Report" menu option sending email *(no milestone assigned)*
+## Unassigned — Gameplay and Content Backlog
+
+- ⬜ #284 feat(combat): add reusable enemy attack presentation profiles
+- ⬜ #238 feat(loot): tune goblin drops by equipment and wave tier
+- ⬜ #237 feat(projectiles): add knife and spear throwable variants
+- ⬜ #230 feat(ui): show enemy knowledge gained after failure
+- ⬜ #229 feat(ui): add progressive enemy bestiary
+- ⬜ #228 feat(ui): unlock knowledge-driven enemy health bars
+- ⬜ #227 feat(enemies): report sightings and confirmed kills
+- ⬜ #226 feat(knowledge): persist enemy sightings and mastery
+- ⬜ #157 feat(gameplay): add additional prototype weapons with distinct swing-speed tiers
+- ⬜ #71 feat(loot): coin tier values (small/medium/large)
+- ⬜ #70 feat(loot): pickup object pooling
+- ⬜ #69 feat(loot): hybrid coin bursts (shower + stack remainder)
+- ⬜ #59 feat(inventory): add item pull (magnet) near player
+
+## Unassigned — Maintenance, Tooling, and Workflow Backlog
+
+- ⬜ #144 refactor(ui): extract close button construction out of TouchUIBindings
+- ⬜ #122 Docs — Living Checklists + Decisions Log
+- ⬜ #119 Auto-wiring (Editor Tool)
+- ⬜ #118 Prefab Creator (Editor Tool)
+- ⬜ #117 Scene Validator (Editor Tool)
+- ⬜ #113 refactor(ui): centralize upgrade button feedback handling
+- ⬜ #111 perf(ui): pool upgrade menu rows
+- ⬜ #36 Define Android versioning strategy for CI and test builds
+- ⬜ #35 Android milestone release workflow (GitHub Releases)
+- ⬜ #34 PR-gated Android APK artifact build (label-based)
+- ⬜ #24 UI: Add “Feedback / Bug Report” menu option sending email
 
 ---
 

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,24 @@
 
 ---
 
+## 2026-08-14 - fix-player-solid-collider-sticking
+
+### Summary
+- Replaced independent-axis Player collision with bounded full-vector CircleCast sweep-and-slide.
+- Added deterministic contact-normal clipping and preventive collider-offset rotation sweeping.
+- Added focused Player collision, dash regression, collider geometry, and allocation coverage.
+
+### New or Updated Tests
+**EditMode**
+- PlayerSweepSlideMathTests — collider offset/radius derivation, tangential clipping, deterministic corner constraints, and repeated allocation-free math.
+
+**PlayMode**
+- PlayerCollisionMove2DPlayTests and PlayerDashPlayTests — Barrier/Vault edges and corners, seams, sustained sliding, rotated blockers, rapid facing rotation, dash blocking, and post-contact recovery.
+
+### Notes
+- Focused EditMode and PlayMode tests passed — user-confirmed.
+- MainPrototype Barrier, wall, and Vault validation passed during rapid facing rotation and dash contact — user-confirmed.
+
 ## 2026-08-14 - fix-pr-293-dynamic-input-state
 
 ### Summary


### PR DESCRIPTION
## Why
`PlayerCollisionMove2D` previously cast X and Y independently from the same starting position, so the final combined diagonal displacement was never fully swept. Corners and irregular geometry could therefore permit invalid destinations, while world-axis separation produced inferior sliding behavior. Investigation also confirmed that `BarrierOverlapResolver` is a one-time, barrier-specific overlap repair abstraction and is not appropriate for continuous player locomotion.

## What changed
- Replaced independent-axis resolution with bounded full-vector iterative `Physics2D.CircleCast` sweep-and-slide.
- Resolve the nearest blocking contact with a normal-space skin distance, then project remaining motion against actual contact normals.
- Re-sweep tangential remainder from virtual resolved collider centers.
- Sort and deduplicate simultaneous contact normals for deterministic corner handling.
- Reuse fixed hit/normal buffers and preserve the authoritative `ContactFilter2D` for an allocation-free normal movement hot path.
- Include rotation-driven displacement of the offset `CircleCollider2D` center in the preventive sweep.
- Preserve dash through the same authoritative mover and preserve the #293 movement/facing separation contract.
- Keep exceptional depenetration out because focused validation showed it is unnecessary.
- Keep the existing Player prefab structure because rapid-rotation contact validation showed the offset circle remains safe.
- Leave the proposed rebound/bounce intentionally deferred.
- Update `Docs/TEST_LOG.md` with user-confirmed automated and MainPrototype validation.
- Synchronize `Docs/LIVING_ISSUE_TREE.md` with current GitHub milestone and open-issue state.

## How to test
1. In MainPrototype, verify sustained direct and diagonal contact against Barrier edges, Barrier corners/seams, castle walls, and Vault edges/corners.
2. Verify wall sliding, movement away from contact, rapid facing rotation during contact, direct/diagonal dash collision, post-dash recovery, and open-space movement/relative-mouse facing.
3. Run tests:
   - EditMode: `PlayerSweepSlideMathTests` and affected Player balance regressions
   - PlayMode: `PlayerCollisionMove2DPlayTests`, `PlayerDashPlayTests`, and `PcControlModePlayTests`
   - The automated suites and MainPrototype checklist above were completed successfully by the user; Codex did not rerun Unity or validation.

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated (N/A - no scene changes were required)
- [x] Prefab links, tags, and layers validated (N/A - the existing Player prefab and physics-layer contract were retained unchanged)
- [x] README / Docs touched (`Docs/TEST_LOG.md` and `Docs/LIVING_ISSUE_TREE.md`)

## Related
- Closes #276
- Preserves #291 and #293 behavior contracts