### PR TITLE
fix(ai): prevent direct enemy stacking

### DIFF
--- a/Assets/_Project/Prefabs/Enemy_Goblin_Melee.prefab
+++ b/Assets/_Project/Prefabs/Enemy_Goblin_Melee.prefab
@@ -167,6 +167,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 9100000000000000001}
+  - {fileID: 8500000000000000001}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!50 &2170073844796163517
@@ -211,8 +212,8 @@ CircleCollider2D:
     m_Bits: 0
   m_ExcludeLayers:
     serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 1
+    m_Bits: 128
+  m_LayerOverridePriority: 2
   m_ForceSendLayers:
     serializedVersion: 2
     m_Bits: 4294967295
@@ -677,3 +678,84 @@ SpriteRenderer:
   m_WasSpriteAssigned: 0
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!1 &8500000000000000000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8500000000000000001}
+  - component: {fileID: 8500000000000000002}
+  - component: {fileID: 8500000000000000003}
+  m_Layer: 7
+  m_Name: EnemySeparation
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8500000000000000001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8500000000000000000}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3011338220405360025}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!58 &8500000000000000002
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8500000000000000000}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 128
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 4294967167
+  m_LayerOverridePriority: 1
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 128
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 128
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.2
+--- !u!114 &8500000000000000003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8500000000000000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b21d1d6fbe2e4da1bc2c5f871ade8665, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  separationCollider: {fileID: 8500000000000000002}

--- a/Assets/_Project/Prefabs/Enemy_Goblin_Ranged.prefab
+++ b/Assets/_Project/Prefabs/Enemy_Goblin_Ranged.prefab
@@ -167,6 +167,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 9100000000000000001}
+  - {fileID: 8500000000000000101}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!50 &2170073844796163517
@@ -211,8 +212,8 @@ CircleCollider2D:
     m_Bits: 0
   m_ExcludeLayers:
     serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 1
+    m_Bits: 128
+  m_LayerOverridePriority: 2
   m_ForceSendLayers:
     serializedVersion: 2
     m_Bits: 4294967295
@@ -670,3 +671,84 @@ SpriteRenderer:
   m_WasSpriteAssigned: 0
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!1 &8500000000000000100
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8500000000000000101}
+  - component: {fileID: 8500000000000000102}
+  - component: {fileID: 8500000000000000103}
+  m_Layer: 7
+  m_Name: EnemySeparation
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8500000000000000101
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8500000000000000100}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3011338220405360025}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!58 &8500000000000000102
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8500000000000000100}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 128
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 4294967167
+  m_LayerOverridePriority: 1
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 128
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 128
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.2
+--- !u!114 &8500000000000000103
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8500000000000000100}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b21d1d6fbe2e4da1bc2c5f871ade8665, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  separationCollider: {fileID: 8500000000000000102}

--- a/Assets/_Project/Prefabs/Enemy_Lurker.prefab
+++ b/Assets/_Project/Prefabs/Enemy_Lurker.prefab
@@ -150,6 +150,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4418641983238910643}
+  - {fileID: 8500000000000000201}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!50 &2170073844796163517
@@ -194,8 +195,8 @@ CircleCollider2D:
     m_Bits: 0
   m_ExcludeLayers:
     serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 1
+    m_Bits: 128
+  m_LayerOverridePriority: 2
   m_ForceSendLayers:
     serializedVersion: 2
     m_Bits: 4294967295
@@ -456,3 +457,84 @@ MonoBehaviour:
   surroundArrivalDistance: 10
   maxAngularArrivalRatio: 0.18
   openGapDeadbandDegrees: 8
+--- !u!1 &8500000000000000200
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8500000000000000201}
+  - component: {fileID: 8500000000000000202}
+  - component: {fileID: 8500000000000000203}
+  m_Layer: 7
+  m_Name: EnemySeparation
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8500000000000000201
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8500000000000000200}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3011338220405360025}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!58 &8500000000000000202
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8500000000000000200}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 128
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 4294967167
+  m_LayerOverridePriority: 1
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 128
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 128
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.2
+--- !u!114 &8500000000000000203
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8500000000000000200}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b21d1d6fbe2e4da1bc2c5f871ade8665, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  separationCollider: {fileID: 8500000000000000202}

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyApproachSpread.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyApproachSpread.cs
@@ -50,12 +50,34 @@ public class EnemyApproachSpread : MonoBehaviour
         Vector2 forward = directionToTarget.normalized;
         Vector2 lateralAxis = new Vector2(-forward.y, forward.x);
         float localPreference = 0f;
+        float longitudinalLanePreference = 0f;
         if (hasNeighbors)
         {
-            Vector2 separation = localSeparation.sqrMagnitude > 0.0001f
-                ? localSeparation.normalized
-                : stableBias.normalized;
-            localPreference = Vector2.Dot(separation, lateralAxis);
+            if (localSeparation.sqrMagnitude > 0.0001f)
+            {
+                float separationMagnitude = localSeparation.magnitude;
+                Vector2 separation = localSeparation / separationMagnitude;
+                localPreference = Vector2.Dot(separation, lateralAxis);
+
+                // Fore/aft pressure has no lateral projection, so reuse the
+                // stable bias to form a lane before hard separation is reached.
+                float longitudinalAlignment = Mathf.Abs(
+                    Vector2.Dot(separation, forward));
+                float longitudinalDominance = Mathf.Clamp01(
+                    longitudinalAlignment - Mathf.Abs(localPreference));
+                float compression = Mathf.Clamp01(separationMagnitude);
+                float stableLanePreference = Vector2.Dot(
+                    stableBias.normalized,
+                    lateralAxis);
+                longitudinalLanePreference = stableLanePreference *
+                    longitudinalDominance * compression;
+            }
+            else
+            {
+                localPreference = Vector2.Dot(
+                    stableBias.normalized,
+                    lateralAxis);
+            }
         }
 
         float angularPreference = 0f;
@@ -72,6 +94,11 @@ public class EnemyApproachSpread : MonoBehaviour
             else if (hasNeighbors && gapCW <= 0f && gapCCW <= 0f)
                 angularPreference = Vector2.Dot(stableBias.normalized, lateralAxis) * 0.5f;
         }
+
+        localPreference = Mathf.Clamp(
+            localPreference + longitudinalLanePreference * (1f - arrival01),
+            -1f,
+            1f);
 
         float localLateral = Mathf.Clamp01(separationStrength) *
                              Mathf.Clamp01(maxLateralRatio) * localPreference;

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyLocomotion.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemyLocomotion.cs
@@ -7,6 +7,7 @@ public class EnemyLocomotion : MonoBehaviour
     [SerializeField] private EnemyRootReceiver rootReceiver;
     [SerializeField] private MonoBehaviour holdMovementPolicySource;
 
+    private EnemySeparationCollider separationCollider;
     private float previousDistance;
     private int distanceTrend;
     private Vector2 lastNonZeroDirection = Vector2.right;
@@ -143,7 +144,22 @@ public class EnemyLocomotion : MonoBehaviour
         Vector2 knockback = knockbackReceiver != null
             ? knockbackReceiver.ConsumeDisplacement(deltaTime)
             : Vector2.zero;
