### PR TITLE
fix(player): preserve repair recovery with sweep-and-slide

### DIFF
--- a/Assets/_Project/Scripts/_Project.Gameplay/Barrier/BarrierHealth.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Barrier/BarrierHealth.cs
@@ -167,10 +167,15 @@ public class BarrierHealth : MonoBehaviour, IDamageable
             var playerCollider = player.GetComponent<Collider2D>();
             if (playerCollider != null)
             {
+                var mover = player.GetComponent<PlayerCollisionMove2D>();
+                mover?.ReconcileExternalPosition(barrierCollider);
+
+                Physics2D.SyncTransforms();
                 ColliderDistance2D dist = Physics2D.Distance(barrierCollider, playerCollider);
                 if (dist.isOverlapped)
                 {
                     BarrierOverlapResolver.ResolveOverlap(barrierCollider, playerCollider, true);
+                    mover?.ReconcileExternalPosition();
                 }
             }
         }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Barrier/BarrierOverlapResolver.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Barrier/BarrierOverlapResolver.cs
@@ -78,6 +78,8 @@ public static class BarrierOverlapResolver
                 return false;
             }
 
+            Vector2 dir = desiredDir.normalized;
+
             for (int i = 0; i < maxIterations; i++)
             {
                 Physics2D.SyncTransforms();
@@ -87,11 +89,31 @@ public static class BarrierOverlapResolver
                     break;
                 }
 
-                Vector2 dir = desiredDir.normalized;
-                float barrierExtent = Mathf.Abs(Vector2.Dot(barrier.bounds.extents, dir));
-                float actorExtent = Mathf.Abs(Vector2.Dot(actor.bounds.extents, dir));
-                Vector2 target = (Vector2)barrier.bounds.center + dir * (barrierExtent + actorExtent + skin);
-                SetPositionImmediate(actor, target);
+                if (i == 0)
+                {
+                    float barrierExtent = Mathf.Abs(Vector2.Dot(barrier.bounds.extents, dir));
+                    float actorExtent = Mathf.Abs(Vector2.Dot(actor.bounds.extents, dir));
+                    Vector2 target = (Vector2)barrier.bounds.center +
+                        dir * (barrierExtent + actorExtent + skin);
+                    SetPositionImmediate(actor, target);
+                    continue;
+                }
+
+                float correctionDistance = -dist.distance + skin;
+                Rigidbody2D body = actor.attachedRigidbody;
+                Vector2 currentPosition = body != null
+                    ? body.position
+                    : (Vector2)actor.transform.position;
+                SetPositionImmediate(actor, currentPosition + dir * correctionDistance);
+            }
+
+            Physics2D.SyncTransforms();
+            ColliderDistance2D remaining = Physics2D.Distance(barrier, actor);
+            if (remaining.isOverlapped)
+            {
+                Debug.LogError(
+                    $"Player repair overlap resolution failed for {actor.name} against " +
+                    $"{barrier.name}; remaining signed distance: {remaining.distance}.");
             }
 
             return false;

--- a/Assets/_Project/Scripts/_Project.Gameplay/Player/Movement/PlayerCollisionMove2D.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Player/Movement/PlayerCollisionMove2D.cs
@@ -22,6 +22,7 @@ public class PlayerCollisionMove2D : MonoBehaviour
     private bool _useVelocityOverride;
     private Vector2 _previousCenterOffset;
     private bool _hasPreviousCenterOffset;
+    private Vector2 _scheduledBodyPosition;
 
     public float MoveSpeed
     {
@@ -46,6 +47,38 @@ public class PlayerCollisionMove2D : MonoBehaviour
         _useVelocityOverride = true;
     }
 
+    /// <summary>
+    /// Reconciles cached mover state after an external position or solid-state change.
+    /// When a collider is supplied, a queued move is cancelled only if it would hit it.
+    /// </summary>
+    public void ReconcileExternalPosition(Collider2D activatedCollider = null)
+    {
+        if (_rb == null)
+        {
+            _rb = GetComponent<Rigidbody2D>();
+        }
+
+        if (_col == null)
+        {
+            _col = GetComponent<CircleCollider2D>();
+        }
+
+        if (_rb == null || _col == null)
+        {
+            return;
+        }
+
+        if (activatedCollider != null &&
+            (!activatedCollider.enabled || !DoesScheduledMoveHit(activatedCollider)))
+        {
+            return;
+        }
+
+        _scheduledBodyPosition = _rb.position;
+        _rb.MovePosition(_scheduledBodyPosition);
+        RefreshCenterOffset();
+    }
+
     private void Awake()
     {
         _rb = GetComponent<Rigidbody2D>();
@@ -53,6 +86,11 @@ public class PlayerCollisionMove2D : MonoBehaviour
 
         if (_rb != null && _rb.bodyType != RigidbodyType2D.Kinematic)
             _rb.bodyType = RigidbodyType2D.Kinematic;
+
+        if (_rb != null)
+        {
+            _scheduledBodyPosition = _rb.position;
+        }
 
         RefreshCenterOffset();
     }
@@ -94,6 +132,7 @@ public class PlayerCollisionMove2D : MonoBehaviour
             filter);
 
         Vector2 resolvedBodyPosition = startCenter + resolvedCenterDisplacement - currentCenterOffset;
+        _scheduledBodyPosition = resolvedBodyPosition;
         _rb.MovePosition(resolvedBodyPosition);
         _previousCenterOffset = currentCenterOffset;
     }
@@ -196,6 +235,41 @@ public class PlayerCollisionMove2D : MonoBehaviour
     private bool IsBlockingHit(RaycastHit2D hit)
     {
         return hit.collider != null && hit.rigidbody != _rb;
+    }
+
+    private bool DoesScheduledMoveHit(Collider2D activatedCollider)
+    {
+        Vector2 displacement = _scheduledBodyPosition - _rb.position;
+        float distance = displacement.magnitude;
+        if (distance <= MinDisplacement)
+        {
+            return false;
+        }
+
+        Vector2 currentCenter = _rb.position + GetCurrentCenterOffset();
+        float radius = PlayerSweepSlideMath.GetWorldRadius(
+            _col.radius,
+            transform.lossyScale);
+        ContactFilter2D filter = new ContactFilter2D();
+        filter.useLayerMask = true;
+        filter.layerMask = solidMask;
+        filter.useTriggers = false;
+        int hitCount = Physics2D.CircleCast(
+            currentCenter,
+            radius,
+            displacement / distance,
+            filter,
+            _hits,
+            distance + Mathf.Max(0f, skin));
+        for (int i = 0; i < hitCount; i++)
+        {
+            if (_hits[i].collider == activatedCollider)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private Vector2 GetCurrentCenterOffset()

--- a/Assets/_Project/_Tests/EditMode/Barrier/BarrierRepairOverlapAnchorTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Barrier/BarrierRepairOverlapAnchorTests.cs
@@ -1,6 +1,6 @@
+using Castlebound.Gameplay.AI;
 using NUnit.Framework;
 using UnityEngine;
-using Castlebound.Gameplay.AI;
 
 namespace Castlebound.Tests.Gate
 {
@@ -9,32 +9,122 @@ namespace Castlebound.Tests.Gate
         [Test]
         public void ResolveOverlap_UsesAnchorDirection_ForPlayerPushIn()
         {
-            var barrierGo = new GameObject("Barrier");
-            var barrier = barrierGo.AddComponent<BoxCollider2D>();
-            barrier.size = new Vector2(2f, 2f);
+            GameObject barrierObject = null;
+            GameObject anchorObject = null;
+            GameObject playerObject = null;
 
-            var hold = barrierGo.AddComponent<EnemyBarrierHoldBehavior>();
-            var anchorGo = new GameObject("Anchor");
-            anchorGo.transform.position = new Vector2(2f, 0f);
-            hold.Debug_SetAnchor(anchorGo.transform);
+            try
+            {
+                barrierObject = new GameObject("Barrier");
+                var barrier = barrierObject.AddComponent<BoxCollider2D>();
+                barrier.size = new Vector2(2f, 2f);
 
-            var playerGo = new GameObject("Player");
-            playerGo.tag = "Player";
-            var player = playerGo.AddComponent<CircleCollider2D>();
-            player.radius = 0.4f;
-            playerGo.transform.position = new Vector2(1.1f, 0f);
+                var hold = barrierObject.AddComponent<EnemyBarrierHoldBehavior>();
+                anchorObject = new GameObject("Anchor");
+                anchorObject.transform.position = new Vector2(2f, 0f);
+                hold.Debug_SetAnchor(anchorObject.transform);
 
-            Physics2D.SyncTransforms();
+                playerObject = new GameObject("Player");
+                playerObject.tag = "Player";
+                var player = playerObject.AddComponent<CircleCollider2D>();
+                player.radius = 0.4f;
+                playerObject.transform.position = new Vector2(1.1f, 0f);
+                Physics2D.SyncTransforms();
 
-            Vector2 before = playerGo.transform.position;
-            BarrierOverlapResolver.ResolveOverlap(barrier, player, isPlayer: true);
+                Vector2 before = player.bounds.center;
+                Vector2 inward = Vector2.left;
+                float expectedBarrierExtent = Mathf.Abs(Vector2.Dot(barrier.bounds.extents, inward));
+                float expectedPlayerExtent = Mathf.Abs(Vector2.Dot(player.bounds.extents, inward));
+                Vector2 expectedHistoricalTarget = (Vector2)barrier.bounds.center +
+                    inward * (expectedBarrierExtent + expectedPlayerExtent + 0.01f);
+                Assert.IsTrue(Physics2D.Distance(barrier, player).isOverlapped);
 
-            Vector2 after = playerGo.transform.position;
-            Assert.Less(after.x, before.x, "Player should be pushed inward opposite the anchor direction.");
+                BarrierOverlapResolver.ResolveOverlap(barrier, player, isPlayer: true);
+                Physics2D.SyncTransforms();
 
-            Object.DestroyImmediate(playerGo);
-            Object.DestroyImmediate(anchorGo);
-            Object.DestroyImmediate(barrierGo);
+                Assert.Less(player.bounds.center.x, before.x,
+                    "Player should be pushed inward opposite the approach anchor.");
+                Assert.Less(player.bounds.center.x, barrier.bounds.center.x,
+                    "The historical Player repair contract always chooses the inner side.");
+                Assert.IsFalse(Physics2D.Distance(barrier, player).isOverlapped,
+                    "Historical repair relocation must fully clear the Barrier.");
+                Assert.That(playerObject.transform.position.x,
+                    Is.EqualTo(expectedHistoricalTarget.x).Within(0.0001f),
+                    "An already-clear historical target must not receive an extra correction.");
+                Assert.That(playerObject.transform.position.y,
+                    Is.EqualTo(expectedHistoricalTarget.y).Within(0.0001f));
+            }
+            finally
+            {
+                if (playerObject != null) Object.DestroyImmediate(playerObject);
+                if (anchorObject != null) Object.DestroyImmediate(anchorObject);
+                if (barrierObject != null) Object.DestroyImmediate(barrierObject);
+            }
+        }
+
+        [Test]
+        public void ResolveOverlap_CorrectsResidualPenetration_ForRotatedOffsetPlayer()
+        {
+            GameObject barrierObject = null;
+            GameObject anchorObject = null;
+            GameObject playerObject = null;
+
+            try
+            {
+                barrierObject = new GameObject("Barrier");
+                var barrier = barrierObject.AddComponent<BoxCollider2D>();
+                barrier.size = new Vector2(2f, 2f);
+
+                var hold = barrierObject.AddComponent<EnemyBarrierHoldBehavior>();
+                anchorObject = new GameObject("Anchor");
+                anchorObject.transform.position = new Vector2(2f, 0f);
+                hold.Debug_SetAnchor(anchorObject.transform);
+
+                playerObject = new GameObject("Player");
+                playerObject.tag = "Player";
+                playerObject.transform.SetPositionAndRotation(
+                    new Vector2(1.1f, 0f),
+                    Quaternion.Euler(0f, 0f, 90f));
+                var body = playerObject.AddComponent<Rigidbody2D>();
+                body.bodyType = RigidbodyType2D.Kinematic;
+                var player = playerObject.AddComponent<CircleCollider2D>();
+                player.radius = 0.4f;
+                player.offset = new Vector2(0f, -0.2f);
+                Physics2D.SyncTransforms();
+
+                Vector2 inward = Vector2.left;
+                float barrierExtent = Mathf.Abs(Vector2.Dot(barrier.bounds.extents, inward));
+                float playerExtent = Mathf.Abs(Vector2.Dot(player.bounds.extents, inward));
+                Vector2 historicalTarget = (Vector2)barrier.bounds.center +
+                    inward * (barrierExtent + playerExtent + 0.01f);
+
+                body.position = historicalTarget;
+                Physics2D.SyncTransforms();
+                ColliderDistance2D historicalResult = Physics2D.Distance(barrier, player);
+                Assert.IsTrue(historicalResult.isOverlapped,
+                    "The rotated offset collider must reproduce residual penetration at the historical root target.");
+                Assert.Less(historicalResult.distance, 0f);
+                float expectedCorrection = -historicalResult.distance + 0.01f;
+
+                body.position = new Vector2(1.1f, 0f);
+                Physics2D.SyncTransforms();
+                BarrierOverlapResolver.ResolveOverlap(barrier, player, isPlayer: true);
+                Physics2D.SyncTransforms();
+
+                ColliderDistance2D resolved = Physics2D.Distance(barrier, player);
+                Assert.IsFalse(resolved.isOverlapped,
+                    "The signed-distance correction must fully clear the actual Player collider.");
+                Assert.That(body.position.x,
+                    Is.EqualTo(historicalTarget.x - expectedCorrection).Within(0.001f));
+                Assert.Less(player.bounds.center.x, barrier.bounds.center.x,
+                    "Residual correction must preserve the authored inward side.");
+            }
+            finally
+            {
+                if (playerObject != null) Object.DestroyImmediate(playerObject);
+                if (anchorObject != null) Object.DestroyImmediate(anchorObject);
+                if (barrierObject != null) Object.DestroyImmediate(barrierObject);
+            }
         }
     }
 }

--- a/Assets/_Project/_Tests/EditMode/Barrier/BarrierRepairOverlapPushTests.cs
+++ b/Assets/_Project/_Tests/EditMode/Barrier/BarrierRepairOverlapPushTests.cs
@@ -1,67 +1,44 @@
 using NUnit.Framework;
 using UnityEngine;
-using Castlebound.Gameplay.AI;
 
 namespace Castlebound.Tests.Gate
 {
     public class BarrierRepairOverlapPushTests
     {
         [Test]
-        public void ResolveOverlap_PushesPlayerIntoBarrier_WhenOverlapping()
-        {
-            var barrierGo = new GameObject("Barrier");
-            var barrier = barrierGo.AddComponent<BoxCollider2D>();
-            barrier.size = new Vector2(2f, 2f);
-
-            var hold = barrierGo.AddComponent<EnemyBarrierHoldBehavior>();
-            var anchorGo = new GameObject("Anchor");
-            anchorGo.transform.position = new Vector2(2f, 0f);
-            hold.Debug_SetAnchor(anchorGo.transform);
-
-            var playerGo = new GameObject("Player");
-            playerGo.tag = "Player";
-            var player = playerGo.AddComponent<CircleCollider2D>();
-            player.radius = 0.4f;
-
-            playerGo.transform.position = new Vector2(1.1f, 0f);
-
-            Physics2D.SyncTransforms();
-
-            Vector2 before = playerGo.transform.position;
-            BarrierOverlapResolver.ResolveOverlap(barrier, player, isPlayer: true);
-
-            Vector2 after = playerGo.transform.position;
-            Assert.Less(after.x, before.x, "Player should be pushed into the barrier area.");
-
-            Object.DestroyImmediate(playerGo);
-            Object.DestroyImmediate(anchorGo);
-            Object.DestroyImmediate(barrierGo);
-        }
-
-        [Test]
         public void ResolveOverlap_PushesEnemyOut_WhenMostlyOutsideBarrier()
         {
-            var barrierGo = new GameObject("Barrier");
-            var barrier = barrierGo.AddComponent<BoxCollider2D>();
-            barrier.size = new Vector2(2f, 2f);
+            GameObject barrierObject = null;
+            GameObject enemyObject = null;
 
-            var enemyGo = new GameObject("Enemy");
-            var enemy = enemyGo.AddComponent<CircleCollider2D>();
-            enemy.radius = 0.4f;
+            try
+            {
+                barrierObject = new GameObject("Barrier");
+                var barrier = barrierObject.AddComponent<BoxCollider2D>();
+                barrier.size = new Vector2(2f, 2f);
 
-            enemyGo.transform.position = new Vector2(1.1f, 0f);
+                enemyObject = new GameObject("Enemy");
+                var enemy = enemyObject.AddComponent<CircleCollider2D>();
+                enemy.radius = 0.4f;
+                enemyObject.transform.position = new Vector2(1.1f, 0f);
+                Physics2D.SyncTransforms();
 
-            Physics2D.SyncTransforms();
+                Vector2 before = enemyObject.transform.position;
+                bool pushedOutside = BarrierOverlapResolver.ResolveOverlap(
+                    barrier,
+                    enemy,
+                    isPlayer: false);
 
-            Vector2 before = enemyGo.transform.position;
-            bool pushedOutside = BarrierOverlapResolver.ResolveOverlap(barrier, enemy, isPlayer: false);
-
-            Vector2 after = enemyGo.transform.position;
-            Assert.Greater(after.x, before.x, "Enemy should be pushed out of the barrier.");
-            Assert.IsFalse(pushedOutside, "Without an authored approach anchor, region ownership cannot be reconciled.");
-
-            Object.DestroyImmediate(enemyGo);
-            Object.DestroyImmediate(barrierGo);
+                Assert.Greater(enemyObject.transform.position.x, before.x,
+                    "Enemy should retain the historical minimum-separation behavior.");
+                Assert.IsFalse(pushedOutside,
+                    "Without an authored anchor, region ownership cannot be reconciled.");
+            }
+            finally
+            {
+                if (enemyObject != null) Object.DestroyImmediate(enemyObject);
+                if (barrierObject != null) Object.DestroyImmediate(barrierObject);
+            }
         }
     }
 }

--- a/Assets/_Project/_Tests/PlayMode/Barrier/BarrierRepairOverlapIntegrationPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/Barrier/BarrierRepairOverlapIntegrationPlayTests.cs
@@ -1,8 +1,8 @@
 using System.Collections;
+using Castlebound.Gameplay.AI;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
-using Castlebound.Gameplay.AI;
 
 namespace Castlebound.Tests.Gate
 {
@@ -11,47 +11,51 @@ namespace Castlebound.Tests.Gate
         [UnityTest]
         public IEnumerator Repair_ResolvesPlayerOverlap_AndPushesInward()
         {
-            var barrierGo = new GameObject("Barrier");
-            var barrierCollider = barrierGo.AddComponent<BoxCollider2D>();
-            barrierCollider.size = new Vector2(2f, 2f);
-            barrierGo.AddComponent<SpriteRenderer>();
+            GameObject barrierObject = null;
+            GameObject anchorObject = null;
+            GameObject playerObject = null;
 
-            var hold = barrierGo.AddComponent<EnemyBarrierHoldBehavior>();
-            var anchorGo = new GameObject("Anchor");
-            anchorGo.transform.position = new Vector2(2f, 0f);
-            hold.Debug_SetAnchor(anchorGo.transform);
+            try
+            {
+                barrierObject = new GameObject("Barrier");
+                var barrier = barrierObject.AddComponent<BoxCollider2D>();
+                barrier.size = new Vector2(2f, 2f);
+                barrierObject.AddComponent<SpriteRenderer>();
 
-            var barrierHealth = barrierGo.AddComponent<BarrierHealth>();
+                var hold = barrierObject.AddComponent<EnemyBarrierHoldBehavior>();
+                anchorObject = new GameObject("Anchor");
+                anchorObject.transform.position = new Vector2(2f, 0f);
+                hold.Debug_SetAnchor(anchorObject.transform);
+                var health = barrierObject.AddComponent<BarrierHealth>();
 
-            var playerGo = new GameObject("Player");
-            playerGo.tag = "Player";
-            playerGo.AddComponent<Rigidbody2D>().bodyType = RigidbodyType2D.Kinematic;
-            playerGo.AddComponent<PlayerController>();
-            var playerCollider = playerGo.AddComponent<CircleCollider2D>();
-            playerCollider.radius = 0.4f;
+                playerObject = new GameObject("Player");
+                playerObject.tag = "Player";
+                playerObject.AddComponent<Rigidbody2D>().bodyType = RigidbodyType2D.Kinematic;
+                var player = playerObject.AddComponent<CircleCollider2D>();
+                player.radius = 0.4f;
+                playerObject.AddComponent<PlayerController>();
+                playerObject.transform.position = new Vector2(1.1f, 0f);
+                Physics2D.SyncTransforms();
 
-            playerGo.transform.position = new Vector2(1.1f, 0f);
+                Vector2 before = player.bounds.center;
+                health.TakeDamage(1);
+                Assert.IsTrue(health.Repair());
 
-            Physics2D.SyncTransforms();
+                Assert.Less(player.bounds.center.x, before.x);
+                Assert.Less(player.bounds.center.x, barrier.bounds.center.x);
+                Assert.IsFalse(Physics2D.Distance(barrier, player).isOverlapped);
 
-            Vector2 before = playerGo.transform.position;
-            barrierHealth.MaxHealth = 10;
-            barrierHealth.CurrentHealth = 10;
-            barrierHealth.TakeDamage(1);
-            barrierHealth.Repair();
-
-            yield return new WaitForFixedUpdate();
-            Physics2D.SyncTransforms();
-
-            Vector2 after = playerGo.transform.position;
-            var dist = Physics2D.Distance(barrierCollider, playerCollider);
-
-            Assert.Less(after.x, before.x, "Player should be pushed inward opposite the anchor direction.");
-            Assert.IsFalse(dist.isOverlapped, "Player should no longer overlap the barrier after Repair.");
-
-            Object.Destroy(barrierGo);
-            Object.Destroy(anchorGo);
-            Object.Destroy(playerGo);
+                yield return new WaitForFixedUpdate();
+                Physics2D.SyncTransforms();
+                Assert.IsFalse(Physics2D.Distance(barrier, player).isOverlapped,
+                    "Player must remain clear on the next physics step.");
+            }
+            finally
+            {
+                if (playerObject != null) Object.DestroyImmediate(playerObject);
+                if (anchorObject != null) Object.DestroyImmediate(anchorObject);
+                if (barrierObject != null) Object.DestroyImmediate(barrierObject);
+            }
         }
     }
 }