-        Vector2 displacement = (radial + tangent) * deltaTime + knockback;
+        Vector2 locomotionDisplacement = (radial + tangent) * deltaTime;
+        if (separationCollider == null)
+            separationCollider = GetComponentInChildren<EnemySeparationCollider>();
+        if (separationCollider != null)
+        {
+            locomotionDisplacement = separationCollider
+                .ConstrainLocomotionDisplacement(locomotionDisplacement);
+        }
+
+        Vector2 displacement = locomotionDisplacement + knockback;
+        if (separationCollider != null)
+        {
+            separationCollider.RecordScheduledBodyPosition(
+                body.position + displacement);
+        }
+
         body.MovePosition(body.position + displacement);
         return displacement.sqrMagnitude > Mathf.Epsilon;
     }

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemySeparationCollider.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemySeparationCollider.cs
@@ -1,0 +1,331 @@
+using System.Collections.Generic;
+using Castlebound.Gameplay.AI;
+using UnityEngine;
+
+[DisallowMultipleComponent]
+[RequireComponent(typeof(CircleCollider2D))]
+public sealed class EnemySeparationCollider : MonoBehaviour
+{
+    private const float DirectStackThreshold = 0.001f;
+    private const float MaxCorrectionRadiusRatio = 0.25f;
+    // Keeps exact-boundary float noise below the threshold for physical recovery.
+    private const float PenetrationToleranceContactOffsetRatio = 0.01f;
+    private const int ConstraintPassCount = 2;
+    private const int CastBufferSize = 8;
+
+    [SerializeField] private CircleCollider2D separationCollider;
+
+    private readonly List<EnemySeparationCollider> overlappingSensors =
+        new List<EnemySeparationCollider>(8);
+    private readonly RaycastHit2D[] castBuffer = new RaycastHit2D[CastBufferSize];
+    private Rigidbody2D body;
+    private CircleCollider2D primaryCollider;
+    private EnemyRootReceiver rootReceiver;
+    private EnemyStaggerReceiver staggerReceiver;
+    private ContactFilter2D worldFilter;
+    private Vector2 scheduledBodyPosition;
+    private float scheduledFixedTime = float.NegativeInfinity;
+
+#if UNITY_EDITOR
+    public int DebugFallbackCorrectionCount { get; private set; }
+#endif
+
+    public CircleCollider2D Collider
+    {
+        get
+        {
+            if (separationCollider == null)
+                separationCollider = GetComponent<CircleCollider2D>();
+
+            return separationCollider;
+        }
+    }
+
+    private void Awake()
+    {
+        CacheComponents();
+        worldFilter = new ContactFilter2D
+        {
+            useLayerMask = true,
+            layerMask = BuildWorldBlockerMask(),
+            useTriggers = false
+        };
+    }
+
+    private void OnTriggerEnter2D(Collider2D other)
+    {
+        HandleOverlap(other);
+    }
+
+    private void OnTriggerStay2D(Collider2D other)
+    {
+        HandleOverlap(other);
+    }
+
+    private void OnTriggerExit2D(Collider2D other)
+    {
+        EnemySeparationCollider sensor = GetSensor(other);
+        if (sensor != null && !IsWithinTrackingRange(sensor))
+            overlappingSensors.Remove(sensor);
+    }
+
+    private void OnDisable()
+    {
+        for (int i = overlappingSensors.Count - 1; i >= 0; i--)
+        {
+            EnemySeparationCollider other = overlappingSensors[i];
+            if (other != null)
+                other.overlappingSensors.Remove(this);
+        }
+
+        overlappingSensors.Clear();
+    }
+
+    private void HandleOverlap(Collider2D other)
+    {
+        EnemySeparationCollider sensor = GetSensor(other);
+        if (sensor == null || sensor == this || !sensor.isActiveAndEnabled)
+            return;
+
+        TrackSensor(sensor);
+
+        if (GetInstanceID() < sensor.GetInstanceID())
+            ResolvePair(sensor);
+    }
+
+    private void ResolvePair(EnemySeparationCollider other)
+    {
+        CacheComponents();
+        other.CacheComponents();
+        if (!CanResolve(body) || !CanResolve(other.body))
+            return;
+
+        CircleCollider2D ownSensor = Collider;
+        CircleCollider2D otherSensor = other.Collider;
+        Vector2 centerDelta = otherSensor.bounds.center - ownSensor.bounds.center;
+        float centerDistance = centerDelta.magnitude;
+        float ownRadius = ownSensor.bounds.extents.x;
+        float otherRadius = otherSensor.bounds.extents.x;
+        float penetration = ownRadius + otherRadius - centerDistance;
+        if (penetration <= GetPenetrationTolerance())
+            return;
+
+        bool ownLocked = IsMovementLocked();
+        bool otherLocked = other.IsMovementLocked();
+        if (ownLocked && otherLocked)
+            return;
+
+        Vector2 axis = EnemySeparationMath.ResolveAxis(
+            centerDelta,
+            DirectStackThreshold);
+        float maxCorrection = Mathf.Min(ownRadius, otherRadius) *
+            MaxCorrectionRadiusRatio;
+
+        float ownCapacity = ownLocked
+            ? 0f
+            : GetWorldSafeDistance(-axis, Mathf.Min(penetration, maxCorrection));
+        float otherCapacity = otherLocked
+            ? 0f
+            : other.GetWorldSafeDistance(axis, Mathf.Min(penetration, maxCorrection));
+
+        EnemySeparationMath.AllocateCorrections(
+            penetration,
+            ownCapacity,
+            otherCapacity,
+            out float ownCorrection,
+            out float otherCorrection);
+
+        if (ownCorrection > 0f)
+            body.position -= axis * ownCorrection;
+        if (otherCorrection > 0f)
+            other.body.position += axis * otherCorrection;
+
+#if UNITY_EDITOR
+        if (ownCorrection > 0f || otherCorrection > 0f)
+            DebugFallbackCorrectionCount++;
+#endif
+    }
+
+    public Vector2 ConstrainLocomotionDisplacement(Vector2 proposedDisplacement)
+    {
+        CacheComponents();
+        if (body == null || proposedDisplacement.sqrMagnitude <= Mathf.Epsilon)
+            return proposedDisplacement;
+
+        Vector2 constrainedDisplacement = proposedDisplacement;
+        Vector2 ownCenter = Collider.bounds.center;
+        for (int i = overlappingSensors.Count - 1; i >= 0; i--)
+        {
+            EnemySeparationCollider other = overlappingSensors[i];
+            if (other == null || !other.isActiveAndEnabled ||
+                !IsWithinTrackingRange(other))
+            {
+                overlappingSensors.RemoveAt(i);
+            }
+        }
+
+        for (int pass = 0; pass < ConstraintPassCount; pass++)
+        {
+            for (int i = 0; i < overlappingSensors.Count; i++)
+            {
+                EnemySeparationCollider other = overlappingSensors[i];
+                other.CacheComponents();
+                if (other.body == null)
+                    continue;
+
+                Vector2 otherCenter = other.GetScheduledSensorCenter();
+                float minimumDistance = Collider.bounds.extents.x +
+                    other.Collider.bounds.extents.x + GetPenetrationTolerance();
+                constrainedDisplacement = EnemySeparationMath.ClampInwardDisplacement(
+                    otherCenter - ownCenter,
+                    minimumDistance,
+                    constrainedDisplacement,
+                    DirectStackThreshold);
+            }
+        }
+
+        return constrainedDisplacement;
+    }
+
+    public void RecordScheduledBodyPosition(Vector2 position)
+    {
+        scheduledBodyPosition = position;
+        scheduledFixedTime = Time.fixedTime;
+    }
+
+#if UNITY_EDITOR
+    public void Debug_ResetFallbackCorrectionCount()
+    {
+        DebugFallbackCorrectionCount = 0;
+    }
+#endif
+
+    private Vector2 GetScheduledSensorCenter()
+    {
+        Vector2 currentCenter = Collider.bounds.center;
+        return body != null && scheduledFixedTime == Time.fixedTime
+            ? currentCenter + scheduledBodyPosition - body.position
+            : currentCenter;
+    }
+
+    private bool IsWithinTrackingRange(EnemySeparationCollider other)
+    {
+        if (other == null)
+            return false;
+
+        CircleCollider2D ownSensor = Collider;
+        CircleCollider2D otherSensor = other.Collider;
+        float trackingDistance = ownSensor.bounds.extents.x +
+            otherSensor.bounds.extents.x + Physics2D.defaultContactOffset;
+        return Vector2.Distance(ownSensor.bounds.center, otherSensor.bounds.center) <=
+            trackingDistance;
+    }
+
+    private static float GetPenetrationTolerance()
+    {
+        return Physics2D.defaultContactOffset *
+            PenetrationToleranceContactOffsetRatio;
+    }
+
+    private void TrackSensor(EnemySeparationCollider sensor)
+    {
+        int sensorId = sensor.GetInstanceID();
+        for (int i = 0; i < overlappingSensors.Count; i++)
+        {
+            EnemySeparationCollider tracked = overlappingSensors[i];
+            if (tracked == sensor)
+                return;
+            if (tracked == null || tracked.GetInstanceID() > sensorId)
+            {
+                overlappingSensors.Insert(i, sensor);
+                return;
+            }
+        }
+
+        overlappingSensors.Add(sensor);
+    }
+
+    private float GetWorldSafeDistance(Vector2 direction, float requestedDistance)
+    {
+        if (requestedDistance <= 0f || primaryCollider == null ||
+            !primaryCollider.enabled || worldFilter.layerMask == 0)
+        {
+            return Mathf.Max(0f, requestedDistance);
+        }
+
+        int hitCount = primaryCollider.Cast(
+            direction,
+            worldFilter,
+            castBuffer,
+            requestedDistance);
+        float allowedDistance = requestedDistance;
+        for (int i = 0; i < hitCount; i++)
+        {
+            RaycastHit2D hit = castBuffer[i];
+            if (hit.collider == null)
+                continue;
+
+            allowedDistance = Mathf.Min(
+                allowedDistance,
+                Mathf.Max(0f, hit.distance - Physics2D.defaultContactOffset));
+        }
+
+        return allowedDistance;
+    }
+
+    private bool IsMovementLocked()
+    {
+        if (rootReceiver == null && body != null)
+            rootReceiver = body.GetComponent<EnemyRootReceiver>();
+        if (staggerReceiver == null && body != null)
+            staggerReceiver = body.GetComponent<EnemyStaggerReceiver>();
+
+        return (rootReceiver != null && rootReceiver.IsRooted) ||
+               (staggerReceiver != null && staggerReceiver.IsActionLocked);
+    }
+
+    private void CacheComponents()
+    {
+        CircleCollider2D sensor = Collider;
+        if (body == null)
+            body = sensor.attachedRigidbody;
+        if (primaryCollider == null && body != null)
+            primaryCollider = body.GetComponent<CircleCollider2D>();
+        if (rootReceiver == null && body != null)
+            rootReceiver = body.GetComponent<EnemyRootReceiver>();
+        if (staggerReceiver == null && body != null)
+            staggerReceiver = body.GetComponent<EnemyStaggerReceiver>();
+    }
+
+    private static EnemySeparationCollider GetSensor(Collider2D candidate)
+    {
+        return candidate != null
+            ? candidate.GetComponent<EnemySeparationCollider>()
+            : null;
+    }
+
+    private static bool CanResolve(Rigidbody2D candidate)
+    {
+        return candidate != null &&
+               candidate.simulated &&
+               candidate.bodyType == RigidbodyType2D.Dynamic;
+    }
+
+    private static LayerMask BuildWorldBlockerMask()
+    {
+        int mask = 0;
+        AddLayer(ref mask, "Player");
+        AddLayer(ref mask, "Walls");
+        AddLayer(ref mask, "Barriers");
+        AddLayer(ref mask, "Gates");
+        AddLayer(ref mask, "Environment");
+        return mask;
+    }
+
+    private static void AddLayer(ref int mask, string layerName)
+    {
+        int layer = LayerMask.NameToLayer(layerName);
+        if (layer >= 0)
+            mask |= 1 << layer;
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemySeparationCollider.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemySeparationCollider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b21d1d6fbe2e4da1bc2c5f871ade8665
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemySeparationMath.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemySeparationMath.cs
@@ -1,0 +1,78 @@
+using UnityEngine;
+
+namespace Castlebound.Gameplay.AI
+{
+    public static class EnemySeparationMath
+    {
+        public static Vector2 ClampInwardDisplacement(
+            Vector2 centerDelta,
+            float minimumDistance,
+            Vector2 proposedDisplacement,
+            float usableAxisThreshold)
+        {
+            float centerDistance = centerDelta.magnitude;
+            if (centerDistance <= usableAxisThreshold)
+                return proposedDisplacement;
+
+            Vector2 inwardAxis = centerDelta / centerDistance;
+            float proposedInwardDistance = Vector2.Dot(
+                proposedDisplacement,
+                inwardAxis);
+            if (proposedInwardDistance <= 0f)
+                return proposedDisplacement;
+
+            Vector2 tangentialDisplacement = proposedDisplacement -
+                inwardAxis * proposedInwardDistance;
+            float requiredRadialDistance = Mathf.Sqrt(Mathf.Max(
+                0f,
+                minimumDistance * minimumDistance -
+                tangentialDisplacement.sqrMagnitude));
+            float allowedInwardDistance = Mathf.Max(
+                0f,
+                centerDistance - requiredRadialDistance);
+            float violatingDistance = proposedInwardDistance - allowedInwardDistance;
+            return violatingDistance > 0f
+                ? proposedDisplacement - inwardAxis * violatingDistance
+                : proposedDisplacement;
+        }
+
+        public static Vector2 ResolveAxis(Vector2 centerDelta, float directStackThreshold)
+        {
+            float distance = centerDelta.magnitude;
+            return distance > directStackThreshold
+                ? centerDelta / distance
+                : Vector2.right;
+        }
+
+        public static void AllocateCorrections(
+            float penetration,
+            float ownCapacity,
+            float otherCapacity,
+            out float ownCorrection,
+            out float otherCorrection)
+        {
+            penetration = Mathf.Max(0f, penetration);
+            ownCapacity = Mathf.Max(0f, ownCapacity);
+            otherCapacity = Mathf.Max(0f, otherCapacity);
+
+            ownCorrection = Mathf.Min(penetration * 0.5f, ownCapacity);
+            otherCorrection = Mathf.Min(penetration * 0.5f, otherCapacity);
+            float remaining = penetration - ownCorrection - otherCorrection;
+            AllocateRemaining(ref ownCorrection, ownCapacity, ref remaining);
+            AllocateRemaining(ref otherCorrection, otherCapacity, ref remaining);
+        }
+
+        private static void AllocateRemaining(
+            ref float correction,
+            float capacity,
+            ref float remaining)
+        {
+            if (remaining <= 0f)
+                return;
+
+            float additional = Mathf.Min(remaining, capacity - correction);
+            correction += additional;
+            remaining -= additional;
+        }
+    }
+}

--- a/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemySeparationMath.cs.meta
+++ b/Assets/_Project/Scripts/_Project.Gameplay/AI/EnemySeparationMath.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c72f0b8cbfa344e8b6f2cf0713cc8f43

--- a/Assets/_Project/Scripts/_Project.Gameplay/Barrier/BarrierHealth.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Barrier/BarrierHealth.cs
@@ -188,7 +188,7 @@ public class BarrierHealth : MonoBehaviour, IDamageable
         for (int i = 0; i < count; i++)
         {
             var other = _overlapBuffer[i];
-            if (other == null)
+            if (other == null || other.GetComponent<EnemySeparationCollider>() != null)
             {
                 continue;
             }

--- a/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerTargetingController.cs
+++ b/Assets/_Project/Scripts/_Project.Gameplay/Tower/TowerTargetingController.cs
@@ -129,6 +129,11 @@ namespace Castlebound.Gameplay.Tower
                 return false;
             }
 
+            if (candidateCollider.GetComponent<EnemySeparationCollider>() != null)
+            {
+                return false;
+            }
+
             if (candidateCollider.transform == transform || candidateCollider.transform.IsChildOf(transform))
             {
                 return false;

--- a/Assets/_Project/_Tests/EditMode/AI/EnemyApproachSpreadTests.cs
+++ b/Assets/_Project/_Tests/EditMode/AI/EnemyApproachSpreadTests.cs
@@ -39,6 +39,75 @@ namespace Castlebound.Tests.AI
             Assert.That(tangent.y, Is.LessThan(0f));
         }
 
+        [Test]
+        public void LongitudinalCompression_UsesStableBiasToCreateApproachLane()
+        {
+            EnemyApproachSpread.ComputeApproach(
+                Vector2.right * 8f,
+                Vector2.right,
+                Vector2.left * 0.75f,
+                hasNeighbors: true,
+                stableBias: Vector2.up,
+                speed: 8f,
+                separationStrength: 0.8f,
+                maxLateralRatio: 0.35f,
+                minimumForwardRatio: 0.8f,
+                out Vector2 radial,
+                out Vector2 tangent);
+
+            Assert.That(tangent.y, Is.GreaterThan(0f));
+            Assert.That(radial.x, Is.GreaterThanOrEqualTo(6.4f));
+            Assert.That((radial + tangent).magnitude, Is.LessThanOrEqualTo(8.001f));
+        }
+
+        [Test]
+        public void LongitudinalLaneAssist_FadesAsSurroundArrivalTakesOver()
+        {
+            EnemyApproachSpread.ComputeApproach(
+                Vector2.right * 8f, Vector2.right, Vector2.left * 0.75f,
+                hasNeighbors: true, stableBias: Vector2.up,
+                distance: 13f, engagementDistance: 2.6f,
+                gapCW: 0.2f, gapCCW: 0.2f, hasGroup: true, speed: 8f,
+                separationStrength: 0.8f, maxLateralRatio: 0.35f,
+                minimumForwardRatio: 0.8f, surroundArrivalDistance: 10f,
+                maxAngularArrivalRatio: 0.18f, gapDeadbandRadians: 8f * Mathf.Deg2Rad,
+                out _, out Vector2 distantTangent);
+
+            EnemyApproachSpread.ComputeApproach(
+                Vector2.right * 8f, Vector2.right, Vector2.left * 0.75f,
+                hasNeighbors: true, stableBias: Vector2.up,
+                distance: 3.6f, engagementDistance: 2.6f,
+                gapCW: 0.2f, gapCCW: 0.2f, hasGroup: true, speed: 8f,
+                separationStrength: 0.8f, maxLateralRatio: 0.35f,
+                minimumForwardRatio: 0.8f, surroundArrivalDistance: 10f,
+                maxAngularArrivalRatio: 0.18f, gapDeadbandRadians: 8f * Mathf.Deg2Rad,
+                out _, out Vector2 arrivingTangent);
+
+            Assert.That(distantTangent.y, Is.GreaterThan(0f));
+            Assert.That(arrivingTangent.y, Is.GreaterThan(0f));
+            Assert.That(arrivingTangent.magnitude,
+                Is.LessThan(distantTangent.magnitude * 0.2f));
+        }
+
+        [Test]
+        public void LateralSeparation_RemainsAuthoritativeOverStableLaneBias()
+        {
+            EnemyApproachSpread.ComputeApproach(
+                Vector2.right * 8f,
+                Vector2.right,
+                Vector2.up,
+                hasNeighbors: true,
+                stableBias: Vector2.down,
+                speed: 8f,
+                separationStrength: 0.8f,
+                maxLateralRatio: 0.35f,
+                minimumForwardRatio: 0.8f,
+                out _,
+                out Vector2 tangent);
+
+            Assert.That(tangent.y, Is.GreaterThan(0f));
+        }
+
         [TestCase(false)]
         [TestCase(true)]
         public void UncrowdedApproach_RemainsDirect(bool hasNeighbors)

--- a/Assets/_Project/_Tests/EditMode/AI/EnemySeparationMathTests.cs
+++ b/Assets/_Project/_Tests/EditMode/AI/EnemySeparationMathTests.cs
@@ -1,0 +1,100 @@
+using Castlebound.Gameplay.AI;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Castlebound.Tests.AI
+{
+    public class EnemySeparationMathTests
+    {
+        [Test]
+        public void ClampInwardDisplacement_RemovesOnlyMinimumFootprintViolation()
+        {
+            Vector2 result = EnemySeparationMath.ClampInwardDisplacement(
+                new Vector2(0.42f, 0f),
+                0.4f,
+                new Vector2(0.05f, 0.03f),
+                0.001f);
+
+            float expectedInward = 0.42f - Mathf.Sqrt(0.4f * 0.4f - 0.03f * 0.03f);
+            Assert.That(result.x, Is.EqualTo(expectedInward).Within(0.000001f));
+            Assert.That(result.y, Is.EqualTo(0.03f).Within(0.000001f));
+        }
+
+        [Test]
+        public void ClampInwardDisplacement_PreservesOutwardMovement()
+        {
+            Vector2 proposed = new Vector2(-0.05f, 0.03f);
+            Vector2 result = EnemySeparationMath.ClampInwardDisplacement(
+                new Vector2(0.4f, 0f),
+                0.4f,
+                proposed,
+                0.001f);
+
+            Assert.That(result, Is.EqualTo(proposed));
+        }
+
+        [Test]
+        public void ClampInwardDisplacement_DoesNotPermitCrossingThroughFootprint()
+        {
+            Vector2 result = EnemySeparationMath.ClampInwardDisplacement(
+                new Vector2(0.4f, 0f),
+                0.4f,
+                Vector2.right,
+                0.001f);
+
+            Assert.That(result, Is.EqualTo(Vector2.zero));
+        }
+
+        [Test]
+        public void ResolveAxis_ExactCoincidence_UsesStableFallback()
+        {
+            Assert.That(
+                EnemySeparationMath.ResolveAxis(Vector2.zero, 0.001f),
+                Is.EqualTo(Vector2.right));
+        }
+
+        [Test]
+        public void AllocateCorrections_OneSideBlocked_MovesOnlyAvailableSide()
+        {
+            EnemySeparationMath.AllocateCorrections(
+                0.1f,
+                0f,
+                0.1f,
+                out float blockedCorrection,
+                out float availableCorrection);
+
+            Assert.That(blockedCorrection, Is.Zero);
+            Assert.That(availableCorrection, Is.EqualTo(0.1f).Within(0.000001f));
+        }
+
+        [Test]
+        public void AllocateCorrections_OpposingStep_SplitsFullPenetration()
+        {
+            EnemySeparationMath.AllocateCorrections(
+                0.08f,
+                0.05f,
+                0.05f,
+                out float firstCorrection,
+                out float secondCorrection);
+
+            Assert.That(firstCorrection, Is.EqualTo(0.04f).Within(0.000001f));
+            Assert.That(secondCorrection, Is.EqualTo(0.04f).Within(0.000001f));
+            Assert.That(firstCorrection + secondCorrection,
+                Is.EqualTo(0.08f).Within(0.000001f));
+        }
+
+        [Test]
+        public void AllocateCorrections_BothSidesBlocked_DoesNotCreateMovement()
+        {
+            EnemySeparationMath.AllocateCorrections(
+                0.1f,
+                0f,
+                0f,
+                out float firstCorrection,
+                out float secondCorrection);
+
+            Assert.That(firstCorrection, Is.Zero);
+            Assert.That(secondCorrection, Is.Zero);
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/AI/EnemySeparationMathTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/AI/EnemySeparationMathTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fd4a80e695f148f285119e1921107cd8

--- a/Assets/_Project/_Tests/EditMode/AI/EnemySeparationPrefabContractTests.cs
+++ b/Assets/_Project/_Tests/EditMode/AI/EnemySeparationPrefabContractTests.cs
@@ -1,0 +1,109 @@
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+
+namespace Castlebound.Tests.AI
+{
+    public class EnemySeparationPrefabContractTests
+    {
+        private const float PrimaryBodyRadius = 0.87684506f;
+        private const float SeparationRadius = 0.2f;
+
+        [TestCase("Assets/_Project/Prefabs/Enemy_Goblin_Melee.prefab")]
+        [TestCase("Assets/_Project/Prefabs/Enemy_Goblin_Ranged.prefab")]
+        [TestCase("Assets/_Project/Prefabs/Enemy_Lurker.prefab")]
+        public void ActiveEnemyPrefab_IsolatesAConsistentSmallSeparationFootprint(
+            string prefabPath)
+        {
+            GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>(prefabPath);
+
+            Assert.NotNull(prefab, $"Expected enemy prefab at {prefabPath}.");
+            Assert.That(prefab.tag, Is.EqualTo("Enemy"));
+            Assert.That(LayerMask.LayerToName(prefab.layer), Is.EqualTo("Enemies"));
+
+            Rigidbody2D body = prefab.GetComponent<Rigidbody2D>();
+            Assert.NotNull(body);
+            Assert.That(body.bodyType, Is.EqualTo(RigidbodyType2D.Dynamic));
+            Assert.That(body.collisionDetectionMode, Is.EqualTo(CollisionDetectionMode2D.Continuous));
+            Assert.That(body.constraints & RigidbodyConstraints2D.FreezeRotation,
+                Is.EqualTo(RigidbodyConstraints2D.FreezeRotation));
+
+            CircleCollider2D primary = prefab.GetComponent<CircleCollider2D>();
+            Assert.NotNull(primary);
+            Assert.IsFalse(primary.isTrigger);
+            Assert.That(primary.radius, Is.EqualTo(PrimaryBodyRadius).Within(0.000001f),
+                "The existing combat/body footprint must not be resized.");
+
+            var engagementData = new SerializedObject(prefab.GetComponent<EnemyEngagement>());
+            Assert.That(
+                engagementData.FindProperty("bodyCollider").objectReferenceValue,
+                Is.SameAs(primary),
+                "Engagement distance must continue to use the primary body collider.");
+
+            Transform separationTransform = prefab.transform.Find("EnemySeparation");
+            Assert.NotNull(separationTransform);
+            Assert.That(LayerMask.LayerToName(separationTransform.gameObject.layer),
+                Is.EqualTo("Enemies"));
+            Assert.That(separationTransform.tag, Is.EqualTo("Untagged"),
+                "The separation footprint must not become an Enemy-tagged hurtbox.");
+            Assert.That(separationTransform.localPosition, Is.EqualTo(Vector3.zero));
+            Assert.That(separationTransform.localScale, Is.EqualTo(Vector3.one));
+
+            EnemySeparationCollider marker =
+                separationTransform.GetComponent<EnemySeparationCollider>();
+            CircleCollider2D separation = separationTransform.GetComponent<CircleCollider2D>();
+            Assert.NotNull(marker);
+            Assert.NotNull(separation);
+            Assert.That(marker.Collider, Is.SameAs(separation));
+            Assert.IsTrue(separation.isTrigger,
+                "The separation footprint must detect overlaps without physical impulses.");
+            Assert.That(separation.radius, Is.EqualTo(SeparationRadius).Within(0.000001f));
+            Assert.That(separation.radius, Is.LessThan(primary.radius * 0.25f));
+
+            SpriteRenderer sprite = prefab.GetComponentInChildren<SpriteRenderer>(true);
+            Assert.NotNull(sprite);
+            Assert.NotNull(sprite.sprite);
+            Assert.That(separation.radius * 2f,
+                Is.LessThan(Mathf.Min(sprite.sprite.bounds.size.x, sprite.sprite.bounds.size.y)),
+                "The physical minimum footprint must still permit visible sprite overlap.");
+
+            Assert.IsNull(separation.sharedMaterial,
+                "A non-impulse trigger must not retain the obsolete solid-contact material.");
+
+            int enemiesMask = 1 << LayerMask.NameToLayer("Enemies");
+            Assert.That(separation.includeLayers.value, Is.EqualTo(enemiesMask));
+            Assert.That(separation.excludeLayers.value, Is.EqualTo(~enemiesMask));
+            Assert.That(separation.forceSendLayers.value, Is.Zero,
+                "The sensor must not transmit knockback or separation impulses.");
+            Assert.That(separation.forceReceiveLayers.value, Is.Zero,
+                "The sensor must not receive knockback or separation impulses.");
+            Assert.That(separation.contactCaptureLayers.value, Is.EqualTo(enemiesMask));
+            Assert.That(separation.callbackLayers.value, Is.EqualTo(enemiesMask),
+                "Only Enemy overlaps may invoke bounded depenetration.");
+            Assert.That(primary.includeLayers.value & enemiesMask, Is.Zero);
+            Assert.That(primary.excludeLayers.value & enemiesMask, Is.EqualTo(enemiesMask));
+            Assert.That(primary.layerOverridePriority,
+                Is.GreaterThan(separation.layerOverridePriority),
+                "Primary-vs-separation conflicts must preserve the primary exclusion.");
+
+            Collider2D[] colliders = prefab.GetComponentsInChildren<Collider2D>(true);
+            Assert.That(colliders, Has.Length.EqualTo(2));
+            Assert.That(colliders, Does.Contain(primary));
+            Assert.That(colliders, Does.Contain(separation));
+        }
+
+        [Test]
+        public void ProjectCollisionContract_LeavesEnemiesSelfCollisionDisabledGlobally()
+        {
+            int enemiesLayer = LayerMask.NameToLayer("Enemies");
+
+            Assert.That(enemiesLayer, Is.EqualTo(7),
+                "Issue #277 must not add or remap project layers.");
+            Assert.IsTrue(Physics2D.GetIgnoreLayerCollision(enemiesLayer, enemiesLayer),
+                "Enemy self-contact must remain a per-collider override, not a global matrix change.");
+            Assert.That(LayerMask.NameToLayer("Player"), Is.EqualTo(3));
+            Assert.That(LayerMask.NameToLayer("Walls"), Is.EqualTo(6));
+            Assert.That(LayerMask.NameToLayer("Environment"), Is.EqualTo(11));
+        }
+    }
+}

--- a/Assets/_Project/_Tests/EditMode/AI/EnemySeparationPrefabContractTests.cs.meta
+++ b/Assets/_Project/_Tests/EditMode/AI/EnemySeparationPrefabContractTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 53962910e95d446ca74065a1938ec2da
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/_Tests/PlayMode/AI/EnemyApproachSpreadPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/AI/EnemyApproachSpreadPlayTests.cs
@@ -41,6 +41,49 @@ namespace Castlebound.Tests.PlayMode.AI
         }
 
         [UnityTest]
+        public IEnumerator LongitudinallyCompressedGroup_DevelopsApproachLanesBeforeHardContact()
+        {
+            var player = CreatePlayer();
+            var managerObject = new GameObject("EnemyRingManager");
+            var enemies = new[]
+            {
+                CreateEnemy(player.transform, new Vector2(16f, 0f)),
+                CreateEnemy(player.transform, new Vector2(15.4f, 0f)),
+                CreateEnemy(player.transform, new Vector2(14.5f, 0f)),
+                CreateEnemy(player.transform, new Vector2(13.8f, 0f)),
+                CreateEnemy(player.transform, new Vector2(12.6f, 0f))
+            };
+            try
+            {
+                managerObject.AddComponent<EnemyRingManager>();
+                float startingAverageX = AverageX(enemies);
+
+                for (int i = 0; i < 10; i++)
+                    yield return new WaitForFixedUpdate();
+
+                float[] lateralPositions = GetSortedY(enemies);
+                Assert.That(lateralPositions[4] - lateralPositions[0],
+                    Is.GreaterThan(0.12f),
+                    "Longitudinal crowd pressure should produce early approach lanes.");
+                Assert.That(CountDistinct(lateralPositions, 0.025f),
+                    Is.GreaterThanOrEqualTo(3));
+                Assert.That(AverageX(enemies), Is.LessThan(startingAverageX - 1f),
+                    "Lane formation must preserve clear forward chase progress.");
+                Assert.That(Vector2.Distance(
+                        enemies[4].transform.position,
+                        player.transform.position),
+                    Is.GreaterThan(10f),
+                    "Lane formation should occur before near-Player surround steering dominates.");
+            }
+            finally
+            {
+                DestroyEnemies(enemies);
+                Object.Destroy(managerObject);
+                Object.Destroy(player);
+            }
+        }
+
+        [UnityTest]
         public IEnumerator AlreadySpacedGroup_ContinuesMostlyForward()
         {
             var player = CreatePlayer();
@@ -151,6 +194,14 @@ namespace Castlebound.Tests.PlayMode.AI
             for (int i = 1; i < sortedValues.Length; i++)
                 if (sortedValues[i] - sortedValues[i - 1] > tolerance) count++;
             return count;
+        }
+
+        private static float AverageX(GameObject[] enemies)
+        {
+            float sum = 0f;
+            for (int i = 0; i < enemies.Length; i++)
+                sum += enemies[i].transform.position.x;
+            return sum / enemies.Length;
         }
 
         private static void SetField(object instance, string fieldName, object value)

--- a/Assets/_Project/_Tests/PlayMode/AI/EnemySeparationPlayTests.cs
+++ b/Assets/_Project/_Tests/PlayMode/AI/EnemySeparationPlayTests.cs
@@ -1,0 +1,546 @@
+using System.Collections;
+using System.Reflection;
+using Castlebound.Gameplay.AI;
+using Castlebound.Gameplay.Projectile;
+using Castlebound.Gameplay.World.Placement;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Castlebound.Tests.PlayMode.AI
+{
+    public class EnemySeparationPlayTests
+    {
+        private const string MeleePath =
+            "Assets/_Project/Prefabs/Enemy_Goblin_Melee.prefab";
+        private const string RangedPath =
+            "Assets/_Project/Prefabs/Enemy_Goblin_Ranged.prefab";
+        private const string LurkerPath =
+            "Assets/_Project/Prefabs/Enemy_Lurker.prefab";
+
+        [UnityTest]
+        public IEnumerator OpposingMovePositionEnemies_StopAtTheMinimumFootprint()
+        {
+            GameObject left = CreateEnemy(MeleePath, new Vector2(-1f, 0f));
+            GameObject right = CreateEnemy(MeleePath, new Vector2(1f, 0f));
+
+            try
+            {
+                for (int i = 0; i < 50; i++)
+                {
+                    left.GetComponent<Rigidbody2D>().MovePosition(
+                        left.GetComponent<Rigidbody2D>().position + Vector2.right * 0.04f);
+                    right.GetComponent<Rigidbody2D>().MovePosition(
+                        right.GetComponent<Rigidbody2D>().position + Vector2.left * 0.04f);
+                    yield return new WaitForFixedUpdate();
+                }
+
+                AssertMinimumSeparation(left, right);
+                AssertSpritesCanOverlap(left, right);
+            }
+            finally
+            {
+                DestroyNow(left, right);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator SustainedInwardLocomotion_ClampsAtMinimumWithoutRepeatedHardCorrection()
+        {
+            GameObject left = CreateEnemy(MeleePath, new Vector2(-0.19f, 0f));
+            GameObject right = CreateEnemy(RangedPath, new Vector2(0.19f, 0f));
+
+            try
+            {
+                for (int i = 0; i < 3; i++)
+                    yield return new WaitForFixedUpdate();
+
+                EnemySeparationCollider leftSensor =
+                    left.GetComponentInChildren<EnemySeparationCollider>();
+                EnemySeparationCollider rightSensor =
+                    right.GetComponentInChildren<EnemySeparationCollider>();
+                leftSensor.Debug_ResetFallbackCorrectionCount();
+                rightSensor.Debug_ResetFallbackCorrectionCount();
+
+                Rigidbody2D leftBody = left.GetComponent<Rigidbody2D>();
+                Rigidbody2D rightBody = right.GetComponent<Rigidbody2D>();
+                EnemyLocomotion leftLocomotion = left.GetComponent<EnemyLocomotion>();
+                EnemyLocomotion rightLocomotion = right.GetComponent<EnemyLocomotion>();
+                float minimumDistance = leftSensor.Collider.bounds.extents.x +
+                    rightSensor.Collider.bounds.extents.x;
+                float minimumObserved = float.PositiveInfinity;
+                float settledMinimum = float.PositiveInfinity;
+                float settledMaximum = float.NegativeInfinity;
+                Vector2 startingMidpoint = (leftBody.position + rightBody.position) * 0.5f;
+
+                for (int step = 0; step < 30; step++)
+                {
+                    Vector2 pairDelta = rightSensor.Collider.bounds.center -
+                        leftSensor.Collider.bounds.center;
+                    Vector2 pairNormal = pairDelta.sqrMagnitude > 0f
+                        ? pairDelta.normalized
+                        : Vector2.right;
+                    Vector2 sharedTangent = new Vector2(
+                        -pairNormal.y,
+                        pairNormal.x) * 0.5f;
+
+                    Assert.IsTrue(leftLocomotion.ExecuteMovement(
+                        leftBody,
+                        pairNormal * 2f,
+                        sharedTangent,
+                        Time.fixedDeltaTime));
+                    Assert.IsTrue(rightLocomotion.ExecuteMovement(
+                        rightBody,
+                        -pairNormal * 2f,
+                        sharedTangent,
+                        Time.fixedDeltaTime));
+                    yield return new WaitForFixedUpdate();
+
+                    float distance = Vector2.Distance(
+                        leftSensor.Collider.bounds.center,
+                        rightSensor.Collider.bounds.center);
+                    minimumObserved = Mathf.Min(minimumObserved, distance);
+                    if (step >= 10)
+                    {
+                        settledMinimum = Mathf.Min(settledMinimum, distance);
+                        settledMaximum = Mathf.Max(settledMaximum, distance);
+                    }
+                }
+
+                Assert.That(minimumObserved,
+                    Is.GreaterThanOrEqualTo(minimumDistance - 0.005f));
+                Assert.That(settledMaximum - settledMinimum, Is.LessThan(0.01f),
+                    "Sustained convergence must settle without threshold oscillation.");
+                Assert.That(
+                    leftSensor.DebugFallbackCorrectionCount +
+                    rightSensor.DebugFallbackCorrectionCount,
+                    Is.LessThanOrEqualTo(1),
+                    "Ordinary locomotion must not rely on repeated fallback correction.");
+                Vector2 endingMidpoint = (leftBody.position + rightBody.position) * 0.5f;
+                Assert.That(Vector2.Distance(startingMidpoint, endingMidpoint),
+                    Is.GreaterThan(0.2f),
+                    "The hard minimum must preserve tangential movement.");
+                AssertSpritesCanOverlap(left, right);
+            }
+            finally
+            {
+                DestroyNow(left, right);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator CoincidentMixedEnemies_RecoverWithoutLosingDenseOverlap()
+        {
+            GameObject melee = CreateEnemy(MeleePath, Vector2.zero);
+            GameObject ranged = CreateEnemy(RangedPath, Vector2.zero);
+
+            try
+            {
+                for (int i = 0; i < 12; i++)
+                    yield return new WaitForFixedUpdate();
+
+                AssertMinimumSeparation(melee, ranged);
+                AssertSpritesCanOverlap(melee, ranged);
+            }
+            finally
+            {
+                DestroyNow(melee, ranged);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator DenseMixedGroup_ProgressesBesideWallVaultAndBarrier()
+        {
+            int wallsLayer = LayerMask.NameToLayer("Walls");
+            int barriersLayer = LayerMask.NameToLayer("Barriers");
+            var wall = CreateBlocker(
+                "Wall",
+                wallsLayer,
+                new Vector2(0f, -1.8f),
+                new Vector2(10f, 0.4f));
+            var vault = CreateBlocker(
+                "Vault",
+                wallsLayer,
+                new Vector2(0f, 1.8f),
+                new Vector2(1.1f, 0.4f));
+            var barrier = CreateBlocker(
+                "Barrier",
+                barriersLayer,
+                new Vector2(1f, 0f),
+                new Vector2(0.5f, 2.8f));
+            GameObject[] enemies =
+            {
+                CreateEnemy(MeleePath, new Vector2(-3f, -0.55f)),
+                CreateEnemy(RangedPath, new Vector2(-3f, -0.15f)),
+                CreateEnemy(LurkerPath, new Vector2(-3f, 0.25f)),
+                CreateEnemy(MeleePath, new Vector2(-3.45f, -0.35f)),
+                CreateEnemy(RangedPath, new Vector2(-3.45f, 0.05f)),
+                CreateEnemy(LurkerPath, new Vector2(-3.45f, 0.45f))
+            };
+
+            try
+            {
+                float startAverageX = AverageX(enemies);
+                for (int step = 0; step < 100; step++)
+                {
+                    for (int i = 0; i < enemies.Length; i++)
+                    {
+                        Rigidbody2D body = enemies[i].GetComponent<Rigidbody2D>();
+                        body.MovePosition(body.position + Vector2.right * 0.04f);
+                    }
+
+                    yield return new WaitForFixedUpdate();
+                }
+
+                for (int i = 0; i < 4; i++)
+                    yield return new WaitForFixedUpdate();
+
+                Assert.That(AverageX(enemies), Is.GreaterThan(startAverageX + 1f),
+                    "A dense mixed crowd must continue progressing toward its blocker.");
+                AssertAllPairsSeparated(enemies);
+
+                for (int i = 0; i < enemies.Length; i++)
+                {
+                    CircleCollider2D primary = enemies[i].GetComponent<CircleCollider2D>();
+                    AssertStableAgainst(primary, wall);
+                    AssertStableAgainst(primary, vault);
+                    AssertStableAgainst(primary, barrier);
+                    AssertSeparationIgnoresWorld(enemies[i], wall, vault, barrier);
+                    Assert.That(enemies[i].GetComponent<Rigidbody2D>().velocity.sqrMagnitude,
+                        Is.LessThan(100f),
+                        "World-adjacent crowd contact must not launch an enemy.");
+                }
+            }
+            finally
+            {
+                DestroyNow(enemies);
+                DestroyNow(wall.gameObject, vault.gameObject, barrier.gameObject);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator RootStaggerAndKnockbackRemainFunctionalInASeparatedCrowd()
+        {
+            GameObject rooted = CreateEnemy(MeleePath, Vector2.zero);
+            GameObject rootNeighbor = CreateEnemy(RangedPath, new Vector2(0.3f, 0f));
+            GameObject staggered = CreateEnemy(MeleePath, new Vector2(2f, 0f));
+            GameObject staggerNeighbor = CreateEnemy(LurkerPath, new Vector2(2.3f, 0f));
+            GameObject knocked = CreateEnemy(MeleePath, new Vector2(-3f, 0f));
+            GameObject knockNeighbor = CreateEnemy(RangedPath, new Vector2(-2.55f, 0f));
+
+            try
+            {
+                EnemyRootReceiver root = rooted.GetComponent<EnemyRootReceiver>() ??
+                    rooted.AddComponent<EnemyRootReceiver>();
+                root.RootAt(Vector2.zero, 1f);
+                float rootContactCorrection = ContactCorrectionAllowance(rooted, rootNeighbor);
+                Assert.IsFalse(rooted.GetComponent<EnemyLocomotion>().ExecuteMovement(
+                    rooted.GetComponent<Rigidbody2D>(),
+                    Vector2.right * 10f,
+                    Vector2.zero,
+                    0.1f),
+                    "Root must reject locomotion even while resolving Enemy contact.");
+
+                EnemyController2D staggerController = staggered.GetComponent<EnemyController2D>();
+                staggerController.enabled = true;
+                EnemyStaggerReceiver stagger = staggered.GetComponent<EnemyStaggerReceiver>();
+                Assert.NotNull(stagger);
+                Assert.IsTrue(stagger.TryStagger());
+                float staggerContactCorrection = ContactCorrectionAllowance(
+                    staggered,
+                    staggerNeighbor);
+
+                EnemyKnockbackReceiver knockback = knocked.GetComponent<EnemyKnockbackReceiver>();
+                EnemyLocomotion locomotion = knocked.GetComponent<EnemyLocomotion>();
+                knockback.AddKnockback(Vector2.right * 8f, 5f);
+                Assert.IsTrue(locomotion.ExecuteMovement(
+                    knocked.GetComponent<Rigidbody2D>(),
+                    Vector2.zero,
+                    Vector2.zero,
+                    0.1f));
+
+                for (int i = 0; i < 6; i++)
+                    yield return new WaitForFixedUpdate();
+
+                Assert.That(rooted.GetComponent<Rigidbody2D>().position.magnitude,
+                    Is.LessThanOrEqualTo(rootContactCorrection),
+                    "Root must remain immovable during hard separation.");
+                Assert.IsTrue(root.IsRooted);
+                AssertMinimumSeparation(rooted, rootNeighbor);
+                Assert.That(Vector2.Distance(
+                        staggered.GetComponent<Rigidbody2D>().position,
+                        stagger.LockPosition),
+                    Is.LessThanOrEqualTo(staggerContactCorrection),
+                    "Stagger must retain its authored movement lock.");
+                Assert.That(stagger.State, Is.EqualTo(EnemyStaggerState.Staggered));
+                AssertMinimumSeparation(staggered, staggerNeighbor);
+                Assert.That(knocked.GetComponent<Rigidbody2D>().position.x, Is.GreaterThan(-2.95f),
+                    "Knockback displacement must still be consumed.");
+                Assert.That(knockNeighbor.GetComponent<Rigidbody2D>().position.x, Is.LessThan(-1.5f),
+                    "A nearby enemy must not be launched into a chain reaction.");
+            }
+            finally
+            {
+                DestroyNow(rooted, rootNeighbor, staggered, staggerNeighbor, knocked, knockNeighbor);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator LockedCoincidentPair_WaitsUntilOneEnemyCanMove()
+        {
+            GameObject first = CreateEnemy(MeleePath, Vector2.zero);
+            GameObject second = CreateEnemy(RangedPath, Vector2.zero);
+
+            try
+            {
+                EnemyRootReceiver firstRoot = first.GetComponent<EnemyRootReceiver>() ??
+                    first.AddComponent<EnemyRootReceiver>();
+                EnemyRootReceiver secondRoot = second.GetComponent<EnemyRootReceiver>() ??
+                    second.AddComponent<EnemyRootReceiver>();
+                firstRoot.RootAt(Vector2.zero, 1f);
+                secondRoot.RootAt(Vector2.zero, 1f);
+
+                for (int i = 0; i < 4; i++)
+                    yield return new WaitForFixedUpdate();
+
+                Assert.That(first.GetComponent<Rigidbody2D>().position.magnitude,
+                    Is.LessThanOrEqualTo(Physics2D.defaultContactOffset));
+                Assert.That(second.GetComponent<Rigidbody2D>().position.magnitude,
+                    Is.LessThanOrEqualTo(Physics2D.defaultContactOffset));
+
+                firstRoot.ClearRoot();
+                for (int i = 0; i < 12; i++)
+                    yield return new WaitForFixedUpdate();
+
+                Assert.That(second.GetComponent<Rigidbody2D>().position.magnitude,
+                    Is.LessThanOrEqualTo(Physics2D.defaultContactOffset),
+                    "The still-rooted enemy must remain immovable.");
+                AssertMinimumSeparation(first, second);
+            }
+            finally
+            {
+                DestroyNow(first, second);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator SeparationChild_DoesNotBecomeAHitProjectileOrTrapTarget()
+        {
+            int enemiesLayer = LayerMask.NameToLayer("Enemies");
+            GameObject enemy = CreateEnemy(MeleePath, Vector2.zero);
+            CircleCollider2D primary = enemy.GetComponent<CircleCollider2D>();
+            Health health = enemy.GetComponent<Health>();
+            int startingHealth = health.Current;
+            primary.enabled = false;
+
+            var hitboxObject = new GameObject("Hitbox");
+            hitboxObject.layer = LayerMask.NameToLayer("Default");
+            var hitCollider = hitboxObject.AddComponent<CircleCollider2D>();
+            hitCollider.isTrigger = true;
+            hitCollider.radius = 0.5f;
+            Hitbox hitbox = hitboxObject.AddComponent<Hitbox>();
+            hitbox.Activate();
+
+            GameObject trapPrefab = AssetDatabase.LoadAssetAtPath<GameObject>(
+                "Assets/_Project/Prefabs/BearTrap.prefab");
+            GameObject trapObject = Object.Instantiate(trapPrefab, Vector3.zero, Quaternion.identity);
+            BearTrapTrigger trap = trapObject.GetComponent<BearTrapTrigger>();
+
+            GameObject projectilePrefab = AssetDatabase.LoadAssetAtPath<GameObject>(
+                "Assets/_Project/Prefabs/Projectile_Rock.prefab");
+            GameObject projectileObject = Object.Instantiate(
+                projectilePrefab,
+                Vector3.zero,
+                Quaternion.identity);
+            ProjectileRuntime projectile = projectileObject.GetComponent<ProjectileRuntime>();
+            projectile.Launch(new ProjectileLaunchContext(
+                Vector2.zero,
+                Vector2.right,
+                null,
+                0.01f,
+                1,
+                1f,
+                (LayerMask)(1 << enemiesLayer)));
+
+            try
+            {
+                yield return new WaitForFixedUpdate();
+                yield return null;
+
+                Assert.That(health.Current, Is.EqualTo(startingHealth));
+                Assert.IsFalse(trap.IsSpent);
+                Assert.NotNull(projectile);
+                Assert.IsTrue(projectile.GetComponent<Collider2D>().enabled,
+                    "The projectile must not impact the separation-only child.");
+            }
+            finally
+            {
+                DestroyNow(enemy, hitboxObject, trapObject, projectileObject);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator PlayerSweepStillStopsOnThePrimaryEnemyBody()
+        {
+            int playerLayer = LayerMask.NameToLayer("Player");
+            int enemiesLayer = LayerMask.NameToLayer("Enemies");
+            GameObject enemy = CreateEnemy(MeleePath, Vector2.zero);
+            CircleCollider2D enemyPrimary = enemy.GetComponent<CircleCollider2D>();
+            var player = new GameObject("Player");
+            player.layer = playerLayer;
+            player.transform.position = new Vector2(-3f, 0f);
+            Rigidbody2D playerBody = player.AddComponent<Rigidbody2D>();
+            playerBody.bodyType = RigidbodyType2D.Kinematic;
+            CircleCollider2D playerCollider = player.AddComponent<CircleCollider2D>();
+            playerCollider.radius = 0.4f;
+            PlayerCollisionMove2D mover = player.AddComponent<PlayerCollisionMove2D>();
+            mover.MoveSpeed = 3f;
+            SetField(mover, "solidMask", (LayerMask)(1 << enemiesLayer));
+            mover.SetMoveInput(Vector2.right);
+
+            try
+            {
+                for (int i = 0; i < 80; i++)
+                    yield return new WaitForFixedUpdate();
+
+                Physics2D.SyncTransforms();
+                Assert.IsFalse(Physics2D.Distance(playerCollider, enemyPrimary).isOverlapped);
+                float centerDistance = Vector2.Distance(playerBody.position, enemy.transform.position);
+                float expectedContactDistance = playerCollider.radius + enemyPrimary.radius;
+                Assert.That(centerDistance,
+                    Is.InRange(expectedContactDistance - 0.02f, expectedContactDistance + 0.08f),
+                    "Player movement must retain the existing primary-body contact distance.");
+            }
+            finally
+            {
+                DestroyNow(enemy, player);
+            }
+        }
+
+        private static GameObject CreateEnemy(string path, Vector2 position)
+        {
+            GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>(path);
+            Assert.NotNull(prefab, $"Missing enemy prefab at {path}.");
+            GameObject enemy = Object.Instantiate(prefab, position, Quaternion.identity);
+            EnemyController2D controller = enemy.GetComponent<EnemyController2D>();
+            if (controller != null)
+                controller.enabled = false;
+            EnemyAttack attack = enemy.GetComponent<EnemyAttack>();
+            if (attack != null)
+                attack.enabled = false;
+            return enemy;
+        }
+
+        private static BoxCollider2D CreateBlocker(
+            string name,
+            int layer,
+            Vector2 position,
+            Vector2 size)
+        {
+            var blocker = new GameObject(name);
+            blocker.layer = layer;
+            blocker.transform.position = position;
+            BoxCollider2D collider = blocker.AddComponent<BoxCollider2D>();
+            collider.size = size;
+            return collider;
+        }
+
+        private static void AssertMinimumSeparation(GameObject a, GameObject b)
+        {
+            CircleCollider2D footprintA =
+                a.GetComponentInChildren<EnemySeparationCollider>().Collider;
+            CircleCollider2D footprintB =
+                b.GetComponentInChildren<EnemySeparationCollider>().Collider;
+            float minimum = footprintA.bounds.extents.x + footprintB.bounds.extents.x;
+            float actual = Vector2.Distance(
+                footprintA.bounds.center,
+                footprintB.bounds.center);
+            Assert.That(actual, Is.GreaterThanOrEqualTo(minimum - 0.03f),
+                "Enemies must not settle effectively center-on-center.");
+        }
+
+        private static void AssertSpritesCanOverlap(GameObject a, GameObject b)
+        {
+            SpriteRenderer spriteA = a.GetComponentInChildren<SpriteRenderer>(true);
+            SpriteRenderer spriteB = b.GetComponentInChildren<SpriteRenderer>(true);
+            float visibleWidth = Mathf.Min(spriteA.bounds.size.x, spriteB.bounds.size.x);
+            float actual = Vector2.Distance(a.transform.position, b.transform.position);
+            Assert.That(actual, Is.LessThan(visibleWidth),
+                "The minimum footprint must remain smaller than the visible sprites.");
+        }
+
+        private static void AssertAllPairsSeparated(GameObject[] enemies)
+        {
+            for (int i = 0; i < enemies.Length; i++)
+            {
+                for (int j = i + 1; j < enemies.Length; j++)
+                    AssertMinimumSeparation(enemies[i], enemies[j]);
+            }
+        }
+
+        private static void AssertStableAgainst(Collider2D actor, Collider2D blocker)
+        {
+            Physics2D.SyncTransforms();
+            ColliderDistance2D distance = Physics2D.Distance(actor, blocker);
+            Assert.That(distance.distance,
+                Is.GreaterThanOrEqualTo(-Physics2D.defaultContactOffset),
+                $"{actor.name} must remain stable beside {blocker.name}; " +
+                $"signed distance was {distance.distance}.");
+        }
+
+        private static void AssertSeparationIgnoresWorld(
+            GameObject enemy,
+            params Collider2D[] blockers)
+        {
+            CircleCollider2D separation =
+                enemy.GetComponentInChildren<EnemySeparationCollider>().Collider;
+            for (int i = 0; i < blockers.Length; i++)
+            {
+                Assert.IsFalse(separation.IsTouching(blockers[i]),
+                    $"Separation-only contact must ignore {blockers[i].name}.");
+            }
+        }
+
+        private static float ContactCorrectionAllowance(GameObject a, GameObject b)
+        {
+            Physics2D.SyncTransforms();
+            CircleCollider2D footprintA =
+                a.GetComponentInChildren<EnemySeparationCollider>().Collider;
+            CircleCollider2D footprintB =
+                b.GetComponentInChildren<EnemySeparationCollider>().Collider;
+            ColliderDistance2D initialDistance = Physics2D.Distance(footprintA, footprintB);
+            float initialPenetration = Mathf.Max(0f, -initialDistance.distance);
+            return initialPenetration + Physics2D.defaultContactOffset;
+        }
+
+        private static float AverageX(GameObject[] enemies)
+        {
+            float sum = 0f;
+            for (int i = 0; i < enemies.Length; i++)
+                sum += enemies[i].transform.position.x;
+            return sum / enemies.Length;
+        }
+
+        private static void SetField(object instance, string fieldName, object value)
+        {
+            FieldInfo field = instance.GetType().GetField(
+                fieldName,
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(field, $"Missing field {fieldName}.");
+            field.SetValue(instance, value);
+        }
+
+        private static void DestroyNow(params GameObject[] objects)
+        {
+            if (objects == null)
+                return;
+
+            for (int i = 0; i < objects.Length; i++)
+            {
+                if (objects[i] != null)
+                    Object.DestroyImmediate(objects[i]);
+            }
+        }
+    }
+}

--- a/Assets/_Project/_Tests/PlayMode/AI/EnemySeparationPlayTests.cs.meta
+++ b/Assets/_Project/_Tests/PlayMode/AI/EnemySeparationPlayTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 290d70bf428f4b829563a408e57fcde0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Docs/TEST_LOG.md
+++ b/Docs/TEST_LOG.md
@@ -4,6 +4,169 @@
 
 ---
 
+## 2026-08-24 - fix-enemy-direct-stacking-final-validation
+
+### Summary
+- User validation confirmed the full EditMode and PlayMode suites pass with the final non-impulse separation, preventive locomotion clamp, and chase-lane behavior.
+- MainPrototype validation confirmed direct stacking is substantially prevented, dense sprite overlap remains, chase movement is substantially smoother, and no unacceptable knockback chain reaction was observed.
+- Wall, Barrier, Vault, combat, root/stagger, and related interaction contracts were acceptable in user validation.
+
+### New or Updated Tests
+**EditMode**
+- Full EditMode suite — user-confirmed passing, including separation prefab/math and approach-spread contracts.
+
+**PlayMode**
+- Full PlayMode suite — user-confirmed passing, including separation, world stability, interaction routing, knockback isolation, and chase-lane coverage.
+
+### Notes
+- MainPrototype direct-stacking, dense-overlap, crowd-chase, knockback, and world/combat validation passed according to the user.
+- CHASE → surround transition can still briefly clump/jitter before the final circle forms; intentionally deferred from #277 to follow-up #296 as separate movement polish.
+
+## 2026-08-24 - fix-enemy-direct-stacking-chase-lanes
+
+### Summary
+- Verified that distance-weighted neighbor separation became laterally blind when crowd pressure aligned ahead/behind the Player pursuit direction, leaving dense CHASE groups on common paths until hard separation intervened.
+- Extended existing approach spread with deterministic compression-scaled lane bias for longitudinal crowd pressure while retaining the authored forward floor and lateral cap.
+- Faded the added lane influence as near-Player angular surround arrival takes over; hard separation, HOLD, Barrier targeting, and movement-lock contracts remain unchanged.
+
+### New or Updated Tests
+**EditMode**
+- EnemyApproachSpreadTests — longitudinal lane creation, compression-to-arrival fade, preserved lateral authority, forward progress, and speed cap.
+
+**PlayMode**
+- EnemyApproachSpreadPlayTests — a longitudinally compressed group develops multiple lanes before near-Player surround behavior while continuing forward.
+
+### Notes
+- Focused EditMode, focused PlayMode, full EditMode, full PlayMode, and MainPrototype crowd validation remain pending user execution; no passing result is claimed.
+- Codex did not run Unity, EditMode, or PlayMode tests.
+
+## 2026-08-23 - fix-enemy-direct-stacking-clamp-tolerance
+
+### Summary
+- Traced repeated fallback counts during stable preventive convergence to float-sized residual penetrations at the exact sensor-radius boundary rather than meaningful overlap.
+- Aligned preventive and fallback geometry with one tolerance equal to one percent of Physics2D.defaultContactOffset.
+- Kept the non-impulse sensor, footprint size, scheduled-target prediction, deterministic fallback ownership, and movement behavior unchanged.
+
+### New or Updated Tests
+**EditMode**
+- N/A — existing separation math and prefab contracts remain unchanged.
+
+**PlayMode**
+- EnemySeparationPlayTests — existing sustained-inward regression remains the acceptance test for stable preventive convergence without repeated fallback correction.
+
+### Notes
+- Focused EnemySeparationPlayTests and the full PlayMode suite remain pending user execution; no passing result is claimed.
+- Codex did not run Unity, EditMode, or PlayMode tests.
+
+## 2026-08-23 - fix-enemy-direct-stacking-preventive-clamp
+
+### Summary
+- Verified that ordinary inward MovePosition requests repeatedly re-entered the hard footprint after post-physics correction, producing visible interpolation jitter.
+- Added a pair-aware preventive locomotion clamp that removes only footprint-violating inward displacement while preserving tangential, outward, soft-spacing, and knockback movement.
+- Retained bounded post-physics depenetration as an exceptional fallback for coincident spawn and external overlap states.
+
+### New or Updated Tests
+**EditMode**
+- EnemySeparationMathTests — inward minimum-footprint clipping with tangential and outward movement preservation.
+
+**PlayMode**
+- EnemySeparationPlayTests — sustained opposing production locomotion settles at the minimum without repeated fallback corrections while retaining tangential movement and dense visual overlap.
+
+### Notes
+- Focused EditMode, focused PlayMode, full EditMode, full PlayMode, and MainPrototype validation remain pending user execution; no passing result is claimed.
+- Codex did not run Unity, EditMode, or PlayMode tests.
+
+## 2026-08-20 - fix-enemy-direct-stacking-opposing-movement-follow-up
+
+### Summary
+- User validation confirmed the prior #277 failures pass individually; full PlayMode isolated one remaining opposing-MovePosition timing regression.
+- Verified that pre-physics depenetration reached the 0.40 sensor footprint before the final two 0.04 inward MovePosition requests reduced the observed separation to 0.32.
+- Reconciled the same bounded, deterministic pair correction from Enemy trigger callbacks after scheduled movement is applied, without changing sensor size or architecture.
+
+### New or Updated Tests
+**EditMode**
+- EnemySeparationMathTests — opposing 0.08 penetration is fully split into two 0.04 bounded corrections.
+
+**PlayMode**
+- EnemySeparationPlayTests — existing opposing-MovePosition minimum-footprint regression remains the behavioral acceptance test.
+
+### Notes
+- The focused opposing test, full EnemySeparationPlayTests, and full PlayMode suite require user rerun; no passing result is claimed for this correction.
+- Codex did not run Unity, EditMode, or PlayMode tests.
+
+## 2026-08-20 - fix-enemy-direct-stacking-non-impulse-replacement
+
+### Summary
+- Removed the rejected solid Dynamic-Rigidbody Enemy separation response and its obsolete physics material after validation proved knockback transferred through neighboring bodies.
+- Reused the small child footprint as an Enemy-only trigger sensor with one deterministic pair owner and capped, allocation-conscious depenetration.
+- Preserved root/stagger locks, isolated knockback momentum, and clamped corrections with the primary collider against Player and authored world-solid geometry.
+
+### New or Updated Tests
+**EditMode**
+- EnemySeparationPrefabContractTests and EnemySeparationMathTests — non-impulse sensor contracts, deterministic coincidence axis, blocked-side redistribution, and both-locked behavior.
+
+**PlayMode**
+- EnemySeparationPlayTests — coincident and ordinary separation, mixed crowd progress, world-contact tolerance/isolation, root/stagger locks, knockback isolation, both-locked deferral, and unchanged hit routing.
+
+### Notes
+- Full EditMode and the three focused PlayMode failures require user rerun against the replacement implementation; no passing result is claimed.
+- Codex did not run Unity, EditMode, PlayMode, or MainPrototype validation.
+
+## 2026-08-20 - fix-enemy-direct-stacking-architecture-reassessment
+
+### Summary
+- Full EditMode remained green, while exact coincident recovery, Barrier tolerance, and knockback isolation remained failing diagnostics in PlayMode.
+- Verified that coincidence callbacks never execute because the separation colliders capture no contact layers, even though Enemy callback layers are enabled.
+- Rejected solid Dynamic-Rigidbody Enemy separation because its mutual Enemy force masks transmit knockback impulses into neighboring enemies; replacement design remains pending approval.
+
+### New or Updated Tests
+**EditMode**
+- N/A
+
+**PlayMode**
+- N/A
+
+### Notes
+- The Barrier diagnostic measures the primary body at -0.005053639 signed distance, within the authored Physics2D default contact offset of 0.01; the separation child excludes Barrier/world contact.
+- Recommended replacement: an allocation-conscious, bounded Enemy-only overlap/depenetration owner that does not use physical Enemy-to-Enemy impulse response and clamps corrections against primary world geometry.
+- Codex did not run Unity or tests; the three PlayMode diagnostics remain failing pending replacement-design approval and implementation.
+
+## 2026-08-20 - fix-enemy-direct-stacking-validation-follow-up
+
+### Summary
+- User validation passed full EditMode and found three focused PlayMode failures: exact coincident recovery, primary-body Barrier settling, and root contact displacement.
+- Added an Enemy-only callback and deterministic sub-radius tie-break for the exact identical-circle degeneracy while leaving ordinary separation to Physics2D.
+- Kept Barrier/world isolation unchanged, allowed the forced-movement fixture to settle before asserting primary-body clearance, and bounded root/stagger displacement by initial contact penetration instead of an arbitrary distance.
+
+### New or Updated Tests
+**EditMode**
+- EnemySeparationPrefabContractTests — separation callbacks remain restricted to the Enemies layer.
+
+**PlayMode**
+- EnemySeparationPlayTests — exact coincident recovery, settled primary-body world clearance, separation-child world isolation, and penetration-relative root/stagger locks.
+
+### Notes
+- Full EditMode passed before this follow-up; the three corrected PlayMode tests and both full suites require user rerun.
+- Codex did not run Unity, EditMode, PlayMode, or MainPrototype validation.
+
+## 2026-08-20 - fix-enemy-direct-stacking
+
+### Summary
+- Verified that active enemies use one large primary combat/body collider while the Enemies layer globally ignores itself, leaving soft steering unable to guarantee minimum center separation.
+- Added a small child-only Enemy separation footprint with isolated per-collider layer overrides and a neutral zero-friction, zero-bounce material.
+- Preserved the primary collider as the authoritative engagement, combat, Player, Barrier, projectile, trap, and world-contact footprint.
+
+### New or Updated Tests
+**EditMode**
+- EnemySeparationPrefabContractTests — melee, ranged, and Lurker Rigidbody2D, primary-body, child-footprint, layer-override, material, tag, and unchanged global-matrix contracts.
+
+**PlayMode**
+- EnemySeparationPlayTests — opposing and coincident convergence, mixed-crowd progress, wall/Barrier/Vault stability, root/stagger/knockback behavior, combat/projectile/trap routing, and Player primary-body contact.
+
+### Notes
+- Unity, EditMode, PlayMode, and MainPrototype validation were not run; validation remains pending from the user.
+- Barrier repair overlap handling and Tower targeting explicitly ignore the separation-only child so existing primary-collider routing remains authoritative.
+
 ## 2026-08-20 - fix-player-barrier-repair-overlap
 
 ### Summary


### PR DESCRIPTION
## Why
Enemies could collapse into direct center-on-center stacks during dense movement. The fix needs to preserve crowded sprite overlap without turning enemies into impulse-driven bodies that shove each other or propagate knockback.

## What changed
- Added a small Enemy-only trigger/sensor footprint to melee, ranged, and Lurker prefabs while preserving their primary combat/body colliders
- Prevented ordinary locomotion from crossing the minimum footprint and retained bounded deterministic depenetration only for exceptional overlap states
- Kept Enemy-to-Enemy force exchange disabled, the global collision matrix unchanged, and existing Player, combat, projectile, trap, Barrier, wall, and Vault routing intact
- Extended existing approach spread with compression-scaled lateral lane assistance that fades into near-Player surround steering
- Added focused prefab, separation-math, convergence, world-stability, movement-lock, knockback-isolation, interaction-routing, and chase-lane coverage

## How to test
1. Open MainPrototype and start a representative mixed enemy wave
2. Verify direct stacking is prevented while dense sprite overlap, forward chase progress, knockback isolation, and world/combat interactions remain intact
3. Run tests:
   - EditMode: full suite
   - PlayMode: full suite

## Checklist
- [x] Unit tests (EditMode) added or updated
- [x] PlayMode test or manual validation included
- [x] Demo scene updated (N/A - the behavior is prefab/component driven and requires no scene asset change)
- [x] Prefab links, tags, and layers validated
- [x] README / Docs touched (TEST_LOG records final user validation and deferred polish)

## Related
- Closes #277
- Refs #296 for separately deferred CHASE-to-surround transition polish