--- a/Assets/_Project/_Tests/PlayMode/Barrier/BarrierRepairPlayerRecoveryPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/Barrier/BarrierRepairPlayerRecoveryPlayTests.cs
@@ -1,0 +1,202 @@
+using System.Collections;
+using System.Reflection;
+using Castlebound.Gameplay.AI;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Castlebound.Tests.PlayMode.Barrier
+{
+    public class BarrierRepairPlayerRecoveryPlayTests
+    {
+        [UnityTest]
+        public IEnumerator ActiveMovement_RepairPushesInwardAndResynchronizesMover()
+        {
+            CreateFixture(
+                new Vector2(1.1f, 0f),
+                new Vector2(0f, -0.2f),
+                90f,
+                out BarrierHealth health,
+                out BoxCollider2D barrier,
+                out GameObject anchor,
+                out GameObject player,
+                out CircleCollider2D playerCollider,
+                out PlayerCollisionMove2D mover,
+                out PlayerController controller);
+
+            try
+            {
+                SetField(controller, "movementInput", Vector2.left);
+                mover.SetMoveInput(Vector2.left);
+                InvokeFixedUpdate(mover);
+
+                Assert.IsTrue(health.Repair());
+                AssertClear(playerCollider, barrier);
+                Assert.Less(playerCollider.bounds.center.x, barrier.bounds.center.x,
+                    "Historical repair relocation must choose the inner side.");
+
+                float repairedX = player.transform.position.x;
+                yield return new WaitForFixedUpdate();
+                AssertClear(playerCollider, barrier);
+                Assert.Less(player.transform.position.x, repairedX,
+                    "The next FixedUpdate must continue from the repaired position.");
+
+                SetField(controller, "movementInput", Vector2.right);
+                for (int i = 0; i < 20; i++)
+                {
+                    yield return new WaitForFixedUpdate();
+                    AssertClear(playerCollider, barrier);
+                }
+
+                float contactX = player.transform.position.x;
+                yield return new WaitForFixedUpdate();
+                Assert.That(player.transform.position.x, Is.EqualTo(contactX).Within(0.001f));
+                AssertClear(playerCollider, barrier);
+
+                SetField(controller, "movementInput", Vector2.left);
+                yield return new WaitForFixedUpdate();
+                yield return new WaitForFixedUpdate();
+                Assert.Less(player.transform.position.x, contactX - 0.05f,
+                    "Player must move away from the repaired Barrier without sticking.");
+            }
+            finally
+            {
+                DestroyFixture(health.gameObject, anchor, player);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator PendingMovePositionIntoOpening_IsCancelledWhenBarrierRepairs()
+        {
+            CreateFixture(
+                new Vector2(1.6f, 0f),
+                Vector2.zero,
+                0f,
+                out BarrierHealth health,
+                out BoxCollider2D barrier,
+                out GameObject anchor,
+                out GameObject player,
+                out CircleCollider2D playerCollider,
+                out PlayerCollisionMove2D mover,
+                out PlayerController controller);
+
+            try
+            {
+                SetField(controller, "movementInput", Vector2.left);
+                mover.SetMoveInput(Vector2.left);
+                InvokeFixedUpdate(mover);
+                Assert.GreaterOrEqual(playerCollider.bounds.center.x, 1.59f,
+                    "MovePosition should still be pending before the physics step.");
+
+                Assert.IsTrue(health.Repair());
+                AssertClear(playerCollider, barrier);
+
+                yield return new WaitForFixedUpdate();
+                AssertClear(playerCollider, barrier);
+                Assert.GreaterOrEqual(playerCollider.bounds.center.x, 1.39f,
+                    "The stale pre-repair target must not place Player inside the Barrier.");
+            }
+            finally
+            {
+                DestroyFixture(health.gameObject, anchor, player);
+            }
+        }
+
+        private static void CreateFixture(
+            Vector2 playerPosition,
+            Vector2 colliderOffset,
+            float playerRotation,
+            out BarrierHealth health,
+            out BoxCollider2D barrier,
+            out GameObject anchor,
+            out GameObject player,
+            out CircleCollider2D playerCollider,
+            out PlayerCollisionMove2D mover,
+            out PlayerController controller)
+        {
+            health = null;
+            barrier = null;
+            anchor = null;
+            player = null;
+            playerCollider = null;
+            mover = null;
+            controller = null;
+            GameObject barrierObject = null;
+
+            try
+            {
+                int barrierLayer = LayerMask.NameToLayer("Barriers");
+                int playerLayer = LayerMask.NameToLayer("Player");
+
+                barrierObject = new GameObject("Barrier");
+                barrierObject.layer = barrierLayer;
+                barrier = barrierObject.AddComponent<BoxCollider2D>();
+                barrier.size = new Vector2(2f, 2f);
+                barrierObject.AddComponent<SpriteRenderer>();
+                var hold = barrierObject.AddComponent<EnemyBarrierHoldBehavior>();
+                anchor = new GameObject("OutsideAnchor");
+                anchor.transform.position = new Vector2(2f, 0f);
+                hold.Debug_SetAnchor(anchor.transform);
+                health = barrierObject.AddComponent<BarrierHealth>();
+                health.TakeDamage(health.MaxHealth);
+
+                player = new GameObject("Player");
+                player.tag = "Player";
+                player.layer = playerLayer;
+                player.transform.position = playerPosition;
+                player.transform.rotation = Quaternion.Euler(0f, 0f, playerRotation);
+                var body = player.AddComponent<Rigidbody2D>();
+                body.bodyType = RigidbodyType2D.Kinematic;
+                body.gravityScale = 0f;
+                playerCollider = player.AddComponent<CircleCollider2D>();
+                playerCollider.radius = 0.4f;
+                playerCollider.offset = colliderOffset;
+                mover = player.AddComponent<PlayerCollisionMove2D>();
+                mover.MoveSpeed = 12f;
+                SetField(mover, "solidMask", (LayerMask)(1 << barrierLayer));
+                controller = player.AddComponent<PlayerController>();
+                Physics2D.SyncTransforms();
+            }
+            catch
+            {
+                DestroyFixture(barrierObject, anchor, player);
+                throw;
+            }
+        }
+
+        private static void InvokeFixedUpdate(PlayerCollisionMove2D mover)
+        {
+            MethodInfo method = typeof(PlayerCollisionMove2D).GetMethod(
+                "FixedUpdate",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(method);
+            method.Invoke(mover, null);
+        }
+
+        private static void SetField(object instance, string fieldName, object value)
+        {
+            FieldInfo field = instance.GetType().GetField(
+                fieldName,
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(field);
+            field.SetValue(instance, value);
+        }
+
+        private static void AssertClear(Collider2D player, Collider2D barrier)
+        {
+            Physics2D.SyncTransforms();
+            Assert.IsFalse(Physics2D.Distance(barrier, player).isOverlapped,
+                "Player must be fully clear of the repaired Barrier.");
+        }
+
+        private static void DestroyFixture(
+            GameObject barrier,
+            GameObject anchor,
+            GameObject player)
+        {
+            if (player != null) Object.DestroyImmediate(player);
+            if (anchor != null) Object.DestroyImmediate(anchor);
+            if (barrier != null) Object.DestroyImmediate(barrier);
+        }
+    }
+}

--- a/Assets/_Project/_Tests/PlayMode/Barrier/BarrierRepairPlayerRecoveryPlayTests.cs.meta
+++ b/Assets/_Project/_Tests/PlayMode/Barrier/BarrierRepairPlayerRecoveryPlayTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 747193f8da3e4a04b95db2d1b5140a7f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,31 @@
 
 ---
 
+## 2026-08-20 - fix-player-barrier-repair-overlap
+
+### Summary
+- Restored the long-standing pre-#294 Barrier resolver as the authoritative repair-time Player relocation path.
+- Preserved #294 full-vector sweep-and-slide for ordinary movement without a second recovery or navigation system.
+- Added a minimal mover handoff for queued MovePosition cancellation and collider-center cache synchronization after external relocation.
+- Added a bounded inward-only signed-distance correction for residual penetration after the historical repair target.
+
+### New or Updated Tests
+**EditMode**
+- BarrierRepairOverlapAnchorTests and BarrierRepairOverlapPushTests — historical inward Player relocation, rotated offset-circle residual correction, already-clear target behavior, and unchanged enemy separation behavior.
+
+**PlayMode**
+- BarrierRepairOverlapIntegrationPlayTests and BarrierRepairPlayerRecoveryPlayTests — inward repair relocation with representative rotated offset-circle geometry, full clearance, active-movement synchronization, pending MovePosition cancellation, next-step stability, and immediate movement recovery.
+
+### Notes
+- The #294 mover can retain a queued MovePosition and cached collider-center offset after another system directly sets Rigidbody2D.position; without reconciliation, the next physics step can restore stale movement or interpret the old center state.
+- Existing #294 movement/dash and enemy repair expulsion/retarget suites remain the regression authority for those unchanged behaviors.
+- MainPrototype diagnostics verified that the historical resolver selected the correct inward direction, but the actual post-reposition ColliderDistance2D remained overlapped at approximately -0.0255 signed distance for a rotated offset Player circle.
+- The residual came from assigning the bounds-based historical target to the Rigidbody root while the rotated collider offset displaced the actual world-space circle center; follow-up correction now uses the measured signed penetration plus the existing skin along the same inward direction.
+- The active-movement regression drives PlayerController's production movement-input contract while retaining direct mover invocation only to stage the pre-repair MovePosition under test.
+- All EditMode and PlayMode tests passed — user-confirmed; Codex did not run Unity or tests.
+- MainPrototype validation passed — user confirmed no sticking against walls, corners, the Vault, or repaired Barriers; inward repair relocation and ordinary #294 movement remained correct.
+- Enemy repair behavior remained acceptable during user validation.
+
 ## 2026-08-14 - fix-player-solid-collider-sticking
 
 ### Summary


### PR DESCRIPTION
## Why
PR #294 fixed ordinary Player sticking with preventive full-vector sweep-and-slide, but Barrier repair could still conflict with mover-owned pending/cached state after directly repositioning the Rigidbody. Runtime diagnostics also showed the historical repair target could leave slight residual penetration when Player rotation displaced its offset circle collider.

## What changed
- Preserved #294's ordinary sweep-and-slide and dash collision behavior unchanged.
- Preserved the historical authored inward-only Barrier repair relocation.
- Added a narrow mover reconciliation handoff to cancel unsafe queued movement and refresh collider-center tracking around external repair repositioning.
- Rechecked actual collider geometry after the historical target and corrected only measured residual penetration using `-ColliderDistance2D.distance + skin` along the same inward direction.
- Kept the correction bounded and explicitly reports failure if actual geometry cannot be cleared.
- Preserved enemy repair expulsion/retarget behavior.
- Removed all generalized recovery search, routing, alternate-side fallback, and temporary diagnostics.
- Added focused EditMode and PlayMode regressions for rotated offset-circle geometry, already-clear targets, active movement, pending `MovePosition`, next-step stability, and immediate movement recovery.
- Updated `Docs/TEST_LOG.md` with user-confirmed automated and MainPrototype validation.

## How to test
1. User-confirmed MainPrototype validation:
   - Repair a Barrier around the Player while stationary and moving; verify immediate inward clearance and normal movement afterward.
   - Verify no sticking against repaired Barriers, walls, corners, or the Vault.
   - Verify enemy repair behavior remains acceptable.
   - Recheck ordinary movement, facing, and dash collision behavior from #294.
2. User-confirmed automated validation:
   - All EditMode tests passed.
   - All PlayMode tests passed.
3. CI:
   - Run the standard EditMode and Unity PlayMode workflows.

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated (N/A - no scene or prefab restructuring required; MainPrototype was user-validated)
- [x] Prefab links, tags, and layers validated (N/A - existing contracts remain unchanged)
- [x] README / Docs touched (`Docs/TEST_LOG.md` records user-confirmed validation)

## Related
- Closes #276
- Preserves the #291 dash, #293 PC-control, and #294 sweep-and-slide contracts.
